### PR TITLE
Prior SearchTerm object model

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -7,6 +7,7 @@ from indra.databases import ndex_client
 import indra.tools.assemble_corpus as ac
 from indra.literature import pubmed_client
 from indra.assemblers.cx import CxAssembler
+from emmaa.priors import SearchTerm
 from emmaa.readers.aws_reader import read_pmid_search_terms
 
 
@@ -57,7 +58,8 @@ class EmmaaModel(object):
         return [es.stmt for es in self.stmts]
 
     def _load_config(self, config):
-        self.search_terms = config['search_terms']
+        self.search_terms = [SearchTerm.from_json(s) for s in
+                             config['search_terms']]
         self.ndex_network = config['ndex']['network']
 
     def search_literature(self, date_limit=None):

--- a/emmaa/priors/__init__.py
+++ b/emmaa/priors/__init__.py
@@ -32,6 +32,7 @@ class SearchTerm(object):
 
     @classmethod
     def from_json(cls, jd):
+        """Return a SearchTerm object from JSON."""
         return SearchTerm(**jd)
 
     def __eq__(self, other):

--- a/emmaa/priors/__init__.py
+++ b/emmaa/priors/__init__.py
@@ -1,5 +1,4 @@
 """This module contains classes to generate prior networks."""
-from collections import OrderedDict
 
 
 class SearchTerm(object):
@@ -25,11 +24,10 @@ class SearchTerm(object):
 
     def to_json(self):
         """Return search term as JSON."""
-        jd = OrderedDict()
-        jd['type'] = self.type
-        jd['name'] = self.name
-        jd['db_refs'] = self.db_refs
-        jd['search_term'] = self.search_term
+        jd = {'type': self.type,
+              'name': self.name,
+              'db_refs': self.db_refs,
+              'search_term': self.search_term}
         return jd
 
     def __eq__(self, other):

--- a/emmaa/priors/__init__.py
+++ b/emmaa/priors/__init__.py
@@ -31,3 +31,8 @@ class SearchTerm(object):
         jd['db_refs'] = self.db_refs
         jd['search_term'] = self.search_term
         return jd
+
+    def __eq__(self, other):
+        return self.type == other.type and self.name == other.name and \
+            self.db_refs == other.db_refs and \
+            self.search_term == other.search_term

--- a/emmaa/priors/__init__.py
+++ b/emmaa/priors/__init__.py
@@ -30,6 +30,10 @@ class SearchTerm(object):
               'search_term': self.search_term}
         return jd
 
+    @classmethod
+    def from_json(cls, jd):
+        return SearchTerm(**jd)
+
     def __eq__(self, other):
         return self.type == other.type and self.name == other.name and \
             self.db_refs == other.db_refs and \

--- a/emmaa/priors/__init__.py
+++ b/emmaa/priors/__init__.py
@@ -1,1 +1,33 @@
 """This module contains classes to generate prior networks."""
+from collections import OrderedDict
+
+
+class SearchTerm(object):
+    """Represents a search term to be used in a model configuration.
+
+    Parameters
+    ----------
+    type : str
+        The type of search term, e.g. gene, bioprocess, other
+    name : str
+        The name of the search term, is equivalent to an Agent name
+    db_refs : dict
+        A dict of database references for the given term, is similar
+        to an Agent db_refs dict
+    search_term : str
+        The actual search term to us for searching PubMed
+    """
+    def __init__(self, type, name, db_refs, search_term):
+        self.type = type
+        self.name = name
+        self.db_refs = db_refs
+        self.search_term = search_term
+
+    def to_json(self):
+        """Return search term as JSON."""
+        jd = OrderedDict()
+        jd['type'] = self.type
+        jd['name'] = self.name
+        jd['db_refs'] = self.db_refs
+        jd['search_term'] = self.search_term
+        return jd

--- a/emmaa/priors/cancer_prior.py
+++ b/emmaa/priors/cancer_prior.py
@@ -187,9 +187,9 @@ class TcgaCancerPrior(object):
                                   search_term=f'{mesh_id}[MeSH Terms]',
                                   db_refs={'MESH': mesh_id})
                 terms.append(term)
-            # TODO: handle MeSH here
+            # TODO: handle GO here
             else:
-                logger.warning('Could not create search term from {node}')
+                logger.warning(f'Could not create search term from {node}')
         return sorted(terms, key=lambda x: x.name)
 
     @staticmethod
@@ -216,7 +216,7 @@ class TcgaCancerPrior(object):
                     if drug.name not in already_added:
                         drug_terms.append(drug)
                         already_added.add(drug.name)
-        return sorted(drugs, key=lambda x: x.name)
+        return sorted(drug_terms, key=lambda x: x.name)
 
 
 def _load_tcga_studies():

--- a/emmaa/priors/cancer_prior.py
+++ b/emmaa/priors/cancer_prior.py
@@ -187,6 +187,7 @@ class TcgaCancerPrior(object):
                                   search_term=f'{mesh_id}[MeSH Terms]',
                                   db_refs={'MESH': mesh_id})
                 terms.append(term)
+            # TODO: handle MeSH here
             else:
                 logger.warning('Could not create search term from {node}')
         return sorted(terms, key=lambda x: x.name)
@@ -195,19 +196,27 @@ class TcgaCancerPrior(object):
     def find_drugs_for_genes(node_list):
         """Return list of drugs targeting gene nodes."""
         def get_drugs_for_gene(stmts, hgnc_id):
-            drugs_for_gene = set()
+            drugs_for_gene = []
             for stmt in stmts:
                 if stmt.obj.db_refs.get('HGNC') == hgnc_id:
-                    drugs_for_gene.add(stmt.subj.name)
+                    term = SearchTerm(type='drug', name=stmt.subj.name,
+                                      db_refs=stmt.subj.db_refs,
+                                      search_term=f'"{stmt.subj.name}"')
+                    drugs_for_gene.append(term)
             return drugs_for_gene
 
         tas_statements = tas.process_csv().statements
-        drugs = set()
+        already_added = set()
+        drug_terms = []
         for node in node_list:
             if node.startswith('HGNC:'):
                 hgnc_id = node.split(':')[1]
-                drugs |= get_drugs_for_gene(tas_statements, hgnc_id)
-        return sorted(list(drugs))
+                drugs = get_drugs_for_gene(tas_statements, hgnc_id)
+                for drug in drugs:
+                    if drug.name not in already_added:
+                        drug_terms.append(drug)
+                        already_added.add(drug.name)
+        return sorted(drugs, key=lambda x: x.name)
 
 
 def _load_tcga_studies():

--- a/models/aml/config.yaml
+++ b/models/aml/config.yaml
@@ -1,280 +1,1613 @@
 ndex:
   network: ef58f76d-f6a2-11e8-aaa6-0ac135e8bacf
 search_terms:
-- "ABTB1"
-- "ANG"
-- "AP3S2"
-- "AQP5"
-- "ARL3"
-- "ASXL1"
-- "ATP6V1G3"
-- "AURKC"
-- "B3GALT5"
-- "BRCC3"
-- "BRINP3"
-- "BRMS1"
-- "C4BPB"
-- "CACNG2"
-- "CADM2"
-- "CALR"
-- "CAPS"
-- "CARD18"
-- "CBFB"
-- "CBL"
-- "CBX5"
-- "CBX7"
-- "CCDC24"
-- "CCDC32"
-- "CCL11"
-- "CCL16"
-- "CCL20"
-- "CCL21"
-- "CD320"
-- "CD70"
-- "CD74"
-- "CDC42"
-- "CEBPA"
-- "CFAP300"
-- "CFHR2"
-- "CHIC2"
-- "CLDN11"
-- "CLDN14"
-- "CLDN18"
-- "CRISPLD1"
-- "CTSG"
-- "DAOA"
-- "DAZAP2"
-- "DCTD"
-- "DDX41"
-- "DESI1"
-- "DIO2"
-- "DIS3"
-- "DLX3"
-- "DNMT3A"
-- "DRD2"
-- "DUOXA2"
-- "DUSP26"
-- "EED"
-- "EGFL8"
-- "ELANE"
-- "EPGN"
-- "ETFRF1"
-- "ETV6"
-- "EZH2"
-- "FAM19A4"
-- "FAM57B"
-- "FLT3"
-- "GALNT18"
-- "GATA2"
-- "GBP4"
-- "GCLM"
-- "GJB3"
-- "GJB4"
-- "GPX2"
-- "GREM2"
-- "GSTK1"
-- "GSTM3"
-- "GUCA2A"
-- "GZMB"
-- "HADH"
-- "HIST1H3D"
-- "HNRNPK"
-- "HSPB7"
-- "IDH1"
-- "IDH2"
-- "IL32"
-- "ILDR1"
-- "IMMP2L"
-- "JAM2"
-- "KCNE3"
-- "KCNK13"
-- "KIT"
-- "KLK7"
-- "KLRK1"
-- "KRAS"
-- "KRTAP10-8"
-- "LCE1B"
-- "MAX"
-- "MDFI"
-- "MED21"
-- "MSRB1"
-- "MT-ATP6"
-- "MT-CO1"
-- "MT-CO2"
-- "MT-CO3"
-- "MT-CYB"
-- "MT-ND1"
-- "MT-ND5"
-- "MYEOV"
-- "MYF5"
-- "NAPA"
-- "NAT8L"
-- "NCCRP1"
-- "NIPSNAP1"
-- "NMNAT2"
-- "NMUR2"
-- "NOTCH2NLA"
-- "NPM1"
-- "NPM2"
-- "NR2E1"
-- "NRAS"
-- "NRXN3"
-- "OR2AG1"
-- "OR2M3"
-- "OR3A2"
-- "OR51L1"
-- "OR5AR1"
-- "OR5W2"
-- "OR6B2"
-- "OR7D4"
-- "ORAI1"
-- "P2RY2"
-- "PDC"
-- "PDCD2L"
-- "PDCL3"
-- "PHACTR1"
-- "PHF6"
-- "PIP4P2"
-- "PKIB"
-- "PLA2G2D"
-- "PLPP1"
-- "POLR2E"
-- "PPIC"
-- "PTPN11"
-- "RAB15"
-- "RAB17"
-- "RAB23"
-- "RAB25"
-- "RAB5IF"
-- "RAD21"
-- "RAP1B"
-- "RBBP4"
-- "RBKS"
-- "RCAN2"
-- "REC114"
-- "RFC3"
-- "RIT1"
-- "RPL32"
-- "RPL6"
-- "RPL9"
-- "RPS3A"
-- "RUNX1"
-- "SBSPON"
-- "SLPI"
-- "SMC1A"
-- "SMC3"
-- "SPDYA"
-- "SPRR4"
-- "SRSF2"
-- "SSSCA1"
-- "STAG2"
-- "STC2"
-- "STX3"
-- "SULT1B1"
-- "SULT1C2"
-- "SUMO2"
-- "SUZ12"
-- "TCL1A"
-- "TCTE3"
-- "TET2"
-- "TFAM"
-- "TMCO5A"
-- "TMEM18"
-- "TMEM231"
-- "TMEM47"
-- "TNNC2"
-- "TP53"
-- "TPRG1"
-- "TRA2B"
-- "TRIM48"
-- "TSPAN2"
-- "TUBA3C"
-- "U2AF1"
-- "UBE2R2"
-- "UQCC1"
-- "UQCR10"
-- "USB1"
-- "WAC"
-- "WT1"
-- "ZFP42"
-- "ZNF788P"
-- "AC220"
-- "ALW-II-38-3"
-- "ALW-II-49-7"
-- "AT9283"
-- "AZD7762"
-- "Amuvatinib"
-- "Axitinib"
-- "Azacitidine"
-- "BAY61-3606"
-- "BIX 02565"
-- "BMS 777607"
-- "BMS-536924"
-- "BX-912"
-- "Barasertib"
-- "Bortezomib"
-- "Bosutinib"
-- "Brivanib"
-- "Cabozantinib"
-- "Cediranib"
-- "Celecoxib"
-- "Crizotinib"
-- "DCC-2036"
-- "Dasatinib"
-- "Decitabine"
-- "Doramapimod"
-- "Dorsomorphin"
-- "Dovitinib"
-- "Entospletinib"
-- "Enzastaurin"
-- "Erlotinib"
-- "Fedratinib"
-- "Filgotinib"
-- "Foretinib"
-- "GSK1070916"
-- "GSK461364"
-- "GTPL6019"
-- "GW843682X"
-- "Go 6976"
-- "HG-14-10-04"
-- "Imatinib"
-- "KIN001-269"
-- "KW2449"
-- "Ki20227"
-- "Lestaurtinib"
-- "Linifanib"
-- "MLN8054"
-- "Masitinib"
-- "Motesanib"
-- "NMS-1286937"
-- "NSC-87877"
-- "NVP-TAE226"
-- "NVP-TAE684"
-- "Nilotinib"
-- "Nintedanib"
-- "Nutlin 3a"
-- "OSI-930"
-- "PF562271"
-- "PHA-665752"
-- "PKC412"
-- "PP1"
-- "PRT062607"
-- "Pacritinib"
-- "Pazopanib"
-- "Ponatinib"
-- "R406"
-- "RAF 265"
-- "Regorafenib"
-- "Resveratrol"
-- "SGI-1776"
-- "Saracatinib"
-- "Sorafenib"
-- "Staurosporine"
-- "Sulindac sulfide"
-- "Sunitinib"
-- "Tivozanib"
-- "Tozasertib"
-- "URMC-099"
-- "Vandetanib"
-- "WZ3105"
-- "XL019"
+- db_refs:
+    HGNC: '18275'
+  name: ABTB1
+  search_term: '"ABTB1"'
+  type: gene
+- db_refs:
+    HGNC: '483'
+  name: ANG
+  search_term: '"ANG"'
+  type: gene
+- db_refs:
+    HGNC: '571'
+  name: AP3S2
+  search_term: '"AP3S2"'
+  type: gene
+- db_refs:
+    HGNC: '638'
+  name: AQP5
+  search_term: '"AQP5"'
+  type: gene
+- db_refs:
+    HGNC: '694'
+  name: ARL3
+  search_term: '"ARL3"'
+  type: gene
+- db_refs:
+    HGNC: '18318'
+  name: ASXL1
+  search_term: '"ASXL1"'
+  type: gene
+- db_refs:
+    HGNC: '18265'
+  name: ATP6V1G3
+  search_term: '"ATP6V1G3"'
+  type: gene
+- db_refs:
+    HGNC: '11391'
+  name: AURKC
+  search_term: '"AURKC"'
+  type: gene
+- db_refs:
+    HGNC: '920'
+  name: B3GALT5
+  search_term: '"B3GALT5"'
+  type: gene
+- db_refs:
+    HGNC: '24185'
+  name: BRCC3
+  search_term: '"BRCC3"'
+  type: gene
+- db_refs:
+    HGNC: '22393'
+  name: BRINP3
+  search_term: '"BRINP3"'
+  type: gene
+- db_refs:
+    HGNC: '17262'
+  name: BRMS1
+  search_term: '"BRMS1"'
+  type: gene
+- db_refs:
+    HGNC: '1328'
+  name: C4BPB
+  search_term: '"C4BPB"'
+  type: gene
+- db_refs:
+    HGNC: '1406'
+  name: CACNG2
+  search_term: '"CACNG2"'
+  type: gene
+- db_refs:
+    HGNC: '29849'
+  name: CADM2
+  search_term: '"CADM2"'
+  type: gene
+- db_refs:
+    HGNC: '1455'
+  name: CALR
+  search_term: '"CALR"'
+  type: gene
+- db_refs:
+    HGNC: '1487'
+  name: CAPS
+  search_term: '"CAPS"'
+  type: gene
+- db_refs:
+    HGNC: '28861'
+  name: CARD18
+  search_term: '"CARD18"'
+  type: gene
+- db_refs:
+    HGNC: '1539'
+  name: CBFB
+  search_term: '"CBFB"'
+  type: gene
+- db_refs:
+    HGNC: '1541'
+  name: CBL
+  search_term: '"CBL"'
+  type: gene
+- db_refs:
+    HGNC: '1555'
+  name: CBX5
+  search_term: '"CBX5"'
+  type: gene
+- db_refs:
+    HGNC: '1557'
+  name: CBX7
+  search_term: '"CBX7"'
+  type: gene
+- db_refs:
+    HGNC: '28688'
+  name: CCDC24
+  search_term: '"CCDC24"'
+  type: gene
+- db_refs:
+    HGNC: '28295'
+  name: CCDC32
+  search_term: '"CCDC32"'
+  type: gene
+- db_refs:
+    HGNC: '10610'
+  name: CCL11
+  search_term: '"CCL11"'
+  type: gene
+- db_refs:
+    HGNC: '10614'
+  name: CCL16
+  search_term: '"CCL16"'
+  type: gene
+- db_refs:
+    HGNC: '10619'
+  name: CCL20
+  search_term: '"CCL20"'
+  type: gene
+- db_refs:
+    HGNC: '10620'
+  name: CCL21
+  search_term: '"CCL21"'
+  type: gene
+- db_refs:
+    HGNC: '16692'
+  name: CD320
+  search_term: '"CD320"'
+  type: gene
+- db_refs:
+    HGNC: '11937'
+  name: CD70
+  search_term: '"CD70"'
+  type: gene
+- db_refs:
+    HGNC: '1697'
+  name: CD74
+  search_term: '"CD74"'
+  type: gene
+- db_refs:
+    HGNC: '1736'
+  name: CDC42
+  search_term: '"CDC42"'
+  type: gene
+- db_refs:
+    HGNC: '1833'
+  name: CEBPA
+  search_term: '"CEBPA"'
+  type: gene
+- db_refs:
+    HGNC: '28188'
+  name: CFAP300
+  search_term: '"CFAP300"'
+  type: gene
+- db_refs:
+    HGNC: '4890'
+  name: CFHR2
+  search_term: '"CFHR2"'
+  type: gene
+- db_refs:
+    HGNC: '1935'
+  name: CHIC2
+  search_term: '"CHIC2"'
+  type: gene
+- db_refs:
+    HGNC: '8514'
+  name: CLDN11
+  search_term: '"CLDN11"'
+  type: gene
+- db_refs:
+    HGNC: '2035'
+  name: CLDN14
+  search_term: '"CLDN14"'
+  type: gene
+- db_refs:
+    HGNC: '2039'
+  name: CLDN18
+  search_term: '"CLDN18"'
+  type: gene
+- db_refs:
+    HGNC: '18206'
+  name: CRISPLD1
+  search_term: '"CRISPLD1"'
+  type: gene
+- db_refs:
+    HGNC: '2532'
+  name: CTSG
+  search_term: '"CTSG"'
+  type: gene
+- db_refs:
+    HGNC: '21191'
+  name: DAOA
+  search_term: '"DAOA"'
+  type: gene
+- db_refs:
+    HGNC: '2684'
+  name: DAZAP2
+  search_term: '"DAZAP2"'
+  type: gene
+- db_refs:
+    HGNC: '2710'
+  name: DCTD
+  search_term: '"DCTD"'
+  type: gene
+- db_refs:
+    HGNC: '18674'
+  name: DDX41
+  search_term: '"DDX41"'
+  type: gene
+- db_refs:
+    HGNC: '24577'
+  name: DESI1
+  search_term: '"DESI1"'
+  type: gene
+- db_refs:
+    HGNC: '2884'
+  name: DIO2
+  search_term: '"DIO2"'
+  type: gene
+- db_refs:
+    HGNC: '20604'
+  name: DIS3
+  search_term: '"DIS3"'
+  type: gene
+- db_refs:
+    HGNC: '2916'
+  name: DLX3
+  search_term: '"DLX3"'
+  type: gene
+- db_refs:
+    HGNC: '2978'
+  name: DNMT3A
+  search_term: '"DNMT3A"'
+  type: gene
+- db_refs:
+    HGNC: '3023'
+  name: DRD2
+  search_term: '"DRD2"'
+  type: gene
+- db_refs:
+    HGNC: '32698'
+  name: DUOXA2
+  search_term: '"DUOXA2"'
+  type: gene
+- db_refs:
+    HGNC: '28161'
+  name: DUSP26
+  search_term: '"DUSP26"'
+  type: gene
+- db_refs:
+    HGNC: '3188'
+  name: EED
+  search_term: '"EED"'
+  type: gene
+- db_refs:
+    HGNC: '13944'
+  name: EGFL8
+  search_term: '"EGFL8"'
+  type: gene
+- db_refs:
+    HGNC: '3309'
+  name: ELANE
+  search_term: '"ELANE"'
+  type: gene
+- db_refs:
+    HGNC: '17470'
+  name: EPGN
+  search_term: '"EPGN"'
+  type: gene
+- db_refs:
+    HGNC: '27052'
+  name: ETFRF1
+  search_term: '"ETFRF1"'
+  type: gene
+- db_refs:
+    HGNC: '3495'
+  name: ETV6
+  search_term: '"ETV6"'
+  type: gene
+- db_refs:
+    HGNC: '3527'
+  name: EZH2
+  search_term: '"EZH2"'
+  type: gene
+- db_refs:
+    HGNC: '21591'
+  name: FAM19A4
+  search_term: '"FAM19A4"'
+  type: gene
+- db_refs:
+    HGNC: '25295'
+  name: FAM57B
+  search_term: '"FAM57B"'
+  type: gene
+- db_refs:
+    HGNC: '3765'
+  name: FLT3
+  search_term: '"FLT3"'
+  type: gene
+- db_refs:
+    HGNC: '30488'
+  name: GALNT18
+  search_term: '"GALNT18"'
+  type: gene
+- db_refs:
+    HGNC: '4171'
+  name: GATA2
+  search_term: '"GATA2"'
+  type: gene
+- db_refs:
+    HGNC: '20480'
+  name: GBP4
+  search_term: '"GBP4"'
+  type: gene
+- db_refs:
+    HGNC: '4312'
+  name: GCLM
+  search_term: '"GCLM"'
+  type: gene
+- db_refs:
+    HGNC: '4285'
+  name: GJB3
+  search_term: '"GJB3"'
+  type: gene
+- db_refs:
+    HGNC: '4286'
+  name: GJB4
+  search_term: '"GJB4"'
+  type: gene
+- db_refs:
+    HGNC: '4554'
+  name: GPX2
+  search_term: '"GPX2"'
+  type: gene
+- db_refs:
+    HGNC: '17655'
+  name: GREM2
+  search_term: '"GREM2"'
+  type: gene
+- db_refs:
+    HGNC: '16906'
+  name: GSTK1
+  search_term: '"GSTK1"'
+  type: gene
+- db_refs:
+    HGNC: '4635'
+  name: GSTM3
+  search_term: '"GSTM3"'
+  type: gene
+- db_refs:
+    HGNC: '4682'
+  name: GUCA2A
+  search_term: '"GUCA2A"'
+  type: gene
+- db_refs:
+    HGNC: '4709'
+  name: GZMB
+  search_term: '"GZMB"'
+  type: gene
+- db_refs:
+    HGNC: '4799'
+  name: HADH
+  search_term: '"HADH"'
+  type: gene
+- db_refs:
+    HGNC: '4767'
+  name: HIST1H3D
+  search_term: '"HIST1H3D"'
+  type: gene
+- db_refs:
+    HGNC: '5044'
+  name: HNRNPK
+  search_term: '"HNRNPK"'
+  type: gene
+- db_refs:
+    HGNC: '5249'
+  name: HSPB7
+  search_term: '"HSPB7"'
+  type: gene
+- db_refs:
+    HGNC: '5382'
+  name: IDH1
+  search_term: '"IDH1"'
+  type: gene
+- db_refs:
+    HGNC: '5383'
+  name: IDH2
+  search_term: '"IDH2"'
+  type: gene
+- db_refs:
+    HGNC: '16830'
+  name: IL32
+  search_term: '"IL32"'
+  type: gene
+- db_refs:
+    HGNC: '28741'
+  name: ILDR1
+  search_term: '"ILDR1"'
+  type: gene
+- db_refs:
+    HGNC: '14598'
+  name: IMMP2L
+  search_term: '"IMMP2L"'
+  type: gene
+- db_refs:
+    HGNC: '14686'
+  name: JAM2
+  search_term: '"JAM2"'
+  type: gene
+- db_refs:
+    HGNC: '6243'
+  name: KCNE3
+  search_term: '"KCNE3"'
+  type: gene
+- db_refs:
+    HGNC: '6275'
+  name: KCNK13
+  search_term: '"KCNK13"'
+  type: gene
+- db_refs:
+    HGNC: '6342'
+  name: KIT
+  search_term: '"KIT"'
+  type: gene
+- db_refs:
+    HGNC: '6368'
+  name: KLK7
+  search_term: '"KLK7"'
+  type: gene
+- db_refs:
+    HGNC: '18788'
+  name: KLRK1
+  search_term: '"KLRK1"'
+  type: gene
+- db_refs:
+    HGNC: '6407'
+  name: KRAS
+  search_term: '"KRAS"'
+  type: gene
+- db_refs:
+    HGNC: '20525'
+  name: KRTAP10-8
+  search_term: '"KRTAP10-8"'
+  type: gene
+- db_refs:
+    HGNC: '16611'
+  name: LCE1B
+  search_term: '"LCE1B"'
+  type: gene
+- db_refs:
+    HGNC: '6913'
+  name: MAX
+  search_term: '"MAX"'
+  type: gene
+- db_refs:
+    HGNC: '6967'
+  name: MDFI
+  search_term: '"MDFI"'
+  type: gene
+- db_refs:
+    HGNC: '11473'
+  name: MED21
+  search_term: '"MED21"'
+  type: gene
+- db_refs:
+    HGNC: '14133'
+  name: MSRB1
+  search_term: '"MSRB1"'
+  type: gene
+- db_refs:
+    HGNC: '7414'
+  name: MT-ATP6
+  search_term: '"MT-ATP6"'
+  type: gene
+- db_refs:
+    HGNC: '7419'
+  name: MT-CO1
+  search_term: '"MT-CO1"'
+  type: gene
+- db_refs:
+    HGNC: '7421'
+  name: MT-CO2
+  search_term: '"MT-CO2"'
+  type: gene
+- db_refs:
+    HGNC: '7422'
+  name: MT-CO3
+  search_term: '"MT-CO3"'
+  type: gene
+- db_refs:
+    HGNC: '7427'
+  name: MT-CYB
+  search_term: '"MT-CYB"'
+  type: gene
+- db_refs:
+    HGNC: '7455'
+  name: MT-ND1
+  search_term: '"MT-ND1"'
+  type: gene
+- db_refs:
+    HGNC: '7461'
+  name: MT-ND5
+  search_term: '"MT-ND5"'
+  type: gene
+- db_refs:
+    HGNC: '7563'
+  name: MYEOV
+  search_term: '"MYEOV"'
+  type: gene
+- db_refs:
+    HGNC: '7565'
+  name: MYF5
+  search_term: '"MYF5"'
+  type: gene
+- db_refs:
+    HGNC: '7641'
+  name: NAPA
+  search_term: '"NAPA"'
+  type: gene
+- db_refs:
+    HGNC: '26742'
+  name: NAT8L
+  search_term: '"NAT8L"'
+  type: gene
+- db_refs:
+    HGNC: '33739'
+  name: NCCRP1
+  search_term: '"NCCRP1"'
+  type: gene
+- db_refs:
+    HGNC: '7827'
+  name: NIPSNAP1
+  search_term: '"NIPSNAP1"'
+  type: gene
+- db_refs:
+    HGNC: '16789'
+  name: NMNAT2
+  search_term: '"NMNAT2"'
+  type: gene
+- db_refs:
+    HGNC: '16454'
+  name: NMUR2
+  search_term: '"NMUR2"'
+  type: gene
+- db_refs:
+    HGNC: '31862'
+  name: NOTCH2NLA
+  search_term: '"NOTCH2NLA"'
+  type: gene
+- db_refs:
+    HGNC: '7910'
+  name: NPM1
+  search_term: '"NPM1"'
+  type: gene
+- db_refs:
+    HGNC: '7930'
+  name: NPM2
+  search_term: '"NPM2"'
+  type: gene
+- db_refs:
+    HGNC: '7973'
+  name: NR2E1
+  search_term: '"NR2E1"'
+  type: gene
+- db_refs:
+    HGNC: '7989'
+  name: NRAS
+  search_term: '"NRAS"'
+  type: gene
+- db_refs:
+    HGNC: '8010'
+  name: NRXN3
+  search_term: '"NRXN3"'
+  type: gene
+- db_refs:
+    HGNC: '15142'
+  name: OR2AG1
+  search_term: '"OR2AG1"'
+  type: gene
+- db_refs:
+    HGNC: '8269'
+  name: OR2M3
+  search_term: '"OR2M3"'
+  type: gene
+- db_refs:
+    HGNC: '8283'
+  name: OR3A2
+  search_term: '"OR3A2"'
+  type: gene
+- db_refs:
+    HGNC: '14759'
+  name: OR51L1
+  search_term: '"OR51L1"'
+  type: gene
+- db_refs:
+    HGNC: '15260'
+  name: OR5AR1
+  search_term: '"OR5AR1"'
+  type: gene
+- db_refs:
+    HGNC: '15299'
+  name: OR5W2
+  search_term: '"OR5W2"'
+  type: gene
+- db_refs:
+    HGNC: '15041'
+  name: OR6B2
+  search_term: '"OR6B2"'
+  type: gene
+- db_refs:
+    HGNC: '8380'
+  name: OR7D4
+  search_term: '"OR7D4"'
+  type: gene
+- db_refs:
+    HGNC: '25896'
+  name: ORAI1
+  search_term: '"ORAI1"'
+  type: gene
+- db_refs:
+    HGNC: '8541'
+  name: P2RY2
+  search_term: '"P2RY2"'
+  type: gene
+- db_refs:
+    HGNC: '8759'
+  name: PDC
+  search_term: '"PDC"'
+  type: gene
+- db_refs:
+    HGNC: '28194'
+  name: PDCD2L
+  search_term: '"PDCD2L"'
+  type: gene
+- db_refs:
+    HGNC: '28860'
+  name: PDCL3
+  search_term: '"PDCL3"'
+  type: gene
+- db_refs:
+    HGNC: '20990'
+  name: PHACTR1
+  search_term: '"PHACTR1"'
+  type: gene
+- db_refs:
+    HGNC: '18145'
+  name: PHF6
+  search_term: '"PHF6"'
+  type: gene
+- db_refs:
+    HGNC: '25452'
+  name: PIP4P2
+  search_term: '"PIP4P2"'
+  type: gene
+- db_refs:
+    HGNC: '9018'
+  name: PKIB
+  search_term: '"PKIB"'
+  type: gene
+- db_refs:
+    HGNC: '9033'
+  name: PLA2G2D
+  search_term: '"PLA2G2D"'
+  type: gene
+- db_refs:
+    HGNC: '9228'
+  name: PLPP1
+  search_term: '"PLPP1"'
+  type: gene
+- db_refs:
+    HGNC: '9192'
+  name: POLR2E
+  search_term: '"POLR2E"'
+  type: gene
+- db_refs:
+    HGNC: '9256'
+  name: PPIC
+  search_term: '"PPIC"'
+  type: gene
+- db_refs:
+    HGNC: '9644'
+  name: PTPN11
+  search_term: '"PTPN11"'
+  type: gene
+- db_refs:
+    HGNC: '20150'
+  name: RAB15
+  search_term: '"RAB15"'
+  type: gene
+- db_refs:
+    HGNC: '16523'
+  name: RAB17
+  search_term: '"RAB17"'
+  type: gene
+- db_refs:
+    HGNC: '14263'
+  name: RAB23
+  search_term: '"RAB23"'
+  type: gene
+- db_refs:
+    HGNC: '18238'
+  name: RAB25
+  search_term: '"RAB25"'
+  type: gene
+- db_refs:
+    HGNC: '15870'
+  name: RAB5IF
+  search_term: '"RAB5IF"'
+  type: gene
+- db_refs:
+    HGNC: '9811'
+  name: RAD21
+  search_term: '"RAD21"'
+  type: gene
+- db_refs:
+    HGNC: '9857'
+  name: RAP1B
+  search_term: '"RAP1B"'
+  type: gene
+- db_refs:
+    HGNC: '9887'
+  name: RBBP4
+  search_term: '"RBBP4"'
+  type: gene
+- db_refs:
+    HGNC: '30325'
+  name: RBKS
+  search_term: '"RBKS"'
+  type: gene
+- db_refs:
+    HGNC: '3041'
+  name: RCAN2
+  search_term: '"RCAN2"'
+  type: gene
+- db_refs:
+    HGNC: '25065'
+  name: REC114
+  search_term: '"REC114"'
+  type: gene
+- db_refs:
+    HGNC: '9971'
+  name: RFC3
+  search_term: '"RFC3"'
+  type: gene
+- db_refs:
+    HGNC: '10023'
+  name: RIT1
+  search_term: '"RIT1"'
+  type: gene
+- db_refs:
+    HGNC: '10336'
+  name: RPL32
+  search_term: '"RPL32"'
+  type: gene
+- db_refs:
+    HGNC: '10362'
+  name: RPL6
+  search_term: '"RPL6"'
+  type: gene
+- db_refs:
+    HGNC: '10369'
+  name: RPL9
+  search_term: '"RPL9"'
+  type: gene
+- db_refs:
+    HGNC: '10421'
+  name: RPS3A
+  search_term: '"RPS3A"'
+  type: gene
+- db_refs:
+    HGNC: '10471'
+  name: RUNX1
+  search_term: '"RUNX1"'
+  type: gene
+- db_refs:
+    HGNC: '30362'
+  name: SBSPON
+  search_term: '"SBSPON"'
+  type: gene
+- db_refs:
+    HGNC: '11092'
+  name: SLPI
+  search_term: '"SLPI"'
+  type: gene
+- db_refs:
+    HGNC: '11111'
+  name: SMC1A
+  search_term: '"SMC1A"'
+  type: gene
+- db_refs:
+    HGNC: '2468'
+  name: SMC3
+  search_term: '"SMC3"'
+  type: gene
+- db_refs:
+    HGNC: '30613'
+  name: SPDYA
+  search_term: '"SPDYA"'
+  type: gene
+- db_refs:
+    HGNC: '23173'
+  name: SPRR4
+  search_term: '"SPRR4"'
+  type: gene
+- db_refs:
+    HGNC: '10783'
+  name: SRSF2
+  search_term: '"SRSF2"'
+  type: gene
+- db_refs:
+    HGNC: '11328'
+  name: SSSCA1
+  search_term: '"SSSCA1"'
+  type: gene
+- db_refs:
+    HGNC: '11355'
+  name: STAG2
+  search_term: '"STAG2"'
+  type: gene
+- db_refs:
+    HGNC: '11374'
+  name: STC2
+  search_term: '"STC2"'
+  type: gene
+- db_refs:
+    HGNC: '11438'
+  name: STX3
+  search_term: '"STX3"'
+  type: gene
+- db_refs:
+    HGNC: '17845'
+  name: SULT1B1
+  search_term: '"SULT1B1"'
+  type: gene
+- db_refs:
+    HGNC: '11456'
+  name: SULT1C2
+  search_term: '"SULT1C2"'
+  type: gene
+- db_refs:
+    HGNC: '11125'
+  name: SUMO2
+  search_term: '"SUMO2"'
+  type: gene
+- db_refs:
+    HGNC: '17101'
+  name: SUZ12
+  search_term: '"SUZ12"'
+  type: gene
+- db_refs:
+    HGNC: '11648'
+  name: TCL1A
+  search_term: '"TCL1A"'
+  type: gene
+- db_refs:
+    HGNC: '11695'
+  name: TCTE3
+  search_term: '"TCTE3"'
+  type: gene
+- db_refs:
+    HGNC: '25941'
+  name: TET2
+  search_term: '"TET2"'
+  type: gene
+- db_refs:
+    HGNC: '11741'
+  name: TFAM
+  search_term: '"TFAM"'
+  type: gene
+- db_refs:
+    HGNC: '28558'
+  name: TMCO5A
+  search_term: '"TMCO5A"'
+  type: gene
+- db_refs:
+    HGNC: '25257'
+  name: TMEM18
+  search_term: '"TMEM18"'
+  type: gene
+- db_refs:
+    HGNC: '37234'
+  name: TMEM231
+  search_term: '"TMEM231"'
+  type: gene
+- db_refs:
+    HGNC: '18515'
+  name: TMEM47
+  search_term: '"TMEM47"'
+  type: gene
+- db_refs:
+    HGNC: '11944'
+  name: TNNC2
+  search_term: '"TNNC2"'
+  type: gene
+- db_refs:
+    HGNC: '11998'
+  name: TP53
+  search_term: '"TP53"'
+  type: gene
+- db_refs:
+    HGNC: '24759'
+  name: TPRG1
+  search_term: '"TPRG1"'
+  type: gene
+- db_refs:
+    HGNC: '10781'
+  name: TRA2B
+  search_term: '"TRA2B"'
+  type: gene
+- db_refs:
+    HGNC: '19021'
+  name: TRIM48
+  search_term: '"TRIM48"'
+  type: gene
+- db_refs:
+    HGNC: '20659'
+  name: TSPAN2
+  search_term: '"TSPAN2"'
+  type: gene
+- db_refs:
+    HGNC: '12408'
+  name: TUBA3C
+  search_term: '"TUBA3C"'
+  type: gene
+- db_refs:
+    HGNC: '12453'
+  name: U2AF1
+  search_term: '"U2AF1"'
+  type: gene
+- db_refs:
+    HGNC: '19907'
+  name: UBE2R2
+  search_term: '"UBE2R2"'
+  type: gene
+- db_refs:
+    HGNC: '15891'
+  name: UQCC1
+  search_term: '"UQCC1"'
+  type: gene
+- db_refs:
+    HGNC: '30863'
+  name: UQCR10
+  search_term: '"UQCR10"'
+  type: gene
+- db_refs:
+    HGNC: '25792'
+  name: USB1
+  search_term: '"USB1"'
+  type: gene
+- db_refs:
+    HGNC: '17327'
+  name: WAC
+  search_term: '"WAC"'
+  type: gene
+- db_refs:
+    HGNC: '12796'
+  name: WT1
+  search_term: '"WT1"'
+  type: gene
+- db_refs:
+    HGNC: '30949'
+  name: ZFP42
+  search_term: '"ZFP42"'
+  type: gene
+- db_refs:
+    HGNC: '33112'
+  name: ZNF788P
+  search_term: '"ZNF788P"'
+  type: gene
+- db_refs:
+    CHEBI: CHEBI:90217
+    HMS-LINCS: '10037'
+    LINCS: LSM-1037
+    PUBCHEM: '24889392'
+  name: AC220
+  search_term: '"AC220"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91324
+    HMS-LINCS: '10002'
+    LINCS: LSM-1002
+    PUBCHEM: '24880028'
+  name: ALW-II-38-3
+  search_term: '"ALW-II-38-3"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91325
+    HMS-LINCS: '10003'
+    LINCS: LSM-1003
+    PUBCHEM: '24875320'
+  name: ALW-II-49-7
+  search_term: '"ALW-II-49-7"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10393'
+    PUBCHEM: '11696609'
+  name: AT9283
+  search_term: '"AT9283"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91328
+    HMS-LINCS: '10006'
+    LINCS: LSM-1006
+    PUBCHEM: '67077825'
+  name: AZD7762
+  search_term: '"AZD7762"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91389
+    HMS-LINCS: '10118'
+    LINCS: LSM-1118
+    PUBCHEM: '11282283'
+  name: Amuvatinib
+  search_term: '"Amuvatinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:94568
+    HMS-LINCS: '10443'
+    PUBCHEM: '6450551'
+  name: Axitinib
+  search_term: '"Axitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:2038
+    HMS-LINCS: '10300'
+    LINCS: LSM-5218
+    PUBCHEM: '9444'
+  name: Azacitidine
+  search_term: '"Azacitidine"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91426
+    CHEMBL: '1190711'
+    HMS-LINCS: '10166'
+    LINCS: LSM-1167
+    PUBCHEM: '10200390'
+  name: BAY61-3606
+  search_term: '"BAY61-3606"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10434'
+    PUBCHEM: '53246941'
+  name: BIX 02565
+  search_term: '"BIX 02565"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91409
+    HMS-LINCS: '10143'
+    LINCS: LSM-1144
+    PUBCHEM: '24794418'
+  name: BMS 777607
+  search_term: '"BMS 777607"'
+  type: drug
+- db_refs:
+    CHEMBL: '401930'
+    HMS-LINCS: '10209'
+    LINCS: LSM-1210
+    PUBCHEM: '68925359'
+  name: BMS-536924
+  search_term: '"BMS-536924"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91357
+    HMS-LINCS: '10055'
+    LINCS: LSM-1055
+    PUBCHEM: '11754511'
+  name: BX-912
+  search_term: '"BX-912"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91367
+    CHEMBL: '215152'
+    HMS-LINCS: '10067'
+    LINCS: LSM-1067
+    PUBCHEM: '16007391'
+  name: Barasertib
+  search_term: '"Barasertib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:52717
+    HMS-LINCS: '10241'
+    LINCS: LSM-6281
+    PUBCHEM: '387447'
+  name: Bortezomib
+  search_term: '"Bortezomib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:39112
+    HMS-LINCS: '10189'
+    LINCS: LSM-1190
+    PUBCHEM: '5328940'
+  name: Bosutinib
+  search_term: '"Bosutinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91432
+    HMS-LINCS: '10177'
+    LINCS: LSM-1178
+    PUBCHEM: '11451527'
+  name: Brivanib
+  search_term: '"Brivanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:72317
+    HMS-LINCS: '10194'
+    LINCS: LSM-1195
+    PUBCHEM: '25102847'
+  name: Cabozantinib
+  search_term: '"Cabozantinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:94782
+    HMS-LINCS: '10444'
+    PUBCHEM: '9933475'
+  name: Cediranib
+  search_term: '"Cediranib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:41423
+    HMS-LINCS: '10503'
+    PUBCHEM: '2662'
+  name: Celecoxib
+  search_term: '"Celecoxib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:64310
+    CHEMBL: '601719'
+    HMS-LINCS: '10027'
+    LINCS: LSM-1027
+    PUBCHEM: '11626560'
+  name: Crizotinib
+  search_term: '"Crizotinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:62166
+    HMS-LINCS: '10351'
+    LINCS: LSM-6708
+    PUBCHEM: '25066467'
+  name: DCC-2036
+  search_term: '"DCC-2036"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:49375
+    CHEMBL: '1421'
+    HMS-LINCS: '10020'
+    LINCS: LSM-1020
+    PUBCHEM: '3062316'
+  name: Dasatinib
+  search_term: '"Dasatinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:50131
+    HMS-LINCS: '10301'
+    LINCS: LSM-5855
+    PUBCHEM: '451668'
+  name: Decitabine
+  search_term: '"Decitabine"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:40953
+    HMS-LINCS: '10169'
+    LINCS: LSM-1170
+    PUBCHEM: '156422'
+  name: Doramapimod
+  search_term: '"Doramapimod"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:78510
+    HMS-LINCS: '10399'
+    PUBCHEM: '11524144'
+  name: Dorsomorphin
+  search_term: '"Dorsomorphin"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10127'
+    LINCS: LSM-1127
+    PUBCHEM: '49830557'
+  name: Dovitinib
+  search_term: '"Dovitinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10372'
+    PUBCHEM: '59473233'
+  name: Entospletinib
+  search_term: '"Entospletinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91368
+    HMS-LINCS: '10069'
+    LINCS: LSM-1069
+    PUBCHEM: '176167'
+  name: Enzastaurin
+  search_term: '"Enzastaurin"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:114785
+    CHEMBL: '553'
+    HMS-LINCS: '10097'
+    LINCS: LSM-1097
+    PUBCHEM: '176870'
+  name: Erlotinib
+  search_term: '"Erlotinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91408
+    HMS-LINCS: '10141'
+    LINCS: LSM-1142
+    PUBCHEM: '16722836'
+  name: Fedratinib
+  search_term: '"Fedratinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10373'
+    PUBCHEM: '49831257'
+  name: Filgotinib
+  search_term: '"Filgotinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91418
+    HMS-LINCS: '10157'
+    LINCS: LSM-1158
+    PUBCHEM: '42642645'
+  name: Foretinib
+  search_term: '"Foretinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91362
+    CHEMBL: '1090479'
+    HMS-LINCS: '10062'
+    LINCS: LSM-1062
+    PUBCHEM: '46885626'
+  name: GSK1070916
+  search_term: '"GSK1070916"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91333
+    HMS-LINCS: '10013'
+    LINCS: LSM-1013
+    PUBCHEM: '15983966'
+  name: GSK461364
+  search_term: '"GSK461364"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10464'
+    PUBCHEM: '10907042'
+  name: GTPL6019
+  search_term: '"GTPL6019"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91334
+    HMS-LINCS: '10014'
+    LINCS: LSM-1014
+    PUBCHEM: '9826308'
+  name: GW843682X
+  search_term: '"GW843682X"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:51913
+    CHEMBL: '302449'
+    HMS-LINCS: '10210'
+    LINCS: LSM-1211
+    PUBCHEM: '3501'
+  name: Go 6976
+  search_term: '"Go 6976"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95092
+    HMS-LINCS: '10342'
+    LINCS: LSM-6345
+    PUBCHEM: '56655374'
+  name: HG-14-10-04
+  search_term: '"HG-14-10-04"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:45783
+    CHEMBL: '941'
+    HMS-LINCS: '10023'
+    LINCS: LSM-1023
+    PUBCHEM: '5291'
+  name: Imatinib
+  search_term: '"Imatinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91443
+    HMS-LINCS: '10195'
+    LINCS: LSM-1196
+    PUBCHEM: '11654378'
+  name: KIN001-269
+  search_term: '"KIN001-269"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10192'
+    LINCS: LSM-42803
+    PUBCHEM: '67089852'
+  name: KW2449
+  search_term: '"KW2449"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91438
+    HMS-LINCS: '10187'
+    LINCS: LSM-1188
+    PUBCHEM: '57345770'
+  name: Ki20227
+  search_term: '"Ki20227"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91471
+    HMS-LINCS: '10230'
+    LINCS: LSM-1231
+    PUBCHEM: '126565'
+  name: Lestaurtinib
+  search_term: '"Lestaurtinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91435
+    HMS-LINCS: '10182'
+    LINCS: LSM-1183
+    PUBCHEM: '11485656'
+  name: Linifanib
+  search_term: '"Linifanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91366
+    CHEMBL: '259084'
+    HMS-LINCS: '10066'
+    LINCS: LSM-1066
+    PUBCHEM: '11712649'
+  name: MLN8054
+  search_term: '"MLN8054"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:63450
+    HMS-LINCS: '10130'
+    LINCS: LSM-1130
+    PUBCHEM: '10074640'
+  name: Masitinib
+  search_term: '"Masitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:51098
+    HMS-LINCS: '10042'
+    LINCS: LSM-1042
+    PUBCHEM: '11667893'
+  name: Motesanib
+  search_term: '"Motesanib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10380'
+    PUBCHEM: '49792852'
+  name: NMS-1286937
+  search_term: '"NMS-1286937"'
+  type: drug
+- db_refs:
+    CHEMBL: '472004'
+    HMS-LINCS: '10297'
+    LINCS: LSM-6314
+    PUBCHEM: '5357795'
+  name: NSC-87877
+  search_term: '"NSC-87877"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91452
+    HMS-LINCS: '10207'
+    LINCS: LSM-1208
+    PUBCHEM: '9934347'
+  name: NVP-TAE226
+  search_term: '"NVP-TAE226"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91338
+    CHEMBL: '509032'
+    HMS-LINCS: '10024'
+    LINCS: LSM-1024
+    PUBCHEM: '16038120'
+  name: NVP-TAE684
+  search_term: '"NVP-TAE684"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:52172
+    CHEMBL: '255863'
+    HMS-LINCS: '10099'
+    LINCS: LSM-1099
+    PUBCHEM: '644241'
+  name: Nilotinib
+  search_term: '"Nilotinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10151'
+    LINCS: LSM-1152
+    PUBCHEM: '56965894'
+  name: Nintedanib
+  search_term: '"Nintedanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95096
+    HMS-LINCS: '10268'
+    LINCS: LSM-6351
+    PUBCHEM: '11433190'
+  name: Nutlin 3a
+  search_term: '"Nutlin 3a"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91433
+    HMS-LINCS: '10178'
+    LINCS: LSM-1179
+    PUBCHEM: '9868037'
+  name: OSI-930
+  search_term: '"OSI-930"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91370
+    HMS-LINCS: '10072'
+    LINCS: LSM-1072
+    PUBCHEM: '11713159'
+  name: PF562271
+  search_term: '"PF562271"'
+  type: drug
+- db_refs:
+    CHEMBL: '450786'
+    HMS-LINCS: '10125'
+    LINCS: LSM-42793
+    PUBCHEM: '66596670'
+  name: PHA-665752
+  search_term: '"PHA-665752"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91464
+    CHEMBL: '338448'
+    HMS-LINCS: '10220'
+    LINCS: LSM-1221
+    PUBCHEM: '16760627'
+  name: PKC412
+  search_term: '"PKC412"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10405'
+    PUBCHEM: '1400'
+  name: PP1
+  search_term: '"PP1"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10406'
+    PUBCHEM: '44462758'
+  name: PRT062607
+  search_term: '"PRT062607"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10381'
+    PUBCHEM: '46216796'
+  name: Pacritinib
+  search_term: '"Pacritinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:71219
+    HMS-LINCS: '10114'
+    LINCS: LSM-1114
+    PUBCHEM: '10113978'
+  name: Pazopanib
+  search_term: '"Pazopanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:78543
+    HMS-LINCS: '10150'
+    LINCS: LSM-1151
+    PUBCHEM: '24826799'
+  name: Ponatinib
+  search_term: '"Ponatinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91348
+    HMS-LINCS: '10040'
+    LINCS: LSM-1040
+    PUBCHEM: '11213558'
+  name: R406
+  search_term: '"R406"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91451
+    HMS-LINCS: '10206'
+    LINCS: LSM-1207
+    PUBCHEM: '11656518'
+  name: RAF 265
+  search_term: '"RAF 265"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:68647
+    HMS-LINCS: '10225'
+    LINCS: LSM-1226
+    PUBCHEM: '11167602'
+  name: Regorafenib
+  search_term: '"Regorafenib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:45713
+    HMS-LINCS: '10318'
+    LINCS: LSM-42917
+    PUBCHEM: '445154'
+  name: Resveratrol
+  search_term: '"Resveratrol"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95061
+    HMS-LINCS: '10288'
+    LINCS: LSM-6307
+    PUBCHEM: '24795070'
+  name: SGI-1776
+  search_term: '"SGI-1776"'
+  type: drug
+- db_refs:
+    CHEMBL: '217092'
+    HMS-LINCS: '10032'
+    LINCS: LSM-1032
+    PUBCHEM: '10302451'
+  name: Saracatinib
+  search_term: '"Saracatinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:50924
+    CHEMBL: '1336'
+    HMS-LINCS: '10008'
+    LINCS: LSM-1008
+    PUBCHEM: '216239'
+  name: Sorafenib
+  search_term: '"Sorafenib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:15738
+    CHEMBL: '388978'
+    HMS-LINCS: '10103'
+    LINCS: LSM-1103
+    PUBCHEM: '44259'
+  name: Staurosporine
+  search_term: '"Staurosporine"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95256
+    HMS-LINCS: '10518'
+    PUBCHEM: '5352624'
+  name: Sulindac sulfide
+  search_term: '"Sulindac sulfide"'
+  type: drug
+- db_refs:
+    CHEMBL: '535'
+    HMS-LINCS: '10175'
+    LINCS: LSM-42800
+    PUBCHEM: '3086686'
+  name: Sunitinib
+  search_term: '"Sunitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91327
+    HMS-LINCS: '10005'
+    LINCS: LSM-1005
+    PUBCHEM: '9911830'
+  name: Tivozanib
+  search_term: '"Tivozanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91336
+    CHEMBL: '572878'
+    HMS-LINCS: '10021'
+    LINCS: LSM-1021
+    PUBCHEM: '5494449'
+  name: Tozasertib
+  search_term: '"Tozasertib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10453'
+    PUBCHEM: '54764565'
+  name: URMC-099
+  search_term: '"URMC-099"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:49960
+    HMS-LINCS: '10198'
+    LINCS: LSM-1199
+    PUBCHEM: '3081361'
+  name: Vandetanib
+  search_term: '"Vandetanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:94800
+    HMS-LINCS: '10084'
+    LINCS: LSM-5970
+    PUBCHEM: '42628507'
+  name: WZ3105
+  search_term: '"WZ3105"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10388'
+    PUBCHEM: '57990869'
+  name: XL019
+  search_term: '"XL019"'
+  type: drug

--- a/models/brca/config.yaml
+++ b/models/brca/config.yaml
@@ -1,343 +1,2083 @@
 ndex:
   network: a16b5ca0-f6a3-11e8-aaa6-0ac135e8bacf
 search_terms:
-- "ABCD4"
-- "ADGRA2"
-- "AES"
-- "AFDN"
-- "AFF2"
-- "AGMO"
-- "AGTR2"
-- "AHNAK2"
-- "AIM2"
-- "AKAIN1"
-- "AKAP9"
-- "AKT1"
-- "AKT2"
-- "ALK"
-- "AMD1"
-- "APOA5"
-- "ARID1A"
-- "ARID1B"
-- "ARMC10"
-- "ARMC12"
-- "ARMCX6"
-- "ASXL1"
-- "ASXL2"
-- "ATR"
-- "ATXN7L3"
-- "BAP1"
-- "BAX"
-- "BDKRB2"
-- "BEX3"
-- "CACNA2D3"
-- "CASP8"
-- "CBFB"
-- "CCDC78"
-- "CCER1"
-- "CCND3"
-- "CD99"
-- "CDH1"
-- "CDKN1B"
-- "CDKN2A"
-- "CHEK2"
-- "COA6"
-- "COL12A1"
-- "COL22A1"
-- "COL6A3"
-- "COX18"
-- "CTCF"
-- "CTNNA3"
-- "DCAF4L2"
-- "DNAH11"
-- "DNAH5"
-- "DTWD2"
-- "EGFR"
-- "EP300"
-- "ERBB2"
-- "ERBB3"
-- "ERBB4"
-- "ESR1"
-- "FAM20C"
-- "FANCA"
-- "FANCD2"
-- "FBXW7"
-- "FERD3L"
-- "FHIT"
-- "FOXA1"
-- "FOXO3"
-- "FOXP1"
-- "FRG1"
-- "GATA3"
-- "GH1"
-- "GLDC"
-- "GLRX5"
-- "GPR32"
-- "GPS2"
-- "GREM2"
-- "HIST1H2AK"
-- "HIST1H2BB"
-- "HIST1H2BC"
-- "HIST1H2BD"
-- "HIST1H3B"
-- "HIST1H3G"
-- "HIST1H4D"
-- "HIST2H2AC"
-- "HIST2H2BE"
-- "HRAS"
-- "HS6ST1"
-- "IFNGR2"
-- "JAK1"
-- "KAAG1"
-- "KDM6A"
-- "KIAA0319"
-- "KLK7"
-- "KLRC1"
-- "KMT2C"
-- "KRAS"
-- "KRTAP13-4"
-- "KRTAP19-6"
-- "L1CAM"
-- "LAMA2"
-- "LAMB3"
-- "LCE1E"
-- "LDLRAP1"
-- "LENEP"
-- "LGALS1"
-- "LHCGR"
-- "LIFR"
-- "LIPI"
-- "MAGEA8"
-- "MAP2K4"
-- "MAP3K1"
-- "MAP3K13"
-- "MEN1"
-- "MMP16"
-- "MT1X"
-- "MXRA7"
-- "MYH9"
-- "MYO1A"
-- "MYO3A"
-- "NCOR1"
-- "NCOR2"
-- "NDUFS2"
-- "NF1"
-- "NOTCH1"
-- "NPNT"
-- "NQO1"
-- "NRG3"
-- "NRXN2"
-- "OAZ3"
-- "OR2M3"
-- "OR5AN1"
-- "OSR2"
-- "PDE4DIP"
-- "PIK3CA"
-- "PIK3R1"
-- "PILRB"
-- "POLR2H"
-- "PPIL1"
-- "PRKACG"
-- "PRKCQ"
-- "PRR16"
-- "PTEN"
-- "PTH2"
-- "PTPN22"
-- "PTPRD"
-- "PTPRM"
-- "RB1"
-- "RHOA"
-- "RHOB"
-- "ROS1"
-- "RPL19"
-- "RUNX1"
-- "RYR2"
-- "SCAMP3"
-- "SETD1A"
-- "SF3B1"
-- "SGCD"
-- "SH2D2A"
-- "SH3BGRL3"
-- "SHANK2"
-- "SHOC2"
-- "SIK1"
-- "SMAD4"
-- "SPAG11B"
-- "SPRR2B"
-- "ST8SIA3"
-- "STAB2"
-- "STK11"
-- "STK19"
-- "SVBP"
-- "TAF1"
-- "TAL2"
-- "TBL1XR1"
-- "TBX3"
-- "TDO2"
-- "TDP2"
-- "TDRP"
-- "TG"
-- "TGIF2LX"
-- "THADA"
-- "THSD7A"
-- "TMED8"
-- "TMEM256"
-- "TMSB15A"
-- "TP53"
-- "TPRKB"
-- "TTYH1"
-- "U2AF1"
-- "UQCR10"
-- "URB1-AS1"
-- "USH2A"
-- "USP28"
-- "UTRN"
-- "VGLL3"
-- "WASHC3"
-- "ZFP36L1"
-- "ZFP64"
-- "ZNF200"
-- "ZNF415"
-- "(-)-Blebbistatin"
-- "(Z)-4-Hydroxytamoxifen"
-- "A443654"
-- "A66"
-- "AG1478"
-- "ALK-IN-1"
-- "AS-252424"
-- "AS605240"
-- "ASP3026"
-- "AST1306"
-- "AT-7519"
-- "AT7867"
-- "AZ 20"
-- "AZD 5438"
-- "AZD-6482"
-- "AZD5363"
-- "AZD7762"
-- "Afatinib"
-- "Alisertib"
-- "Alpelisib"
-- "Alvocidib"
-- "Anacardic acid"
-- "BI-2536"
-- "BMS-536924"
-- "Barasertib"
-- "Baricitinib"
-- "Bosutinib"
-- "Buparlisib"
-- "C646"
-- "CAL-101"
-- "CG-930"
-- "CGK733"
-- "CH5424802"
-- "CP724714"
-- "CTB"
-- "CUDC-907"
-- "Cabozantinib"
-- "Canertinib"
-- "Cediranib"
-- "Ceritinib"
-- "Chk2 inhibitor II"
-- "Crizotinib"
-- "Dacomitinib"
-- "Dactolisib"
-- "Dasatinib"
-- "Dovitinib"
-- "Enzastaurin"
-- "Erlotinib"
-- "Fedratinib"
-- "Filgotinib"
-- "Foretinib"
-- "GDC-0980"
-- "GM6001"
-- "GSK 690693"
-- "GSK-J1"
-- "GSK-J4"
-- "GSK1059615"
-- "GSK1070916"
-- "GSK1838705A"
-- "Garcinol"
-- "Gefitinib"
-- "Go 6976"
-- "H-8"
-- "H89"
-- "HG-14-10-04"
-- "HG-14-8-02"
-- "HG-5-88-01"
-- "HG-6-64-01"
-- "HG-9-91-01"
-- "Ibrutinib"
-- "Ipatasertib"
-- "KIN001-111"
-- "KIN001-135"
-- "KW2449"
-- "LY294002"
-- "Lapatinib"
-- "Lestaurtinib"
-- "Linsitinib"
-- "MK 1775"
-- "MK2206"
-- "ML-9"
-- "MRT67307"
-- "Mocetinostat"
-- "Momelotinib"
-- "NU7441"
-- "NVP-BGT226"
-- "NVP-TAE226"
-- "NVP-TAE684"
-- "Neratinib"
-- "Nintedanib"
-- "Nutlin 3a"
-- "Omipalisib"
-- "PF-06463922"
-- "PF562271"
-- "PHA-767491"
-- "PI103"
-- "PI3K-IN-1"
-- "PIK-93"
-- "PKC412"
-- "PLX-4720"
-- "PP1"
-- "Palbociclib"
-- "Pazopanib"
-- "Pelitinib"
-- "Pictilisib"
-- "Poziotinib"
-- "R406"
-- "RO 31-8220"
-- "Resveratrol"
-- "Rigosertib"
-- "Ro 32-0432"
-- "Ruxolitinib"
-- "S-Ruxolitinib"
-- "SNS-032"
-- "SP600125"
-- "Sigma A6730"
-- "Sotrastaurin"
-- "Staurosporine"
-- "Staurosporine aglycone"
-- "Sunitinib"
-- "TAK-715"
-- "TPCA-1"
-- "Taselisib"
-- "Tofacitinib"
-- "Torin1"
-- "Torin2"
-- "Tozasertib"
-- "Trichostatin A"
-- "Triciribine"
-- "VE-821"
-- "Vandetanib"
-- "Vorinostat"
-- "WH-4-023"
-- "WH-4-025"
-- "WZ-4-145"
-- "WZ4002"
-- "XL019"
-- "XL147"
-- "XL765"
-- "XMD11-50"
-- "Y-27632"
-- "ZM-447439"
-- "ZSTK474"
+- db_refs:
+    HGNC: '68'
+  name: ABCD4
+  search_term: '"ABCD4"'
+  type: gene
+- db_refs:
+    HGNC: '17849'
+  name: ADGRA2
+  search_term: '"ADGRA2"'
+  type: gene
+- db_refs:
+    HGNC: '307'
+  name: AES
+  search_term: '"AES"'
+  type: gene
+- db_refs:
+    HGNC: '7137'
+  name: AFDN
+  search_term: '"AFDN"'
+  type: gene
+- db_refs:
+    HGNC: '3776'
+  name: AFF2
+  search_term: '"AFF2"'
+  type: gene
+- db_refs:
+    HGNC: '33784'
+  name: AGMO
+  search_term: '"AGMO"'
+  type: gene
+- db_refs:
+    HGNC: '338'
+  name: AGTR2
+  search_term: '"AGTR2"'
+  type: gene
+- db_refs:
+    HGNC: '20125'
+  name: AHNAK2
+  search_term: '"AHNAK2"'
+  type: gene
+- db_refs:
+    HGNC: '357'
+  name: AIM2
+  search_term: '"AIM2"'
+  type: gene
+- db_refs:
+    HGNC: '28285'
+  name: AKAIN1
+  search_term: '"AKAIN1"'
+  type: gene
+- db_refs:
+    HGNC: '379'
+  name: AKAP9
+  search_term: '"AKAP9"'
+  type: gene
+- db_refs:
+    HGNC: '391'
+  name: AKT1
+  search_term: '"AKT1"'
+  type: gene
+- db_refs:
+    HGNC: '392'
+  name: AKT2
+  search_term: '"AKT2"'
+  type: gene
+- db_refs:
+    HGNC: '427'
+  name: ALK
+  search_term: '"ALK"'
+  type: gene
+- db_refs:
+    HGNC: '457'
+  name: AMD1
+  search_term: '"AMD1"'
+  type: gene
+- db_refs:
+    HGNC: '17288'
+  name: APOA5
+  search_term: '"APOA5"'
+  type: gene
+- db_refs:
+    HGNC: '11110'
+  name: ARID1A
+  search_term: '"ARID1A"'
+  type: gene
+- db_refs:
+    HGNC: '18040'
+  name: ARID1B
+  search_term: '"ARID1B"'
+  type: gene
+- db_refs:
+    HGNC: '21706'
+  name: ARMC10
+  search_term: '"ARMC10"'
+  type: gene
+- db_refs:
+    HGNC: '21099'
+  name: ARMC12
+  search_term: '"ARMC12"'
+  type: gene
+- db_refs:
+    HGNC: '26094'
+  name: ARMCX6
+  search_term: '"ARMCX6"'
+  type: gene
+- db_refs:
+    HGNC: '18318'
+  name: ASXL1
+  search_term: '"ASXL1"'
+  type: gene
+- db_refs:
+    HGNC: '23805'
+  name: ASXL2
+  search_term: '"ASXL2"'
+  type: gene
+- db_refs:
+    HGNC: '882'
+  name: ATR
+  search_term: '"ATR"'
+  type: gene
+- db_refs:
+    HGNC: '25416'
+  name: ATXN7L3
+  search_term: '"ATXN7L3"'
+  type: gene
+- db_refs:
+    HGNC: '950'
+  name: BAP1
+  search_term: '"BAP1"'
+  type: gene
+- db_refs:
+    HGNC: '959'
+  name: BAX
+  search_term: '"BAX"'
+  type: gene
+- db_refs:
+    HGNC: '1030'
+  name: BDKRB2
+  search_term: '"BDKRB2"'
+  type: gene
+- db_refs:
+    HGNC: '13388'
+  name: BEX3
+  search_term: '"BEX3"'
+  type: gene
+- db_refs:
+    HGNC: '15460'
+  name: CACNA2D3
+  search_term: '"CACNA2D3"'
+  type: gene
+- db_refs:
+    HGNC: '1509'
+  name: CASP8
+  search_term: '"CASP8"'
+  type: gene
+- db_refs:
+    HGNC: '1539'
+  name: CBFB
+  search_term: '"CBFB"'
+  type: gene
+- db_refs:
+    HGNC: '14153'
+  name: CCDC78
+  search_term: '"CCDC78"'
+  type: gene
+- db_refs:
+    HGNC: '28373'
+  name: CCER1
+  search_term: '"CCER1"'
+  type: gene
+- db_refs:
+    HGNC: '1585'
+  name: CCND3
+  search_term: '"CCND3"'
+  type: gene
+- db_refs:
+    HGNC: '7082'
+  name: CD99
+  search_term: '"CD99"'
+  type: gene
+- db_refs:
+    HGNC: '1748'
+  name: CDH1
+  search_term: '"CDH1"'
+  type: gene
+- db_refs:
+    HGNC: '1785'
+  name: CDKN1B
+  search_term: '"CDKN1B"'
+  type: gene
+- db_refs:
+    HGNC: '1787'
+  name: CDKN2A
+  search_term: '"CDKN2A"'
+  type: gene
+- db_refs:
+    HGNC: '16627'
+  name: CHEK2
+  search_term: '"CHEK2"'
+  type: gene
+- db_refs:
+    HGNC: '18025'
+  name: COA6
+  search_term: '"COA6"'
+  type: gene
+- db_refs:
+    HGNC: '2188'
+  name: COL12A1
+  search_term: '"COL12A1"'
+  type: gene
+- db_refs:
+    HGNC: '22989'
+  name: COL22A1
+  search_term: '"COL22A1"'
+  type: gene
+- db_refs:
+    HGNC: '2213'
+  name: COL6A3
+  search_term: '"COL6A3"'
+  type: gene
+- db_refs:
+    HGNC: '26801'
+  name: COX18
+  search_term: '"COX18"'
+  type: gene
+- db_refs:
+    HGNC: '13723'
+  name: CTCF
+  search_term: '"CTCF"'
+  type: gene
+- db_refs:
+    HGNC: '2511'
+  name: CTNNA3
+  search_term: '"CTNNA3"'
+  type: gene
+- db_refs:
+    HGNC: '26657'
+  name: DCAF4L2
+  search_term: '"DCAF4L2"'
+  type: gene
+- db_refs:
+    HGNC: '2942'
+  name: DNAH11
+  search_term: '"DNAH11"'
+  type: gene
+- db_refs:
+    HGNC: '2950'
+  name: DNAH5
+  search_term: '"DNAH5"'
+  type: gene
+- db_refs:
+    HGNC: '19334'
+  name: DTWD2
+  search_term: '"DTWD2"'
+  type: gene
+- db_refs:
+    HGNC: '3236'
+  name: EGFR
+  search_term: '"EGFR"'
+  type: gene
+- db_refs:
+    HGNC: '3373'
+  name: EP300
+  search_term: '"EP300"'
+  type: gene
+- db_refs:
+    HGNC: '3430'
+  name: ERBB2
+  search_term: '"ERBB2"'
+  type: gene
+- db_refs:
+    HGNC: '3431'
+  name: ERBB3
+  search_term: '"ERBB3"'
+  type: gene
+- db_refs:
+    HGNC: '3432'
+  name: ERBB4
+  search_term: '"ERBB4"'
+  type: gene
+- db_refs:
+    HGNC: '3467'
+  name: ESR1
+  search_term: '"ESR1"'
+  type: gene
+- db_refs:
+    HGNC: '22140'
+  name: FAM20C
+  search_term: '"FAM20C"'
+  type: gene
+- db_refs:
+    HGNC: '3582'
+  name: FANCA
+  search_term: '"FANCA"'
+  type: gene
+- db_refs:
+    HGNC: '3585'
+  name: FANCD2
+  search_term: '"FANCD2"'
+  type: gene
+- db_refs:
+    HGNC: '16712'
+  name: FBXW7
+  search_term: '"FBXW7"'
+  type: gene
+- db_refs:
+    HGNC: '16660'
+  name: FERD3L
+  search_term: '"FERD3L"'
+  type: gene
+- db_refs:
+    HGNC: '3701'
+  name: FHIT
+  search_term: '"FHIT"'
+  type: gene
+- db_refs:
+    HGNC: '5021'
+  name: FOXA1
+  search_term: '"FOXA1"'
+  type: gene
+- db_refs:
+    HGNC: '3821'
+  name: FOXO3
+  search_term: '"FOXO3"'
+  type: gene
+- db_refs:
+    HGNC: '3823'
+  name: FOXP1
+  search_term: '"FOXP1"'
+  type: gene
+- db_refs:
+    HGNC: '3954'
+  name: FRG1
+  search_term: '"FRG1"'
+  type: gene
+- db_refs:
+    HGNC: '4172'
+  name: GATA3
+  search_term: '"GATA3"'
+  type: gene
+- db_refs:
+    HGNC: '4261'
+  name: GH1
+  search_term: '"GH1"'
+  type: gene
+- db_refs:
+    HGNC: '4313'
+  name: GLDC
+  search_term: '"GLDC"'
+  type: gene
+- db_refs:
+    HGNC: '20134'
+  name: GLRX5
+  search_term: '"GLRX5"'
+  type: gene
+- db_refs:
+    HGNC: '4487'
+  name: GPR32
+  search_term: '"GPR32"'
+  type: gene
+- db_refs:
+    HGNC: '4550'
+  name: GPS2
+  search_term: '"GPS2"'
+  type: gene
+- db_refs:
+    HGNC: '17655'
+  name: GREM2
+  search_term: '"GREM2"'
+  type: gene
+- db_refs:
+    HGNC: '4726'
+  name: HIST1H2AK
+  search_term: '"HIST1H2AK"'
+  type: gene
+- db_refs:
+    HGNC: '4751'
+  name: HIST1H2BB
+  search_term: '"HIST1H2BB"'
+  type: gene
+- db_refs:
+    HGNC: '4757'
+  name: HIST1H2BC
+  search_term: '"HIST1H2BC"'
+  type: gene
+- db_refs:
+    HGNC: '4747'
+  name: HIST1H2BD
+  search_term: '"HIST1H2BD"'
+  type: gene
+- db_refs:
+    HGNC: '4776'
+  name: HIST1H3B
+  search_term: '"HIST1H3B"'
+  type: gene
+- db_refs:
+    HGNC: '4772'
+  name: HIST1H3G
+  search_term: '"HIST1H3G"'
+  type: gene
+- db_refs:
+    HGNC: '4782'
+  name: HIST1H4D
+  search_term: '"HIST1H4D"'
+  type: gene
+- db_refs:
+    HGNC: '4738'
+  name: HIST2H2AC
+  search_term: '"HIST2H2AC"'
+  type: gene
+- db_refs:
+    HGNC: '4760'
+  name: HIST2H2BE
+  search_term: '"HIST2H2BE"'
+  type: gene
+- db_refs:
+    HGNC: '5173'
+  name: HRAS
+  search_term: '"HRAS"'
+  type: gene
+- db_refs:
+    HGNC: '5201'
+  name: HS6ST1
+  search_term: '"HS6ST1"'
+  type: gene
+- db_refs:
+    HGNC: '5440'
+  name: IFNGR2
+  search_term: '"IFNGR2"'
+  type: gene
+- db_refs:
+    HGNC: '6190'
+  name: JAK1
+  search_term: '"JAK1"'
+  type: gene
+- db_refs:
+    HGNC: '21031'
+  name: KAAG1
+  search_term: '"KAAG1"'
+  type: gene
+- db_refs:
+    HGNC: '12637'
+  name: KDM6A
+  search_term: '"KDM6A"'
+  type: gene
+- db_refs:
+    HGNC: '21580'
+  name: KIAA0319
+  search_term: '"KIAA0319"'
+  type: gene
+- db_refs:
+    HGNC: '6368'
+  name: KLK7
+  search_term: '"KLK7"'
+  type: gene
+- db_refs:
+    HGNC: '6374'
+  name: KLRC1
+  search_term: '"KLRC1"'
+  type: gene
+- db_refs:
+    HGNC: '13726'
+  name: KMT2C
+  search_term: '"KMT2C"'
+  type: gene
+- db_refs:
+    HGNC: '6407'
+  name: KRAS
+  search_term: '"KRAS"'
+  type: gene
+- db_refs:
+    HGNC: '18926'
+  name: KRTAP13-4
+  search_term: '"KRTAP13-4"'
+  type: gene
+- db_refs:
+    HGNC: '18941'
+  name: KRTAP19-6
+  search_term: '"KRTAP19-6"'
+  type: gene
+- db_refs:
+    HGNC: '6470'
+  name: L1CAM
+  search_term: '"L1CAM"'
+  type: gene
+- db_refs:
+    HGNC: '6482'
+  name: LAMA2
+  search_term: '"LAMA2"'
+  type: gene
+- db_refs:
+    HGNC: '6490'
+  name: LAMB3
+  search_term: '"LAMB3"'
+  type: gene
+- db_refs:
+    HGNC: '29466'
+  name: LCE1E
+  search_term: '"LCE1E"'
+  type: gene
+- db_refs:
+    HGNC: '18640'
+  name: LDLRAP1
+  search_term: '"LDLRAP1"'
+  type: gene
+- db_refs:
+    HGNC: '14429'
+  name: LENEP
+  search_term: '"LENEP"'
+  type: gene
+- db_refs:
+    HGNC: '6561'
+  name: LGALS1
+  search_term: '"LGALS1"'
+  type: gene
+- db_refs:
+    HGNC: '6585'
+  name: LHCGR
+  search_term: '"LHCGR"'
+  type: gene
+- db_refs:
+    HGNC: '6597'
+  name: LIFR
+  search_term: '"LIFR"'
+  type: gene
+- db_refs:
+    HGNC: '18821'
+  name: LIPI
+  search_term: '"LIPI"'
+  type: gene
+- db_refs:
+    HGNC: '6806'
+  name: MAGEA8
+  search_term: '"MAGEA8"'
+  type: gene
+- db_refs:
+    HGNC: '6844'
+  name: MAP2K4
+  search_term: '"MAP2K4"'
+  type: gene
+- db_refs:
+    HGNC: '6848'
+  name: MAP3K1
+  search_term: '"MAP3K1"'
+  type: gene
+- db_refs:
+    HGNC: '6852'
+  name: MAP3K13
+  search_term: '"MAP3K13"'
+  type: gene
+- db_refs:
+    HGNC: '7010'
+  name: MEN1
+  search_term: '"MEN1"'
+  type: gene
+- db_refs:
+    HGNC: '7162'
+  name: MMP16
+  search_term: '"MMP16"'
+  type: gene
+- db_refs:
+    HGNC: '7405'
+  name: MT1X
+  search_term: '"MT1X"'
+  type: gene
+- db_refs:
+    HGNC: '7541'
+  name: MXRA7
+  search_term: '"MXRA7"'
+  type: gene
+- db_refs:
+    HGNC: '7579'
+  name: MYH9
+  search_term: '"MYH9"'
+  type: gene
+- db_refs:
+    HGNC: '7595'
+  name: MYO1A
+  search_term: '"MYO1A"'
+  type: gene
+- db_refs:
+    HGNC: '7601'
+  name: MYO3A
+  search_term: '"MYO3A"'
+  type: gene
+- db_refs:
+    HGNC: '7672'
+  name: NCOR1
+  search_term: '"NCOR1"'
+  type: gene
+- db_refs:
+    HGNC: '7673'
+  name: NCOR2
+  search_term: '"NCOR2"'
+  type: gene
+- db_refs:
+    HGNC: '7708'
+  name: NDUFS2
+  search_term: '"NDUFS2"'
+  type: gene
+- db_refs:
+    HGNC: '7765'
+  name: NF1
+  search_term: '"NF1"'
+  type: gene
+- db_refs:
+    HGNC: '7881'
+  name: NOTCH1
+  search_term: '"NOTCH1"'
+  type: gene
+- db_refs:
+    HGNC: '27405'
+  name: NPNT
+  search_term: '"NPNT"'
+  type: gene
+- db_refs:
+    HGNC: '2874'
+  name: NQO1
+  search_term: '"NQO1"'
+  type: gene
+- db_refs:
+    HGNC: '7999'
+  name: NRG3
+  search_term: '"NRG3"'
+  type: gene
+- db_refs:
+    HGNC: '8009'
+  name: NRXN2
+  search_term: '"NRXN2"'
+  type: gene
+- db_refs:
+    HGNC: '8097'
+  name: OAZ3
+  search_term: '"OAZ3"'
+  type: gene
+- db_refs:
+    HGNC: '8269'
+  name: OR2M3
+  search_term: '"OR2M3"'
+  type: gene
+- db_refs:
+    HGNC: '15255'
+  name: OR5AN1
+  search_term: '"OR5AN1"'
+  type: gene
+- db_refs:
+    HGNC: '15830'
+  name: OSR2
+  search_term: '"OSR2"'
+  type: gene
+- db_refs:
+    HGNC: '15580'
+  name: PDE4DIP
+  search_term: '"PDE4DIP"'
+  type: gene
+- db_refs:
+    HGNC: '8975'
+  name: PIK3CA
+  search_term: '"PIK3CA"'
+  type: gene
+- db_refs:
+    HGNC: '8979'
+  name: PIK3R1
+  search_term: '"PIK3R1"'
+  type: gene
+- db_refs:
+    HGNC: '18297'
+  name: PILRB
+  search_term: '"PILRB"'
+  type: gene
+- db_refs:
+    HGNC: '9195'
+  name: POLR2H
+  search_term: '"POLR2H"'
+  type: gene
+- db_refs:
+    HGNC: '9260'
+  name: PPIL1
+  search_term: '"PPIL1"'
+  type: gene
+- db_refs:
+    HGNC: '9382'
+  name: PRKACG
+  search_term: '"PRKACG"'
+  type: gene
+- db_refs:
+    HGNC: '9410'
+  name: PRKCQ
+  search_term: '"PRKCQ"'
+  type: gene
+- db_refs:
+    HGNC: '29654'
+  name: PRR16
+  search_term: '"PRR16"'
+  type: gene
+- db_refs:
+    HGNC: '9588'
+  name: PTEN
+  search_term: '"PTEN"'
+  type: gene
+- db_refs:
+    HGNC: '30828'
+  name: PTH2
+  search_term: '"PTH2"'
+  type: gene
+- db_refs:
+    HGNC: '9652'
+  name: PTPN22
+  search_term: '"PTPN22"'
+  type: gene
+- db_refs:
+    HGNC: '9668'
+  name: PTPRD
+  search_term: '"PTPRD"'
+  type: gene
+- db_refs:
+    HGNC: '9675'
+  name: PTPRM
+  search_term: '"PTPRM"'
+  type: gene
+- db_refs:
+    HGNC: '9884'
+  name: RB1
+  search_term: '"RB1"'
+  type: gene
+- db_refs:
+    HGNC: '667'
+  name: RHOA
+  search_term: '"RHOA"'
+  type: gene
+- db_refs:
+    HGNC: '668'
+  name: RHOB
+  search_term: '"RHOB"'
+  type: gene
+- db_refs:
+    HGNC: '10261'
+  name: ROS1
+  search_term: '"ROS1"'
+  type: gene
+- db_refs:
+    HGNC: '10312'
+  name: RPL19
+  search_term: '"RPL19"'
+  type: gene
+- db_refs:
+    HGNC: '10471'
+  name: RUNX1
+  search_term: '"RUNX1"'
+  type: gene
+- db_refs:
+    HGNC: '10484'
+  name: RYR2
+  search_term: '"RYR2"'
+  type: gene
+- db_refs:
+    HGNC: '10565'
+  name: SCAMP3
+  search_term: '"SCAMP3"'
+  type: gene
+- db_refs:
+    HGNC: '29010'
+  name: SETD1A
+  search_term: '"SETD1A"'
+  type: gene
+- db_refs:
+    HGNC: '10768'
+  name: SF3B1
+  search_term: '"SF3B1"'
+  type: gene
+- db_refs:
+    HGNC: '10807'
+  name: SGCD
+  search_term: '"SGCD"'
+  type: gene
+- db_refs:
+    HGNC: '10821'
+  name: SH2D2A
+  search_term: '"SH2D2A"'
+  type: gene
+- db_refs:
+    HGNC: '15568'
+  name: SH3BGRL3
+  search_term: '"SH3BGRL3"'
+  type: gene
+- db_refs:
+    HGNC: '14295'
+  name: SHANK2
+  search_term: '"SHANK2"'
+  type: gene
+- db_refs:
+    HGNC: '15454'
+  name: SHOC2
+  search_term: '"SHOC2"'
+  type: gene
+- db_refs:
+    HGNC: '11142'
+  name: SIK1
+  search_term: '"SIK1"'
+  type: gene
+- db_refs:
+    HGNC: '6770'
+  name: SMAD4
+  search_term: '"SMAD4"'
+  type: gene
+- db_refs:
+    HGNC: '14534'
+  name: SPAG11B
+  search_term: '"SPAG11B"'
+  type: gene
+- db_refs:
+    HGNC: '11262'
+  name: SPRR2B
+  search_term: '"SPRR2B"'
+  type: gene
+- db_refs:
+    HGNC: '14269'
+  name: ST8SIA3
+  search_term: '"ST8SIA3"'
+  type: gene
+- db_refs:
+    HGNC: '18629'
+  name: STAB2
+  search_term: '"STAB2"'
+  type: gene
+- db_refs:
+    HGNC: '11389'
+  name: STK11
+  search_term: '"STK11"'
+  type: gene
+- db_refs:
+    HGNC: '11398'
+  name: STK19
+  search_term: '"STK19"'
+  type: gene
+- db_refs:
+    HGNC: '29204'
+  name: SVBP
+  search_term: '"SVBP"'
+  type: gene
+- db_refs:
+    HGNC: '11535'
+  name: TAF1
+  search_term: '"TAF1"'
+  type: gene
+- db_refs:
+    HGNC: '11557'
+  name: TAL2
+  search_term: '"TAL2"'
+  type: gene
+- db_refs:
+    HGNC: '29529'
+  name: TBL1XR1
+  search_term: '"TBL1XR1"'
+  type: gene
+- db_refs:
+    HGNC: '11602'
+  name: TBX3
+  search_term: '"TBX3"'
+  type: gene
+- db_refs:
+    HGNC: '11708'
+  name: TDO2
+  search_term: '"TDO2"'
+  type: gene
+- db_refs:
+    HGNC: '17768'
+  name: TDP2
+  search_term: '"TDP2"'
+  type: gene
+- db_refs:
+    HGNC: '26951'
+  name: TDRP
+  search_term: '"TDRP"'
+  type: gene
+- db_refs:
+    HGNC: '11764'
+  name: TG
+  search_term: '"TG"'
+  type: gene
+- db_refs:
+    HGNC: '18570'
+  name: TGIF2LX
+  search_term: '"TGIF2LX"'
+  type: gene
+- db_refs:
+    HGNC: '19217'
+  name: THADA
+  search_term: '"THADA"'
+  type: gene
+- db_refs:
+    HGNC: '22207'
+  name: THSD7A
+  search_term: '"THSD7A"'
+  type: gene
+- db_refs:
+    HGNC: '18633'
+  name: TMED8
+  search_term: '"TMED8"'
+  type: gene
+- db_refs:
+    HGNC: '28618'
+  name: TMEM256
+  search_term: '"TMEM256"'
+  type: gene
+- db_refs:
+    HGNC: '30744'
+  name: TMSB15A
+  search_term: '"TMSB15A"'
+  type: gene
+- db_refs:
+    HGNC: '11998'
+  name: TP53
+  search_term: '"TP53"'
+  type: gene
+- db_refs:
+    HGNC: '24259'
+  name: TPRKB
+  search_term: '"TPRKB"'
+  type: gene
+- db_refs:
+    HGNC: '13476'
+  name: TTYH1
+  search_term: '"TTYH1"'
+  type: gene
+- db_refs:
+    HGNC: '12453'
+  name: U2AF1
+  search_term: '"U2AF1"'
+  type: gene
+- db_refs:
+    HGNC: '30863'
+  name: UQCR10
+  search_term: '"UQCR10"'
+  type: gene
+- db_refs:
+    HGNC: '23128'
+  name: URB1-AS1
+  search_term: '"URB1-AS1"'
+  type: gene
+- db_refs:
+    HGNC: '12601'
+  name: USH2A
+  search_term: '"USH2A"'
+  type: gene
+- db_refs:
+    HGNC: '12625'
+  name: USP28
+  search_term: '"USP28"'
+  type: gene
+- db_refs:
+    HGNC: '12635'
+  name: UTRN
+  search_term: '"UTRN"'
+  type: gene
+- db_refs:
+    HGNC: '24327'
+  name: VGLL3
+  search_term: '"VGLL3"'
+  type: gene
+- db_refs:
+    HGNC: '24256'
+  name: WASHC3
+  search_term: '"WASHC3"'
+  type: gene
+- db_refs:
+    HGNC: '1107'
+  name: ZFP36L1
+  search_term: '"ZFP36L1"'
+  type: gene
+- db_refs:
+    HGNC: '15940'
+  name: ZFP64
+  search_term: '"ZFP64"'
+  type: gene
+- db_refs:
+    HGNC: '12993'
+  name: ZNF200
+  search_term: '"ZNF200"'
+  type: gene
+- db_refs:
+    HGNC: '20636'
+  name: ZNF415
+  search_term: '"ZNF415"'
+  type: gene
+- db_refs:
+    CHEBI: CHEBI:75388
+    HMS-LINCS: '10451'
+    PUBCHEM: '5287792'
+  name: (-)-Blebbistatin
+  search_term: '"(-)-Blebbistatin"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10275'
+    LINCS: LSM-43294
+    PUBCHEM: '53770298'
+  name: (Z)-4-Hydroxytamoxifen
+  search_term: '"(Z)-4-Hydroxytamoxifen"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91351
+    CHEMBL: '379300'
+    HMS-LINCS: '10045'
+    LINCS: LSM-1045
+    PUBCHEM: '10172943'
+  name: A443654
+  search_term: '"A443654"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91449
+    HMS-LINCS: '10203'
+    LINCS: LSM-1204
+    PUBCHEM: '42636535'
+  name: A66
+  search_term: '"A66"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:75404
+    HMS-LINCS: '10223'
+    LINCS: LSM-1224
+    PUBCHEM: '2051'
+  name: AG1478
+  search_term: '"AG1478"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10392'
+    PUBCHEM: '57390074'
+  name: ALK-IN-1
+  search_term: '"ALK-IN-1"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10240'
+    LINCS: LSM-4263
+    PUBCHEM: '56965900'
+  name: AS-252424
+  search_term: '"AS-252424"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10054'
+    LINCS: LSM-42784
+    PUBCHEM: '24906273'
+  name: AS605240
+  search_term: '"AS605240"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10368'
+    PUBCHEM: '25134326'
+  name: ASP3026
+  search_term: '"ASP3026"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91467
+    HMS-LINCS: '10224'
+    LINCS: LSM-1225
+    PUBCHEM: '24739943'
+  name: AST1306
+  search_term: '"AST1306"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91326
+    CHEMBL: '445813'
+    HMS-LINCS: '10004'
+    LINCS: LSM-1004
+    PUBCHEM: '11338033'
+  name: AT-7519
+  search_term: '"AT-7519"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:82708
+    HMS-LINCS: '10154'
+    LINCS: LSM-1155
+    PUBCHEM: '11175137'
+  name: AT7867
+  search_term: '"AT7867"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:124915
+    HMS-LINCS: '10358'
+    LINCS: LSM-36357
+    PUBCHEM: '46244454'
+  name: AZ 20
+  search_term: '"AZ 20"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91419
+    HMS-LINCS: '10158'
+    LINCS: LSM-1159
+    PUBCHEM: '16747683'
+  name: AZD 5438
+  search_term: '"AZD 5438"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91359
+    HMS-LINCS: '10059'
+    LINCS: LSM-1059
+    PUBCHEM: '44137675'
+  name: AZD-6482
+  search_term: '"AZD-6482"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10370'
+    PUBCHEM: '25227436'
+  name: AZD5363
+  search_term: '"AZD5363"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91328
+    HMS-LINCS: '10006'
+    LINCS: LSM-1006
+    PUBCHEM: '67077825'
+  name: AZD7762
+  search_term: '"AZD7762"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10133'
+    LINCS: LSM-43226
+    PUBCHEM: '57519523'
+  name: Afatinib
+  search_term: '"Afatinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:125628
+    HMS-LINCS: '10391'
+    PUBCHEM: '24771867'
+  name: Alisertib
+  search_term: '"Alisertib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:93752
+    HMS-LINCS: '10233'
+    LINCS: LSM-4256
+    PUBCHEM: '56649450'
+  name: Alpelisib
+  search_term: '"Alpelisib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:47344
+    CHEMBL: '428690'
+    HMS-LINCS: '10011'
+    LINCS: LSM-1011
+    PUBCHEM: '5287969'
+  name: Alvocidib
+  search_term: '"Alvocidib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:2696
+    HMS-LINCS: '10308'
+    LINCS: LSM-6320
+    PUBCHEM: '167551'
+  name: Anacardic acid
+  search_term: '"Anacardic acid"'
+  type: drug
+- db_refs:
+    CHEMBL: '513909'
+    HMS-LINCS: '10041'
+    LINCS: LSM-1041
+    PUBCHEM: '11364421'
+  name: BI-2536
+  search_term: '"BI-2536"'
+  type: drug
+- db_refs:
+    CHEMBL: '401930'
+    HMS-LINCS: '10209'
+    LINCS: LSM-1210
+    PUBCHEM: '68925359'
+  name: BMS-536924
+  search_term: '"BMS-536924"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91367
+    CHEMBL: '215152'
+    HMS-LINCS: '10067'
+    LINCS: LSM-1067
+    PUBCHEM: '16007391'
+  name: Barasertib
+  search_term: '"Barasertib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95341
+    HMS-LINCS: '10354'
+    LINCS: LSM-6709
+    PUBCHEM: '44205240'
+  name: Baricitinib
+  search_term: '"Baricitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:39112
+    HMS-LINCS: '10189'
+    LINCS: LSM-1190
+    PUBCHEM: '5328940'
+  name: Bosutinib
+  search_term: '"Bosutinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:71954
+    HMS-LINCS: '10147'
+    LINCS: LSM-1148
+    PUBCHEM: '16654980'
+  name: Buparlisib
+  search_term: '"Buparlisib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10306'
+    LINCS: LSM-43281
+    PUBCHEM: '2871948'
+  name: C646
+  search_term: '"C646"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:82701
+    HMS-LINCS: '10204'
+    LINCS: LSM-1205
+    PUBCHEM: '11625818'
+  name: CAL-101
+  search_term: '"CAL-101"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91358
+    HMS-LINCS: '10058'
+    LINCS: LSM-1058
+    PUBCHEM: '57394468'
+  name: CG-930
+  search_term: '"CG-930"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91739
+    HMS-LINCS: '10359'
+    LINCS: LSM-1610
+    PUBCHEM: '6605258'
+  name: CGK733
+  search_term: '"CGK733"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90936
+    HMS-LINCS: '10201'
+    LINCS: LSM-1202
+    PUBCHEM: '49806720'
+  name: CH5424802
+  search_term: '"CH5424802"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10010'
+    LINCS: LSM-42777
+    PUBCHEM: '53401057'
+  name: CP724714
+  search_term: '"CP724714"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95070
+    HMS-LINCS: '10309'
+    LINCS: LSM-6321
+    PUBCHEM: '729859'
+  name: CTB
+  search_term: '"CTB"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10371'
+    PUBCHEM: '54575456'
+  name: CUDC-907
+  search_term: '"CUDC-907"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:72317
+    HMS-LINCS: '10194'
+    LINCS: LSM-1195
+    PUBCHEM: '25102847'
+  name: Cabozantinib
+  search_term: '"Cabozantinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:61399
+    HMS-LINCS: '10120'
+    LINCS: LSM-1120
+    PUBCHEM: '156414'
+  name: Canertinib
+  search_term: '"Canertinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:94782
+    HMS-LINCS: '10444'
+    PUBCHEM: '9933475'
+  name: Cediranib
+  search_term: '"Cediranib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:78432
+    HMS-LINCS: '10394'
+    PUBCHEM: '57379345'
+  name: Ceritinib
+  search_term: '"Ceritinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10504'
+    PUBCHEM: '9969021'
+  name: Chk2 inhibitor II
+  search_term: '"Chk2 inhibitor II"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:64310
+    CHEMBL: '601719'
+    HMS-LINCS: '10027'
+    LINCS: LSM-1027
+    PUBCHEM: '11626560'
+  name: Crizotinib
+  search_term: '"Crizotinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10222'
+    LINCS: LSM-42808
+    PUBCHEM: '57519532'
+  name: Dacomitinib
+  search_term: '"Dacomitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:71952
+    HMS-LINCS: '10232'
+    LINCS: LSM-4255
+    PUBCHEM: '11977753'
+  name: Dactolisib
+  search_term: '"Dactolisib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:49375
+    CHEMBL: '1421'
+    HMS-LINCS: '10020'
+    LINCS: LSM-1020
+    PUBCHEM: '3062316'
+  name: Dasatinib
+  search_term: '"Dasatinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10127'
+    LINCS: LSM-1127
+    PUBCHEM: '49830557'
+  name: Dovitinib
+  search_term: '"Dovitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91368
+    HMS-LINCS: '10069'
+    LINCS: LSM-1069
+    PUBCHEM: '176167'
+  name: Enzastaurin
+  search_term: '"Enzastaurin"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:114785
+    CHEMBL: '553'
+    HMS-LINCS: '10097'
+    LINCS: LSM-1097
+    PUBCHEM: '176870'
+  name: Erlotinib
+  search_term: '"Erlotinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91408
+    HMS-LINCS: '10141'
+    LINCS: LSM-1142
+    PUBCHEM: '16722836'
+  name: Fedratinib
+  search_term: '"Fedratinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10373'
+    PUBCHEM: '49831257'
+  name: Filgotinib
+  search_term: '"Filgotinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91418
+    HMS-LINCS: '10157'
+    LINCS: LSM-1158
+    PUBCHEM: '42642645'
+  name: Foretinib
+  search_term: '"Foretinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:93753
+    HMS-LINCS: '10234'
+    LINCS: LSM-4257
+    PUBCHEM: '66694608'
+  name: GDC-0980
+  search_term: '"GDC-0980"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:137236
+    HMS-LINCS: '10509'
+    PUBCHEM: '132519'
+  name: GM6001
+  search_term: '"GM6001"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91396
+    HMS-LINCS: '10128'
+    LINCS: LSM-1128
+    PUBCHEM: '16048642'
+  name: GSK 690693
+  search_term: '"GSK 690693"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10321'
+    LINCS: LSM-44939
+  name: GSK-J1
+  search_term: '"GSK-J1"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95077
+    HMS-LINCS: '10323'
+    LINCS: LSM-6328
+    PUBCHEM: '71729975'
+  name: GSK-J4
+  search_term: '"GSK-J4"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10172'
+    LINCS: LSM-1173
+    PUBCHEM: '71317162'
+  name: GSK1059615
+  search_term: '"GSK1059615"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91362
+    CHEMBL: '1090479'
+    HMS-LINCS: '10062'
+    LINCS: LSM-1062
+    PUBCHEM: '46885626'
+  name: GSK1070916
+  search_term: '"GSK1070916"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:93768
+    HMS-LINCS: '10255'
+    LINCS: LSM-4276
+    PUBCHEM: '25182616'
+  name: GSK1838705A
+  search_term: '"GSK1838705A"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10307'
+    LINCS: LSM-6319
+  name: Garcinol
+  search_term: '"Garcinol"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:49668
+    HMS-LINCS: '10098'
+    LINCS: LSM-1098
+    PUBCHEM: '123631'
+  name: Gefitinib
+  search_term: '"Gefitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:51913
+    CHEMBL: '302449'
+    HMS-LINCS: '10210'
+    LINCS: LSM-1211
+    PUBCHEM: '3501'
+  name: Go 6976
+  search_term: '"Go 6976"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:43561
+    HMS-LINCS: '10466'
+    PUBCHEM: '3540'
+  name: H-8
+  search_term: '"H-8"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10411'
+    PUBCHEM: '5702541'
+  name: H89
+  search_term: '"H89"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95092
+    HMS-LINCS: '10342'
+    LINCS: LSM-6345
+    PUBCHEM: '56655374'
+  name: HG-14-10-04
+  search_term: '"HG-14-10-04"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90943
+    HMS-LINCS: '10341'
+    LINCS: LSM-6344
+    PUBCHEM: '71496458'
+  name: HG-14-8-02
+  search_term: '"HG-14-8-02"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:94486
+    HMS-LINCS: '10016'
+    LINCS: LSM-5245
+    PUBCHEM: '25226117'
+  name: HG-5-88-01
+  search_term: '"HG-5-88-01"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10017'
+    LINCS: LSM-43248
+  name: HG-6-64-01
+  search_term: '"HG-6-64-01"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:133818
+    HMS-LINCS: '10340'
+    LINCS: LSM-6343
+    PUBCHEM: '78357808'
+  name: HG-9-91-01
+  search_term: '"HG-9-91-01"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91397
+    HMS-LINCS: '10129'
+    LINCS: LSM-1129
+    PUBCHEM: '16126651'
+  name: Ibrutinib
+  search_term: '"Ibrutinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95089
+    HMS-LINCS: '10338'
+    LINCS: LSM-6341
+    PUBCHEM: '24788740'
+  name: Ipatasertib
+  search_term: '"Ipatasertib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91457
+    CHEMBL: '197603'
+    HMS-LINCS: '10213'
+    LINCS: LSM-1214
+    PUBCHEM: '9549184'
+  name: KIN001-111
+  search_term: '"KIN001-111"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91459
+    CHEMBL: '373751'
+    HMS-LINCS: '10215'
+    LINCS: LSM-1216
+    PUBCHEM: '11626927'
+  name: KIN001-135
+  search_term: '"KIN001-135"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10192'
+    LINCS: LSM-42803
+    PUBCHEM: '67089852'
+  name: KW2449
+  search_term: '"KW2449"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:65329
+    HMS-LINCS: '10510'
+    PUBCHEM: '3973'
+  name: LY294002
+  search_term: '"LY294002"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:49603
+    CHEMBL: '554'
+    HMS-LINCS: '10051'
+    LINCS: LSM-1051
+    PUBCHEM: '208908'
+  name: Lapatinib
+  search_term: '"Lapatinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91471
+    HMS-LINCS: '10230'
+    LINCS: LSM-1231
+    PUBCHEM: '126565'
+  name: Lestaurtinib
+  search_term: '"Lestaurtinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91402
+    CHEMBL: '1091644'
+    HMS-LINCS: '10135'
+    LINCS: LSM-1135
+    PUBCHEM: '11640390'
+  name: Linsitinib
+  search_term: '"Linsitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91414
+    HMS-LINCS: '10152'
+    LINCS: LSM-1153
+    PUBCHEM: '24856436'
+  name: MK 1775
+  search_term: '"MK 1775"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:67271
+    HMS-LINCS: '10057'
+    LINCS: LSM-1057
+    PUBCHEM: '24964624'
+  name: MK2206
+  search_term: '"MK2206"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10469'
+    PUBCHEM: '108047'
+  name: ML-9
+  search_term: '"ML-9"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:124930
+    HMS-LINCS: '10364'
+    LINCS: LSM-36387
+    PUBCHEM: '44464263'
+  name: MRT67307
+  search_term: '"MRT67307"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:94525
+    HMS-LINCS: '10312'
+    LINCS: LSM-5344
+    PUBCHEM: '9865515'
+  name: Mocetinostat
+  search_term: '"Mocetinostat"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91407
+    HMS-LINCS: '10140'
+    LINCS: LSM-1141
+    PUBCHEM: '25062766'
+  name: Momelotinib
+  search_term: '"Momelotinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91361
+    CHEMBL: '188678'
+    HMS-LINCS: '10061'
+    LINCS: LSM-1061
+    PUBCHEM: '11327430'
+  name: NU7441
+  search_term: '"NU7441"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10349'
+    LINCS: LSM-6710
+  name: NVP-BGT226
+  search_term: '"NVP-BGT226"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91452
+    HMS-LINCS: '10207'
+    LINCS: LSM-1208
+    PUBCHEM: '9934347'
+  name: NVP-TAE226
+  search_term: '"NVP-TAE226"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91338
+    CHEMBL: '509032'
+    HMS-LINCS: '10024'
+    LINCS: LSM-1024
+    PUBCHEM: '16038120'
+  name: NVP-TAE684
+  search_term: '"NVP-TAE684"'
+  type: drug
+- db_refs:
+    CHEMBL: '180022'
+    HMS-LINCS: '10018'
+    LINCS: LSM-42778
+    PUBCHEM: '53398697'
+  name: Neratinib
+  search_term: '"Neratinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10151'
+    LINCS: LSM-1152
+    PUBCHEM: '56965894'
+  name: Nintedanib
+  search_term: '"Nintedanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95096
+    HMS-LINCS: '10268'
+    LINCS: LSM-6351
+    PUBCHEM: '11433190'
+  name: Nutlin 3a
+  search_term: '"Nutlin 3a"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95093
+    HMS-LINCS: '10146'
+    LINCS: LSM-1147
+    PUBCHEM: '25167777'
+  name: Omipalisib
+  search_term: '"Omipalisib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10383'
+    PUBCHEM: '71731823'
+  name: PF-06463922
+  search_term: '"PF-06463922"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91370
+    HMS-LINCS: '10072'
+    LINCS: LSM-1072
+    PUBCHEM: '11713159'
+  name: PF562271
+  search_term: '"PF562271"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95058
+    HMS-LINCS: '10285'
+    LINCS: LSM-6304
+    PUBCHEM: '11715767'
+  name: PHA-767491
+  search_term: '"PHA-767491"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90524
+    CHEMBL: '538346'
+    HMS-LINCS: '10126'
+    LINCS: LSM-1126
+    PUBCHEM: '9884685'
+  name: PI103
+  search_term: '"PI103"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:71958
+    HMS-LINCS: '10173'
+    LINCS: LSM-1174
+    PUBCHEM: '49867926'
+  name: PI3K-IN-1
+  search_term: '"PI3K-IN-1"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10190'
+    LINCS: LSM-1191
+    PUBCHEM: '6852167'
+  name: PIK-93
+  search_term: '"PIK-93"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91464
+    CHEMBL: '338448'
+    HMS-LINCS: '10220'
+    LINCS: LSM-1221
+    PUBCHEM: '16760627'
+  name: PKC412
+  search_term: '"PKC412"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90295
+    HMS-LINCS: '10049'
+    LINCS: LSM-1049
+    PUBCHEM: '24180719'
+  name: PLX-4720
+  search_term: '"PLX-4720"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10405'
+    PUBCHEM: '1400'
+  name: PP1
+  search_term: '"PP1"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:85993
+    CHEMBL: '189963'
+    HMS-LINCS: '10071'
+    LINCS: LSM-1071
+    PUBCHEM: '5330286'
+  name: Palbociclib
+  search_term: '"Palbociclib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:71219
+    HMS-LINCS: '10114'
+    LINCS: LSM-1114
+    PUBCHEM: '10113978'
+  name: Pazopanib
+  search_term: '"Pazopanib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10159'
+    LINCS: LSM-1160
+    PUBCHEM: '216467'
+  name: Pelitinib
+  search_term: '"Pelitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:65326
+    CHEMBL: '521851'
+    HMS-LINCS: '10047'
+    LINCS: LSM-1047
+    PUBCHEM: '17755052'
+  name: Pictilisib
+  search_term: '"Pictilisib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10397'
+    PUBCHEM: '25127713'
+  name: Poziotinib
+  search_term: '"Poziotinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91348
+    HMS-LINCS: '10040'
+    LINCS: LSM-1040
+    PUBCHEM: '11213558'
+  name: R406
+  search_term: '"R406"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:38912
+    HMS-LINCS: '10407'
+    PUBCHEM: '5083'
+  name: RO 31-8220
+  search_term: '"RO 31-8220"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:45713
+    HMS-LINCS: '10318'
+    LINCS: LSM-42917
+    PUBCHEM: '445154'
+  name: Resveratrol
+  search_term: '"Resveratrol"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10184'
+    LINCS: LSM-44954
+  name: Rigosertib
+  search_term: '"Rigosertib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10517'
+    PUBCHEM: '127757'
+  name: Ro 32-0432
+  search_term: '"Ro 32-0432"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:66919
+    HMS-LINCS: '10138'
+    LINCS: LSM-1139
+    PUBCHEM: '25126798'
+  name: Ruxolitinib
+  search_term: '"Ruxolitinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10385'
+    PUBCHEM: '50878566'
+  name: S-Ruxolitinib
+  search_term: '"S-Ruxolitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91399
+    HMS-LINCS: '10132'
+    LINCS: LSM-1132
+    PUBCHEM: '3025986'
+  name: SNS-032
+  search_term: '"SNS-032"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90695
+    HMS-LINCS: '10162'
+    LINCS: LSM-1163
+    PUBCHEM: '8515'
+  name: SP600125
+  search_term: '"SP600125"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91346
+    CHEMBL: '258844'
+    HMS-LINCS: '10035'
+    LINCS: LSM-1035
+    PUBCHEM: '10196499'
+  name: Sigma A6730
+  search_term: '"Sigma A6730"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90531
+    HMS-LINCS: '10408'
+    PUBCHEM: '10296883'
+  name: Sotrastaurin
+  search_term: '"Sotrastaurin"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:15738
+    CHEMBL: '388978'
+    HMS-LINCS: '10103'
+    LINCS: LSM-1103
+    PUBCHEM: '44259'
+  name: Staurosporine
+  search_term: '"Staurosporine"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10454'
+    PUBCHEM: '3815'
+  name: Staurosporine aglycone
+  search_term: '"Staurosporine aglycone"'
+  type: drug
+- db_refs:
+    CHEMBL: '535'
+    HMS-LINCS: '10175'
+    LINCS: LSM-42800
+    PUBCHEM: '3086686'
+  name: Sunitinib
+  search_term: '"Sunitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91360
+    HMS-LINCS: '10060'
+    LINCS: LSM-1060
+    PUBCHEM: '9952773'
+  name: TAK-715
+  search_term: '"TAK-715"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91403
+    HMS-LINCS: '10136'
+    LINCS: LSM-1136
+    PUBCHEM: '9903786'
+  name: TPCA-1
+  search_term: '"TPCA-1"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10445'
+    LINCS: LSM-45140
+    PUBCHEM: '51001932'
+  name: Taselisib
+  search_term: '"Taselisib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:71200
+    HMS-LINCS: '10226'
+    LINCS: LSM-1227
+    PUBCHEM: '9926791'
+  name: Tofacitinib
+  search_term: '"Tofacitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:84327
+    HMS-LINCS: '10079'
+    LINCS: LSM-1079
+    PUBCHEM: '49836027'
+  name: Torin1
+  search_term: '"Torin1"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90682
+    HMS-LINCS: '10080'
+    LINCS: LSM-1080
+    PUBCHEM: '51358113'
+  name: Torin2
+  search_term: '"Torin2"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91336
+    CHEMBL: '572878'
+    HMS-LINCS: '10021'
+    LINCS: LSM-1021
+    PUBCHEM: '5494449'
+  name: Tozasertib
+  search_term: '"Tozasertib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10279'
+    LINCS: LSM-43005
+  name: Trichostatin A
+  search_term: '"Trichostatin A"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:65310
+    HMS-LINCS: '10280'
+    LINCS: LSM-3810
+    PUBCHEM: '65399'
+  name: Triciribine
+  search_term: '"Triciribine"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:124916
+    HMS-LINCS: '10361'
+    LINCS: LSM-36358
+    PUBCHEM: '51000408'
+  name: VE-821
+  search_term: '"VE-821"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:49960
+    HMS-LINCS: '10198'
+    LINCS: LSM-1199
+    PUBCHEM: '3081361'
+  name: Vandetanib
+  search_term: '"Vandetanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:45716
+    HMS-LINCS: '10282'
+    LINCS: LSM-3828
+    PUBCHEM: '5311'
+  name: Vorinostat
+  search_term: '"Vorinostat"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10038'
+    LINCS: LSM-5613
+  name: WH-4-023
+  search_term: '"WH-4-023"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10039'
+    LINCS: LSM-44937
+  name: WH-4-025
+  search_term: '"WH-4-025"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10082'
+    LINCS: LSM-5545
+  name: WZ-4-145
+  search_term: '"WZ-4-145"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:61400
+    HMS-LINCS: '10085'
+    LINCS: LSM-1085
+    PUBCHEM: '44607530'
+  name: WZ4002
+  search_term: '"WZ4002"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10388'
+    PUBCHEM: '57990869'
+  name: XL019
+  search_term: '"XL019"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91411
+    HMS-LINCS: '10148'
+    LINCS: LSM-1149
+    PUBCHEM: '52914932'
+  name: XL147
+  search_term: '"XL147"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:124914
+    HMS-LINCS: '10357'
+    LINCS: LSM-36356
+    PUBCHEM: '16123056'
+  name: XL765
+  search_term: '"XL765"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:78413
+    HMS-LINCS: '10086'
+    LINCS: LSM-1086
+    PUBCHEM: '46843906'
+  name: XMD11-50
+  search_term: '"XMD11-50"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91431
+    HMS-LINCS: '10176'
+    LINCS: LSM-1177
+    PUBCHEM: '5711'
+  name: Y-27632
+  search_term: '"Y-27632"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91376
+    HMS-LINCS: '10096'
+    LINCS: LSM-1096
+    PUBCHEM: '9914412'
+  name: ZM-447439
+  search_term: '"ZM-447439"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90545
+    HMS-LINCS: '10053'
+    LINCS: LSM-1053
+    PUBCHEM: '11647372'
+  name: ZSTK474
+  search_term: '"ZSTK474"'
+  type: drug

--- a/models/luad/config.yaml
+++ b/models/luad/config.yaml
@@ -1,283 +1,1634 @@
 ndex:
   network: b56642b3-f6a3-11e8-aaa6-0ac135e8bacf
 search_terms:
-- "ADGRL3"
-- "AMELX"
-- "ASTN1"
-- "BIRC8"
-- "BLID"
-- "BRAF"
-- "BRINP3"
-- "CACNG3"
-- "CALN1"
-- "CD1A"
-- "CD1C"
-- "CD1E"
-- "CD5L"
-- "CDH10"
-- "CDH12"
-- "CDH18"
-- "CDH7"
-- "CDH9"
-- "CDKN2A"
-- "CETN1"
-- "CLEC3A"
-- "COX7B2"
-- "CPXCR1"
-- "CRISP3"
-- "CTNNA2"
-- "CUX1"
-- "DCAF12L1"
-- "DCAF12L2"
-- "DCAF4L2"
-- "DCDC1"
-- "DCSTAMP"
-- "DEFB110"
-- "DEFB115"
-- "DEFB119"
-- "DKK2"
-- "DRD2"
-- "DRD3"
-- "DUSP22"
-- "DUSP26"
-- "EGFR"
-- "EPHA3"
-- "EPHA5"
-- "FAM47B"
-- "FAM71B"
-- "FBXL7"
-- "FCER1A"
-- "FERD3L"
-- "FTMT"
-- "GABRA2"
-- "GABRA5"
-- "GABRG2"
-- "GABRG3"
-- "GALNT13"
-- "GBA3"
-- "GLYAT"
-- "GPX5"
-- "GRM8"
-- "GYPC"
-- "HAMP"
-- "HAPLN1"
-- "HBB"
-- "HBD"
-- "HCN1"
-- "HGF"
-- "HMGA2"
-- "HOXA5"
-- "HTR5A"
-- "INHBA"
-- "INSL5"
-- "KCNJ12"
-- "KCNJ3"
-- "KCNK2"
-- "KEAP1"
-- "KIF2B"
-- "KLHL1"
-- "KRAS"
-- "KRTAP13-1"
-- "KRTAP13-3"
-- "KRTAP15-1"
-- "KRTAP19-2"
-- "KRTAP19-5"
-- "KRTAP19-6"
-- "KRTAP19-7"
-- "KRTAP20-2"
-- "KRTAP21-1"
-- "KRTAP23-1"
-- "KRTAP6-1"
-- "KRTAP6-3"
-- "KRTAP8-1"
-- "LAIR2"
-- "LCE1C"
-- "LCE1F"
-- "LCE3A"
-- "LCE3E"
-- "LHX8"
-- "LLCFC1"
-- "LRFN5"
-- "LRRC4C"
-- "LRRTM4"
-- "MAGEA12"
-- "MAGEA4"
-- "MNDA"
-- "MS4A4A"
-- "MUC7"
-- "NELL1"
-- "NLRP3"
-- "NMUR2"
-- "NRXN1"
-- "NRXN3"
-- "NTM"
-- "NTRK3"
-- "OCA2"
-- "OR2B11"
-- "OR2L2"
-- "OR2M4"
-- "OR2T1"
-- "OR2T12"
-- "OR2T34"
-- "OR2W3"
-- "OR4K2"
-- "OR4L1"
-- "OR4P4"
-- "OR51F2"
-- "OR5D13"
-- "OR5J2"
-- "OR5M11"
-- "OR5T3"
-- "OR5W2"
-- "OR8H3"
-- "PABPC5"
-- "PAK5"
-- "PCDH15"
-- "PDHA2"
-- "PLPPR4"
-- "POTEG"
-- "PRDM9"
-- "PRSS1"
-- "PSG6"
-- "RBFOX1"
-- "REG1A"
-- "REG1B"
-- "REG3A"
-- "REG3G"
-- "RGS4"
-- "RIPPLY2"
-- "RIT1"
-- "RIT2"
-- "RPL10L"
-- "RTL3"
-- "SERPINB4"
-- "SLC39A12"
-- "SLC8A1"
-- "SLITRK1"
-- "SLITRK2"
-- "SNAP25"
-- "SNTG1"
-- "SNURF"
-- "SPATA19"
-- "SPATA8"
-- "SPRR2B"
-- "SPRR2D"
-- "SPRR2G"
-- "SPRR3"
-- "SPTA1"
-- "ST6GAL2"
-- "ST6GALNAC3"
-- "STATH"
-- "STK11"
-- "STK19"
-- "SYNDIG1"
-- "TAC1"
-- "TAS2R1"
-- "TBX5"
-- "TCF21"
-- "TGIF2LX"
-- "TLR4"
-- "TNR"
-- "TP53"
-- "TPK1"
-- "TPTE"
-- "TRIM48"
-- "TRIM51"
-- "TRIM58"
-- "TSLP"
-- "TYR"
-- "U2AF1"
-- "UMOD"
-- "VEGFC"
-- "VGLL3"
-- "VSTM2A"
-- "XCL2"
-- "ZIC1"
-- "ZIC4"
-- "ZNF536"
-- "ZNF804A"
-- "ZP4"
-- "ZSCAN1"
-- "AC220"
-- "AG1478"
-- "ALK-IN-1"
-- "ALW-II-38-3"
-- "ALW-II-49-7"
-- "AST1306"
-- "AZ-628"
-- "AZD4547"
-- "AZD7762"
-- "Afatinib"
-- "Alisertib"
-- "BMS 777607"
-- "BMS-536924"
-- "Bosutinib"
-- "CG-930"
-- "CP724714"
-- "Canertinib"
-- "Cediranib"
-- "Ceritinib"
-- "Crizotinib"
-- "Dabrafenib"
-- "Dacomitinib"
-- "Dasatinib"
-- "Doramapimod"
-- "Dovitinib"
-- "Erlotinib"
-- "Fedratinib"
-- "Foretinib"
-- "GDC-0879"
-- "GNF-5837"
-- "GSK 690693"
-- "GW2580"
-- "Gefitinib"
-- "Go 6976"
-- "HG-14-10-04"
-- "HG-14-8-02"
-- "HG-5-88-01"
-- "IKK16"
-- "Ibrutinib"
-- "KIN001-021"
-- "KIN001-111"
-- "KW2449"
-- "L-779450"
-- "Lapatinib"
-- "Lestaurtinib"
-- "Linifanib"
-- "Motesanib"
-- "NSC-87877"
-- "NVP-TAE226"
-- "NVP-TAE684"
-- "Neratinib"
-- "Nilotinib"
-- "Nintedanib"
-- "Nutlin 3a"
-- "PF-06463922"
-- "PF-3758309"
-- "PF562271"
-- "PHA-665752"
-- "PKC412"
-- "PLX-4720"
-- "PP1"
-- "PRT062607"
-- "Pazopanib"
-- "Pelitinib"
-- "Ponatinib"
-- "Poziotinib"
-- "R406"
-- "RAF 265"
-- "Regorafenib"
-- "Ruxolitinib"
-- "SB 203580"
-- "SB590885"
-- "Sorafenib"
-- "Staurosporine"
-- "Sunitinib"
-- "TAK-632"
-- "TAK-715"
-- "Tozasertib"
-- "Vandetanib"
-- "Vemurafenib"
-- "WH-4-025"
-- "WZ-4-145"
-- "WZ4002"
+- db_refs:
+    HGNC: '20974'
+  name: ADGRL3
+  search_term: '"ADGRL3"'
+  type: gene
+- db_refs:
+    HGNC: '461'
+  name: AMELX
+  search_term: '"AMELX"'
+  type: gene
+- db_refs:
+    HGNC: '773'
+  name: ASTN1
+  search_term: '"ASTN1"'
+  type: gene
+- db_refs:
+    HGNC: '14878'
+  name: BIRC8
+  search_term: '"BIRC8"'
+  type: gene
+- db_refs:
+    HGNC: '33495'
+  name: BLID
+  search_term: '"BLID"'
+  type: gene
+- db_refs:
+    HGNC: '1097'
+  name: BRAF
+  search_term: '"BRAF"'
+  type: gene
+- db_refs:
+    HGNC: '22393'
+  name: BRINP3
+  search_term: '"BRINP3"'
+  type: gene
+- db_refs:
+    HGNC: '1407'
+  name: CACNG3
+  search_term: '"CACNG3"'
+  type: gene
+- db_refs:
+    HGNC: '13248'
+  name: CALN1
+  search_term: '"CALN1"'
+  type: gene
+- db_refs:
+    HGNC: '1634'
+  name: CD1A
+  search_term: '"CD1A"'
+  type: gene
+- db_refs:
+    HGNC: '1636'
+  name: CD1C
+  search_term: '"CD1C"'
+  type: gene
+- db_refs:
+    HGNC: '1638'
+  name: CD1E
+  search_term: '"CD1E"'
+  type: gene
+- db_refs:
+    HGNC: '1690'
+  name: CD5L
+  search_term: '"CD5L"'
+  type: gene
+- db_refs:
+    HGNC: '1749'
+  name: CDH10
+  search_term: '"CDH10"'
+  type: gene
+- db_refs:
+    HGNC: '1751'
+  name: CDH12
+  search_term: '"CDH12"'
+  type: gene
+- db_refs:
+    HGNC: '1757'
+  name: CDH18
+  search_term: '"CDH18"'
+  type: gene
+- db_refs:
+    HGNC: '1766'
+  name: CDH7
+  search_term: '"CDH7"'
+  type: gene
+- db_refs:
+    HGNC: '1768'
+  name: CDH9
+  search_term: '"CDH9"'
+  type: gene
+- db_refs:
+    HGNC: '1787'
+  name: CDKN2A
+  search_term: '"CDKN2A"'
+  type: gene
+- db_refs:
+    HGNC: '1866'
+  name: CETN1
+  search_term: '"CETN1"'
+  type: gene
+- db_refs:
+    HGNC: '2052'
+  name: CLEC3A
+  search_term: '"CLEC3A"'
+  type: gene
+- db_refs:
+    HGNC: '24381'
+  name: COX7B2
+  search_term: '"COX7B2"'
+  type: gene
+- db_refs:
+    HGNC: '2332'
+  name: CPXCR1
+  search_term: '"CPXCR1"'
+  type: gene
+- db_refs:
+    HGNC: '16904'
+  name: CRISP3
+  search_term: '"CRISP3"'
+  type: gene
+- db_refs:
+    HGNC: '2510'
+  name: CTNNA2
+  search_term: '"CTNNA2"'
+  type: gene
+- db_refs:
+    HGNC: '2557'
+  name: CUX1
+  search_term: '"CUX1"'
+  type: gene
+- db_refs:
+    HGNC: '29395'
+  name: DCAF12L1
+  search_term: '"DCAF12L1"'
+  type: gene
+- db_refs:
+    HGNC: '32950'
+  name: DCAF12L2
+  search_term: '"DCAF12L2"'
+  type: gene
+- db_refs:
+    HGNC: '26657'
+  name: DCAF4L2
+  search_term: '"DCAF4L2"'
+  type: gene
+- db_refs:
+    HGNC: '20625'
+  name: DCDC1
+  search_term: '"DCDC1"'
+  type: gene
+- db_refs:
+    HGNC: '18549'
+  name: DCSTAMP
+  search_term: '"DCSTAMP"'
+  type: gene
+- db_refs:
+    HGNC: '18091'
+  name: DEFB110
+  search_term: '"DEFB110"'
+  type: gene
+- db_refs:
+    HGNC: '18096'
+  name: DEFB115
+  search_term: '"DEFB115"'
+  type: gene
+- db_refs:
+    HGNC: '18099'
+  name: DEFB119
+  search_term: '"DEFB119"'
+  type: gene
+- db_refs:
+    HGNC: '2892'
+  name: DKK2
+  search_term: '"DKK2"'
+  type: gene
+- db_refs:
+    HGNC: '3023'
+  name: DRD2
+  search_term: '"DRD2"'
+  type: gene
+- db_refs:
+    HGNC: '3024'
+  name: DRD3
+  search_term: '"DRD3"'
+  type: gene
+- db_refs:
+    HGNC: '16077'
+  name: DUSP22
+  search_term: '"DUSP22"'
+  type: gene
+- db_refs:
+    HGNC: '28161'
+  name: DUSP26
+  search_term: '"DUSP26"'
+  type: gene
+- db_refs:
+    HGNC: '3236'
+  name: EGFR
+  search_term: '"EGFR"'
+  type: gene
+- db_refs:
+    HGNC: '3387'
+  name: EPHA3
+  search_term: '"EPHA3"'
+  type: gene
+- db_refs:
+    HGNC: '3389'
+  name: EPHA5
+  search_term: '"EPHA5"'
+  type: gene
+- db_refs:
+    HGNC: '26659'
+  name: FAM47B
+  search_term: '"FAM47B"'
+  type: gene
+- db_refs:
+    HGNC: '28397'
+  name: FAM71B
+  search_term: '"FAM71B"'
+  type: gene
+- db_refs:
+    HGNC: '13604'
+  name: FBXL7
+  search_term: '"FBXL7"'
+  type: gene
+- db_refs:
+    HGNC: '3609'
+  name: FCER1A
+  search_term: '"FCER1A"'
+  type: gene
+- db_refs:
+    HGNC: '16660'
+  name: FERD3L
+  search_term: '"FERD3L"'
+  type: gene
+- db_refs:
+    HGNC: '17345'
+  name: FTMT
+  search_term: '"FTMT"'
+  type: gene
+- db_refs:
+    HGNC: '4076'
+  name: GABRA2
+  search_term: '"GABRA2"'
+  type: gene
+- db_refs:
+    HGNC: '4079'
+  name: GABRA5
+  search_term: '"GABRA5"'
+  type: gene
+- db_refs:
+    HGNC: '4087'
+  name: GABRG2
+  search_term: '"GABRG2"'
+  type: gene
+- db_refs:
+    HGNC: '4088'
+  name: GABRG3
+  search_term: '"GABRG3"'
+  type: gene
+- db_refs:
+    HGNC: '23242'
+  name: GALNT13
+  search_term: '"GALNT13"'
+  type: gene
+- db_refs:
+    HGNC: '19069'
+  name: GBA3
+  search_term: '"GBA3"'
+  type: gene
+- db_refs:
+    HGNC: '13734'
+  name: GLYAT
+  search_term: '"GLYAT"'
+  type: gene
+- db_refs:
+    HGNC: '4557'
+  name: GPX5
+  search_term: '"GPX5"'
+  type: gene
+- db_refs:
+    HGNC: '4600'
+  name: GRM8
+  search_term: '"GRM8"'
+  type: gene
+- db_refs:
+    HGNC: '4704'
+  name: GYPC
+  search_term: '"GYPC"'
+  type: gene
+- db_refs:
+    HGNC: '15598'
+  name: HAMP
+  search_term: '"HAMP"'
+  type: gene
+- db_refs:
+    HGNC: '2380'
+  name: HAPLN1
+  search_term: '"HAPLN1"'
+  type: gene
+- db_refs:
+    HGNC: '4827'
+  name: HBB
+  search_term: '"HBB"'
+  type: gene
+- db_refs:
+    HGNC: '4829'
+  name: HBD
+  search_term: '"HBD"'
+  type: gene
+- db_refs:
+    HGNC: '4845'
+  name: HCN1
+  search_term: '"HCN1"'
+  type: gene
+- db_refs:
+    HGNC: '4893'
+  name: HGF
+  search_term: '"HGF"'
+  type: gene
+- db_refs:
+    HGNC: '5009'
+  name: HMGA2
+  search_term: '"HMGA2"'
+  type: gene
+- db_refs:
+    HGNC: '5106'
+  name: HOXA5
+  search_term: '"HOXA5"'
+  type: gene
+- db_refs:
+    HGNC: '5300'
+  name: HTR5A
+  search_term: '"HTR5A"'
+  type: gene
+- db_refs:
+    HGNC: '6066'
+  name: INHBA
+  search_term: '"INHBA"'
+  type: gene
+- db_refs:
+    HGNC: '6088'
+  name: INSL5
+  search_term: '"INSL5"'
+  type: gene
+- db_refs:
+    HGNC: '6258'
+  name: KCNJ12
+  search_term: '"KCNJ12"'
+  type: gene
+- db_refs:
+    HGNC: '6264'
+  name: KCNJ3
+  search_term: '"KCNJ3"'
+  type: gene
+- db_refs:
+    HGNC: '6277'
+  name: KCNK2
+  search_term: '"KCNK2"'
+  type: gene
+- db_refs:
+    HGNC: '23177'
+  name: KEAP1
+  search_term: '"KEAP1"'
+  type: gene
+- db_refs:
+    HGNC: '29443'
+  name: KIF2B
+  search_term: '"KIF2B"'
+  type: gene
+- db_refs:
+    HGNC: '6352'
+  name: KLHL1
+  search_term: '"KLHL1"'
+  type: gene
+- db_refs:
+    HGNC: '6407'
+  name: KRAS
+  search_term: '"KRAS"'
+  type: gene
+- db_refs:
+    HGNC: '18924'
+  name: KRTAP13-1
+  search_term: '"KRTAP13-1"'
+  type: gene
+- db_refs:
+    HGNC: '18925'
+  name: KRTAP13-3
+  search_term: '"KRTAP13-3"'
+  type: gene
+- db_refs:
+    HGNC: '18927'
+  name: KRTAP15-1
+  search_term: '"KRTAP15-1"'
+  type: gene
+- db_refs:
+    HGNC: '18937'
+  name: KRTAP19-2
+  search_term: '"KRTAP19-2"'
+  type: gene
+- db_refs:
+    HGNC: '18940'
+  name: KRTAP19-5
+  search_term: '"KRTAP19-5"'
+  type: gene
+- db_refs:
+    HGNC: '18941'
+  name: KRTAP19-6
+  search_term: '"KRTAP19-6"'
+  type: gene
+- db_refs:
+    HGNC: '18942'
+  name: KRTAP19-7
+  search_term: '"KRTAP19-7"'
+  type: gene
+- db_refs:
+    HGNC: '18944'
+  name: KRTAP20-2
+  search_term: '"KRTAP20-2"'
+  type: gene
+- db_refs:
+    HGNC: '18945'
+  name: KRTAP21-1
+  search_term: '"KRTAP21-1"'
+  type: gene
+- db_refs:
+    HGNC: '18928'
+  name: KRTAP23-1
+  search_term: '"KRTAP23-1"'
+  type: gene
+- db_refs:
+    HGNC: '18931'
+  name: KRTAP6-1
+  search_term: '"KRTAP6-1"'
+  type: gene
+- db_refs:
+    HGNC: '18933'
+  name: KRTAP6-3
+  search_term: '"KRTAP6-3"'
+  type: gene
+- db_refs:
+    HGNC: '18935'
+  name: KRTAP8-1
+  search_term: '"KRTAP8-1"'
+  type: gene
+- db_refs:
+    HGNC: '6478'
+  name: LAIR2
+  search_term: '"LAIR2"'
+  type: gene
+- db_refs:
+    HGNC: '29464'
+  name: LCE1C
+  search_term: '"LCE1C"'
+  type: gene
+- db_refs:
+    HGNC: '29467'
+  name: LCE1F
+  search_term: '"LCE1F"'
+  type: gene
+- db_refs:
+    HGNC: '29461'
+  name: LCE3A
+  search_term: '"LCE3A"'
+  type: gene
+- db_refs:
+    HGNC: '29463'
+  name: LCE3E
+  search_term: '"LCE3E"'
+  type: gene
+- db_refs:
+    HGNC: '28838'
+  name: LHX8
+  search_term: '"LHX8"'
+  type: gene
+- db_refs:
+    HGNC: '21750'
+  name: LLCFC1
+  search_term: '"LLCFC1"'
+  type: gene
+- db_refs:
+    HGNC: '20360'
+  name: LRFN5
+  search_term: '"LRFN5"'
+  type: gene
+- db_refs:
+    HGNC: '29317'
+  name: LRRC4C
+  search_term: '"LRRC4C"'
+  type: gene
+- db_refs:
+    HGNC: '19411'
+  name: LRRTM4
+  search_term: '"LRRTM4"'
+  type: gene
+- db_refs:
+    HGNC: '6799'
+  name: MAGEA12
+  search_term: '"MAGEA12"'
+  type: gene
+- db_refs:
+    HGNC: '6802'
+  name: MAGEA4
+  search_term: '"MAGEA4"'
+  type: gene
+- db_refs:
+    HGNC: '7183'
+  name: MNDA
+  search_term: '"MNDA"'
+  type: gene
+- db_refs:
+    HGNC: '13371'
+  name: MS4A4A
+  search_term: '"MS4A4A"'
+  type: gene
+- db_refs:
+    HGNC: '7518'
+  name: MUC7
+  search_term: '"MUC7"'
+  type: gene
+- db_refs:
+    HGNC: '7750'
+  name: NELL1
+  search_term: '"NELL1"'
+  type: gene
+- db_refs:
+    HGNC: '16400'
+  name: NLRP3
+  search_term: '"NLRP3"'
+  type: gene
+- db_refs:
+    HGNC: '16454'
+  name: NMUR2
+  search_term: '"NMUR2"'
+  type: gene
+- db_refs:
+    HGNC: '8008'
+  name: NRXN1
+  search_term: '"NRXN1"'
+  type: gene
+- db_refs:
+    HGNC: '8010'
+  name: NRXN3
+  search_term: '"NRXN3"'
+  type: gene
+- db_refs:
+    HGNC: '17941'
+  name: NTM
+  search_term: '"NTM"'
+  type: gene
+- db_refs:
+    HGNC: '8033'
+  name: NTRK3
+  search_term: '"NTRK3"'
+  type: gene
+- db_refs:
+    HGNC: '8101'
+  name: OCA2
+  search_term: '"OCA2"'
+  type: gene
+- db_refs:
+    HGNC: '31249'
+  name: OR2B11
+  search_term: '"OR2B11"'
+  type: gene
+- db_refs:
+    HGNC: '8266'
+  name: OR2L2
+  search_term: '"OR2L2"'
+  type: gene
+- db_refs:
+    HGNC: '8270'
+  name: OR2M4
+  search_term: '"OR2M4"'
+  type: gene
+- db_refs:
+    HGNC: '8277'
+  name: OR2T1
+  search_term: '"OR2T1"'
+  type: gene
+- db_refs:
+    HGNC: '19592'
+  name: OR2T12
+  search_term: '"OR2T12"'
+  type: gene
+- db_refs:
+    HGNC: '31256'
+  name: OR2T34
+  search_term: '"OR2T34"'
+  type: gene
+- db_refs:
+    HGNC: '15021'
+  name: OR2W3
+  search_term: '"OR2W3"'
+  type: gene
+- db_refs:
+    HGNC: '14728'
+  name: OR4K2
+  search_term: '"OR4K2"'
+  type: gene
+- db_refs:
+    HGNC: '15356'
+  name: OR4L1
+  search_term: '"OR4L1"'
+  type: gene
+- db_refs:
+    HGNC: '15180'
+  name: OR4P4
+  search_term: '"OR4P4"'
+  type: gene
+- db_refs:
+    HGNC: '15197'
+  name: OR51F2
+  search_term: '"OR51F2"'
+  type: gene
+- db_refs:
+    HGNC: '15280'
+  name: OR5D13
+  search_term: '"OR5D13"'
+  type: gene
+- db_refs:
+    HGNC: '19612'
+  name: OR5J2
+  search_term: '"OR5J2"'
+  type: gene
+- db_refs:
+    HGNC: '15291'
+  name: OR5M11
+  search_term: '"OR5M11"'
+  type: gene
+- db_refs:
+    HGNC: '15297'
+  name: OR5T3
+  search_term: '"OR5T3"'
+  type: gene
+- db_refs:
+    HGNC: '15299'
+  name: OR5W2
+  search_term: '"OR5W2"'
+  type: gene
+- db_refs:
+    HGNC: '15309'
+  name: OR8H3
+  search_term: '"OR8H3"'
+  type: gene
+- db_refs:
+    HGNC: '13629'
+  name: PABPC5
+  search_term: '"PABPC5"'
+  type: gene
+- db_refs:
+    HGNC: '15916'
+  name: PAK5
+  search_term: '"PAK5"'
+  type: gene
+- db_refs:
+    HGNC: '14674'
+  name: PCDH15
+  search_term: '"PCDH15"'
+  type: gene
+- db_refs:
+    HGNC: '8807'
+  name: PDHA2
+  search_term: '"PDHA2"'
+  type: gene
+- db_refs:
+    HGNC: '23496'
+  name: PLPPR4
+  search_term: '"PLPPR4"'
+  type: gene
+- db_refs:
+    HGNC: '33896'
+  name: POTEG
+  search_term: '"POTEG"'
+  type: gene
+- db_refs:
+    HGNC: '13994'
+  name: PRDM9
+  search_term: '"PRDM9"'
+  type: gene
+- db_refs:
+    HGNC: '9475'
+  name: PRSS1
+  search_term: '"PRSS1"'
+  type: gene
+- db_refs:
+    HGNC: '9523'
+  name: PSG6
+  search_term: '"PSG6"'
+  type: gene
+- db_refs:
+    HGNC: '18222'
+  name: RBFOX1
+  search_term: '"RBFOX1"'
+  type: gene
+- db_refs:
+    HGNC: '9951'
+  name: REG1A
+  search_term: '"REG1A"'
+  type: gene
+- db_refs:
+    HGNC: '9952'
+  name: REG1B
+  search_term: '"REG1B"'
+  type: gene
+- db_refs:
+    HGNC: '8601'
+  name: REG3A
+  search_term: '"REG3A"'
+  type: gene
+- db_refs:
+    HGNC: '29595'
+  name: REG3G
+  search_term: '"REG3G"'
+  type: gene
+- db_refs:
+    HGNC: '10000'
+  name: RGS4
+  search_term: '"RGS4"'
+  type: gene
+- db_refs:
+    HGNC: '21390'
+  name: RIPPLY2
+  search_term: '"RIPPLY2"'
+  type: gene
+- db_refs:
+    HGNC: '10023'
+  name: RIT1
+  search_term: '"RIT1"'
+  type: gene
+- db_refs:
+    HGNC: '10017'
+  name: RIT2
+  search_term: '"RIT2"'
+  type: gene
+- db_refs:
+    HGNC: '17976'
+  name: RPL10L
+  search_term: '"RPL10L"'
+  type: gene
+- db_refs:
+    HGNC: '22997'
+  name: RTL3
+  search_term: '"RTL3"'
+  type: gene
+- db_refs:
+    HGNC: '10570'
+  name: SERPINB4
+  search_term: '"SERPINB4"'
+  type: gene
+- db_refs:
+    HGNC: '20860'
+  name: SLC39A12
+  search_term: '"SLC39A12"'
+  type: gene
+- db_refs:
+    HGNC: '11068'
+  name: SLC8A1
+  search_term: '"SLC8A1"'
+  type: gene
+- db_refs:
+    HGNC: '20297'
+  name: SLITRK1
+  search_term: '"SLITRK1"'
+  type: gene
+- db_refs:
+    HGNC: '13449'
+  name: SLITRK2
+  search_term: '"SLITRK2"'
+  type: gene
+- db_refs:
+    HGNC: '11132'
+  name: SNAP25
+  search_term: '"SNAP25"'
+  type: gene
+- db_refs:
+    HGNC: '13740'
+  name: SNTG1
+  search_term: '"SNTG1"'
+  type: gene
+- db_refs:
+    HGNC: '11171'
+  name: SNURF
+  search_term: '"SNURF"'
+  type: gene
+- db_refs:
+    HGNC: '30614'
+  name: SPATA19
+  search_term: '"SPATA19"'
+  type: gene
+- db_refs:
+    HGNC: '28676'
+  name: SPATA8
+  search_term: '"SPATA8"'
+  type: gene
+- db_refs:
+    HGNC: '11262'
+  name: SPRR2B
+  search_term: '"SPRR2B"'
+  type: gene
+- db_refs:
+    HGNC: '11264'
+  name: SPRR2D
+  search_term: '"SPRR2D"'
+  type: gene
+- db_refs:
+    HGNC: '11267'
+  name: SPRR2G
+  search_term: '"SPRR2G"'
+  type: gene
+- db_refs:
+    HGNC: '11268'
+  name: SPRR3
+  search_term: '"SPRR3"'
+  type: gene
+- db_refs:
+    HGNC: '11272'
+  name: SPTA1
+  search_term: '"SPTA1"'
+  type: gene
+- db_refs:
+    HGNC: '10861'
+  name: ST6GAL2
+  search_term: '"ST6GAL2"'
+  type: gene
+- db_refs:
+    HGNC: '19343'
+  name: ST6GALNAC3
+  search_term: '"ST6GALNAC3"'
+  type: gene
+- db_refs:
+    HGNC: '11369'
+  name: STATH
+  search_term: '"STATH"'
+  type: gene
+- db_refs:
+    HGNC: '11389'
+  name: STK11
+  search_term: '"STK11"'
+  type: gene
+- db_refs:
+    HGNC: '11398'
+  name: STK19
+  search_term: '"STK19"'
+  type: gene
+- db_refs:
+    HGNC: '15885'
+  name: SYNDIG1
+  search_term: '"SYNDIG1"'
+  type: gene
+- db_refs:
+    HGNC: '11517'
+  name: TAC1
+  search_term: '"TAC1"'
+  type: gene
+- db_refs:
+    HGNC: '14909'
+  name: TAS2R1
+  search_term: '"TAS2R1"'
+  type: gene
+- db_refs:
+    HGNC: '11604'
+  name: TBX5
+  search_term: '"TBX5"'
+  type: gene
+- db_refs:
+    HGNC: '11632'
+  name: TCF21
+  search_term: '"TCF21"'
+  type: gene
+- db_refs:
+    HGNC: '18570'
+  name: TGIF2LX
+  search_term: '"TGIF2LX"'
+  type: gene
+- db_refs:
+    HGNC: '11850'
+  name: TLR4
+  search_term: '"TLR4"'
+  type: gene
+- db_refs:
+    HGNC: '11953'
+  name: TNR
+  search_term: '"TNR"'
+  type: gene
+- db_refs:
+    HGNC: '11998'
+  name: TP53
+  search_term: '"TP53"'
+  type: gene
+- db_refs:
+    HGNC: '17358'
+  name: TPK1
+  search_term: '"TPK1"'
+  type: gene
+- db_refs:
+    HGNC: '12023'
+  name: TPTE
+  search_term: '"TPTE"'
+  type: gene
+- db_refs:
+    HGNC: '19021'
+  name: TRIM48
+  search_term: '"TRIM48"'
+  type: gene
+- db_refs:
+    HGNC: '19023'
+  name: TRIM51
+  search_term: '"TRIM51"'
+  type: gene
+- db_refs:
+    HGNC: '24150'
+  name: TRIM58
+  search_term: '"TRIM58"'
+  type: gene
+- db_refs:
+    HGNC: '30743'
+  name: TSLP
+  search_term: '"TSLP"'
+  type: gene
+- db_refs:
+    HGNC: '12442'
+  name: TYR
+  search_term: '"TYR"'
+  type: gene
+- db_refs:
+    HGNC: '12453'
+  name: U2AF1
+  search_term: '"U2AF1"'
+  type: gene
+- db_refs:
+    HGNC: '12559'
+  name: UMOD
+  search_term: '"UMOD"'
+  type: gene
+- db_refs:
+    HGNC: '12682'
+  name: VEGFC
+  search_term: '"VEGFC"'
+  type: gene
+- db_refs:
+    HGNC: '24327'
+  name: VGLL3
+  search_term: '"VGLL3"'
+  type: gene
+- db_refs:
+    HGNC: '28499'
+  name: VSTM2A
+  search_term: '"VSTM2A"'
+  type: gene
+- db_refs:
+    HGNC: '10646'
+  name: XCL2
+  search_term: '"XCL2"'
+  type: gene
+- db_refs:
+    HGNC: '12872'
+  name: ZIC1
+  search_term: '"ZIC1"'
+  type: gene
+- db_refs:
+    HGNC: '20393'
+  name: ZIC4
+  search_term: '"ZIC4"'
+  type: gene
+- db_refs:
+    HGNC: '29025'
+  name: ZNF536
+  search_term: '"ZNF536"'
+  type: gene
+- db_refs:
+    HGNC: '21711'
+  name: ZNF804A
+  search_term: '"ZNF804A"'
+  type: gene
+- db_refs:
+    HGNC: '15770'
+  name: ZP4
+  search_term: '"ZP4"'
+  type: gene
+- db_refs:
+    HGNC: '23712'
+  name: ZSCAN1
+  search_term: '"ZSCAN1"'
+  type: gene
+- db_refs:
+    CHEBI: CHEBI:90217
+    HMS-LINCS: '10037'
+    LINCS: LSM-1037
+    PUBCHEM: '24889392'
+  name: AC220
+  search_term: '"AC220"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:75404
+    HMS-LINCS: '10223'
+    LINCS: LSM-1224
+    PUBCHEM: '2051'
+  name: AG1478
+  search_term: '"AG1478"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10392'
+    PUBCHEM: '57390074'
+  name: ALK-IN-1
+  search_term: '"ALK-IN-1"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91324
+    HMS-LINCS: '10002'
+    LINCS: LSM-1002
+    PUBCHEM: '24880028'
+  name: ALW-II-38-3
+  search_term: '"ALW-II-38-3"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91325
+    HMS-LINCS: '10003'
+    LINCS: LSM-1003
+    PUBCHEM: '24875320'
+  name: ALW-II-49-7
+  search_term: '"ALW-II-49-7"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91467
+    HMS-LINCS: '10224'
+    LINCS: LSM-1225
+    PUBCHEM: '24739943'
+  name: AST1306
+  search_term: '"AST1306"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91354
+    HMS-LINCS: '10050'
+    LINCS: LSM-1050
+    PUBCHEM: '11676786'
+  name: AZ-628
+  search_term: '"AZ-628"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:63453
+    HMS-LINCS: '10289'
+    LINCS: LSM-6308
+    PUBCHEM: '51039095'
+  name: AZD4547
+  search_term: '"AZD4547"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91328
+    HMS-LINCS: '10006'
+    LINCS: LSM-1006
+    PUBCHEM: '67077825'
+  name: AZD7762
+  search_term: '"AZD7762"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10133'
+    LINCS: LSM-43226
+    PUBCHEM: '57519523'
+  name: Afatinib
+  search_term: '"Afatinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:125628
+    HMS-LINCS: '10391'
+    PUBCHEM: '24771867'
+  name: Alisertib
+  search_term: '"Alisertib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91409
+    HMS-LINCS: '10143'
+    LINCS: LSM-1144
+    PUBCHEM: '24794418'
+  name: BMS 777607
+  search_term: '"BMS 777607"'
+  type: drug
+- db_refs:
+    CHEMBL: '401930'
+    HMS-LINCS: '10209'
+    LINCS: LSM-1210
+    PUBCHEM: '68925359'
+  name: BMS-536924
+  search_term: '"BMS-536924"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:39112
+    HMS-LINCS: '10189'
+    LINCS: LSM-1190
+    PUBCHEM: '5328940'
+  name: Bosutinib
+  search_term: '"Bosutinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91358
+    HMS-LINCS: '10058'
+    LINCS: LSM-1058
+    PUBCHEM: '57394468'
+  name: CG-930
+  search_term: '"CG-930"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10010'
+    LINCS: LSM-42777
+    PUBCHEM: '53401057'
+  name: CP724714
+  search_term: '"CP724714"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:61399
+    HMS-LINCS: '10120'
+    LINCS: LSM-1120
+    PUBCHEM: '156414'
+  name: Canertinib
+  search_term: '"Canertinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:94782
+    HMS-LINCS: '10444'
+    PUBCHEM: '9933475'
+  name: Cediranib
+  search_term: '"Cediranib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:78432
+    HMS-LINCS: '10394'
+    PUBCHEM: '57379345'
+  name: Ceritinib
+  search_term: '"Ceritinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:64310
+    CHEMBL: '601719'
+    HMS-LINCS: '10027'
+    LINCS: LSM-1027
+    PUBCHEM: '11626560'
+  name: Crizotinib
+  search_term: '"Crizotinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:75045
+    HMS-LINCS: '10284'
+    LINCS: LSM-6303
+    PUBCHEM: '44462760'
+  name: Dabrafenib
+  search_term: '"Dabrafenib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10222'
+    LINCS: LSM-42808
+    PUBCHEM: '57519532'
+  name: Dacomitinib
+  search_term: '"Dacomitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:49375
+    CHEMBL: '1421'
+    HMS-LINCS: '10020'
+    LINCS: LSM-1020
+    PUBCHEM: '3062316'
+  name: Dasatinib
+  search_term: '"Dasatinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:40953
+    HMS-LINCS: '10169'
+    LINCS: LSM-1170
+    PUBCHEM: '156422'
+  name: Doramapimod
+  search_term: '"Doramapimod"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10127'
+    LINCS: LSM-1127
+    PUBCHEM: '49830557'
+  name: Dovitinib
+  search_term: '"Dovitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:114785
+    CHEMBL: '553'
+    HMS-LINCS: '10097'
+    LINCS: LSM-1097
+    PUBCHEM: '176870'
+  name: Erlotinib
+  search_term: '"Erlotinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91408
+    HMS-LINCS: '10141'
+    LINCS: LSM-1142
+    PUBCHEM: '16722836'
+  name: Fedratinib
+  search_term: '"Fedratinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91418
+    HMS-LINCS: '10157'
+    LINCS: LSM-1158
+    PUBCHEM: '42642645'
+  name: Foretinib
+  search_term: '"Foretinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10181'
+    LINCS: LSM-42801
+    PUBCHEM: '57519545'
+  name: GDC-0879
+  search_term: '"GDC-0879"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10365'
+    LINCS: LSM-44935
+    PUBCHEM: '59397065'
+  name: GNF-5837
+  search_term: '"GNF-5837"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91396
+    HMS-LINCS: '10128'
+    LINCS: LSM-1128
+    PUBCHEM: '16048642'
+  name: GSK 690693
+  search_term: '"GSK 690693"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10401'
+    PUBCHEM: '11617559'
+  name: GW2580
+  search_term: '"GW2580"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:49668
+    HMS-LINCS: '10098'
+    LINCS: LSM-1098
+    PUBCHEM: '123631'
+  name: Gefitinib
+  search_term: '"Gefitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:51913
+    CHEMBL: '302449'
+    HMS-LINCS: '10210'
+    LINCS: LSM-1211
+    PUBCHEM: '3501'
+  name: Go 6976
+  search_term: '"Go 6976"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95092
+    HMS-LINCS: '10342'
+    LINCS: LSM-6345
+    PUBCHEM: '56655374'
+  name: HG-14-10-04
+  search_term: '"HG-14-10-04"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90943
+    HMS-LINCS: '10341'
+    LINCS: LSM-6344
+    PUBCHEM: '71496458'
+  name: HG-14-8-02
+  search_term: '"HG-14-8-02"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:94486
+    HMS-LINCS: '10016'
+    LINCS: LSM-5245
+    PUBCHEM: '25226117'
+  name: HG-5-88-01
+  search_term: '"HG-5-88-01"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:92257
+    HMS-LINCS: '10228'
+    LINCS: LSM-2309
+    PUBCHEM: '9549298'
+  name: IKK16
+  search_term: '"IKK16"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91397
+    HMS-LINCS: '10129'
+    LINCS: LSM-1129
+    PUBCHEM: '16126651'
+  name: Ibrutinib
+  search_term: '"Ibrutinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91456
+    CHEMBL: '1242367'
+    HMS-LINCS: '10212'
+    LINCS: LSM-1213
+    PUBCHEM: '24825971'
+  name: KIN001-021
+  search_term: '"KIN001-021"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91457
+    CHEMBL: '197603'
+    HMS-LINCS: '10213'
+    LINCS: LSM-1214
+    PUBCHEM: '9549184'
+  name: KIN001-111
+  search_term: '"KIN001-111"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10192'
+    LINCS: LSM-42803
+    PUBCHEM: '67089852'
+  name: KW2449
+  search_term: '"KW2449"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:93773
+    HMS-LINCS: '10262'
+    LINCS: LSM-4283
+    PUBCHEM: '9950176'
+  name: L-779450
+  search_term: '"L-779450"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:49603
+    CHEMBL: '554'
+    HMS-LINCS: '10051'
+    LINCS: LSM-1051
+    PUBCHEM: '208908'
+  name: Lapatinib
+  search_term: '"Lapatinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91471
+    HMS-LINCS: '10230'
+    LINCS: LSM-1231
+    PUBCHEM: '126565'
+  name: Lestaurtinib
+  search_term: '"Lestaurtinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91435
+    HMS-LINCS: '10182'
+    LINCS: LSM-1183
+    PUBCHEM: '11485656'
+  name: Linifanib
+  search_term: '"Linifanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:51098
+    HMS-LINCS: '10042'
+    LINCS: LSM-1042
+    PUBCHEM: '11667893'
+  name: Motesanib
+  search_term: '"Motesanib"'
+  type: drug
+- db_refs:
+    CHEMBL: '472004'
+    HMS-LINCS: '10297'
+    LINCS: LSM-6314
+    PUBCHEM: '5357795'
+  name: NSC-87877
+  search_term: '"NSC-87877"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91452
+    HMS-LINCS: '10207'
+    LINCS: LSM-1208
+    PUBCHEM: '9934347'
+  name: NVP-TAE226
+  search_term: '"NVP-TAE226"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91338
+    CHEMBL: '509032'
+    HMS-LINCS: '10024'
+    LINCS: LSM-1024
+    PUBCHEM: '16038120'
+  name: NVP-TAE684
+  search_term: '"NVP-TAE684"'
+  type: drug
+- db_refs:
+    CHEMBL: '180022'
+    HMS-LINCS: '10018'
+    LINCS: LSM-42778
+    PUBCHEM: '53398697'
+  name: Neratinib
+  search_term: '"Neratinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:52172
+    CHEMBL: '255863'
+    HMS-LINCS: '10099'
+    LINCS: LSM-1099
+    PUBCHEM: '644241'
+  name: Nilotinib
+  search_term: '"Nilotinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10151'
+    LINCS: LSM-1152
+    PUBCHEM: '56965894'
+  name: Nintedanib
+  search_term: '"Nintedanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95096
+    HMS-LINCS: '10268'
+    LINCS: LSM-6351
+    PUBCHEM: '11433190'
+  name: Nutlin 3a
+  search_term: '"Nutlin 3a"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10383'
+    PUBCHEM: '71731823'
+  name: PF-06463922
+  search_term: '"PF-06463922"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:93751
+    HMS-LINCS: '10231'
+    LINCS: LSM-4254
+    PUBCHEM: '25227462'
+  name: PF-3758309
+  search_term: '"PF-3758309"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91370
+    HMS-LINCS: '10072'
+    LINCS: LSM-1072
+    PUBCHEM: '11713159'
+  name: PF562271
+  search_term: '"PF562271"'
+  type: drug
+- db_refs:
+    CHEMBL: '450786'
+    HMS-LINCS: '10125'
+    LINCS: LSM-42793
+    PUBCHEM: '66596670'
+  name: PHA-665752
+  search_term: '"PHA-665752"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91464
+    CHEMBL: '338448'
+    HMS-LINCS: '10220'
+    LINCS: LSM-1221
+    PUBCHEM: '16760627'
+  name: PKC412
+  search_term: '"PKC412"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90295
+    HMS-LINCS: '10049'
+    LINCS: LSM-1049
+    PUBCHEM: '24180719'
+  name: PLX-4720
+  search_term: '"PLX-4720"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10405'
+    PUBCHEM: '1400'
+  name: PP1
+  search_term: '"PP1"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10406'
+    PUBCHEM: '44462758'
+  name: PRT062607
+  search_term: '"PRT062607"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:71219
+    HMS-LINCS: '10114'
+    LINCS: LSM-1114
+    PUBCHEM: '10113978'
+  name: Pazopanib
+  search_term: '"Pazopanib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10159'
+    LINCS: LSM-1160
+    PUBCHEM: '216467'
+  name: Pelitinib
+  search_term: '"Pelitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:78543
+    HMS-LINCS: '10150'
+    LINCS: LSM-1151
+    PUBCHEM: '24826799'
+  name: Ponatinib
+  search_term: '"Ponatinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10397'
+    PUBCHEM: '25127713'
+  name: Poziotinib
+  search_term: '"Poziotinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91348
+    HMS-LINCS: '10040'
+    LINCS: LSM-1040
+    PUBCHEM: '11213558'
+  name: R406
+  search_term: '"R406"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91451
+    HMS-LINCS: '10206'
+    LINCS: LSM-1207
+    PUBCHEM: '11656518'
+  name: RAF 265
+  search_term: '"RAF 265"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:68647
+    HMS-LINCS: '10225'
+    LINCS: LSM-1226
+    PUBCHEM: '11167602'
+  name: Regorafenib
+  search_term: '"Regorafenib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:66919
+    HMS-LINCS: '10138'
+    LINCS: LSM-1139
+    PUBCHEM: '25126798'
+  name: Ruxolitinib
+  search_term: '"Ruxolitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90705
+    HMS-LINCS: '10167'
+    LINCS: LSM-1168
+    PUBCHEM: '176155'
+  name: SB 203580
+  search_term: '"SB 203580"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10046'
+    LINCS: LSM-42746
+    PUBCHEM: '53239990'
+  name: SB590885
+  search_term: '"SB590885"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:50924
+    CHEMBL: '1336'
+    HMS-LINCS: '10008'
+    LINCS: LSM-1008
+    PUBCHEM: '216239'
+  name: Sorafenib
+  search_term: '"Sorafenib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:15738
+    CHEMBL: '388978'
+    HMS-LINCS: '10103'
+    LINCS: LSM-1103
+    PUBCHEM: '44259'
+  name: Staurosporine
+  search_term: '"Staurosporine"'
+  type: drug
+- db_refs:
+    CHEMBL: '535'
+    HMS-LINCS: '10175'
+    LINCS: LSM-42800
+    PUBCHEM: '3086686'
+  name: Sunitinib
+  search_term: '"Sunitinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10409'
+    PUBCHEM: '46209401'
+  name: TAK-632
+  search_term: '"TAK-632"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91360
+    HMS-LINCS: '10060'
+    LINCS: LSM-1060
+    PUBCHEM: '9952773'
+  name: TAK-715
+  search_term: '"TAK-715"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91336
+    CHEMBL: '572878'
+    HMS-LINCS: '10021'
+    LINCS: LSM-1021
+    PUBCHEM: '5494449'
+  name: Tozasertib
+  search_term: '"Tozasertib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:49960
+    HMS-LINCS: '10198'
+    LINCS: LSM-1199
+    PUBCHEM: '3081361'
+  name: Vandetanib
+  search_term: '"Vandetanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:63637
+    HMS-LINCS: '10068'
+    LINCS: LSM-1068
+    PUBCHEM: '42611257'
+  name: Vemurafenib
+  search_term: '"Vemurafenib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10039'
+    LINCS: LSM-44937
+  name: WH-4-025
+  search_term: '"WH-4-025"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10082'
+    LINCS: LSM-5545
+  name: WZ-4-145
+  search_term: '"WZ-4-145"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:61400
+    HMS-LINCS: '10085'
+    LINCS: LSM-1085
+    PUBCHEM: '44607530'
+  name: WZ4002
+  search_term: '"WZ4002"'
+  type: drug

--- a/models/paad/config.yaml
+++ b/models/paad/config.yaml
@@ -1,235 +1,1265 @@
 ndex:
   network: 8d1330ca-f6a2-11e8-aaa6-0ac135e8bacf
 search_terms:
-- "ACER1"
-- "ACTL9"
-- "ACVR1B"
-- "ACVR2A"
-- "ADAT2"
-- "APTX"
-- "ARID1A"
-- "ATG101"
-- "ATP5MC3"
-- "ATP5MD"
-- "ATP6V1F"
-- "B9D2"
-- "BAGE2"
-- "BDNF"
-- "BLID"
-- "BPIFA1"
-- "CCL24"
-- "CCL3"
-- "CCND2"
-- "CD33"
-- "CD86"
-- "CDC42SE2"
-- "CDKN2A"
-- "CETN1"
-- "CHCHD7"
-- "CIDEA"
-- "CLEC4A"
-- "CNBD1"
-- "CNIH3"
-- "COPS9"
-- "COX4I2"
-- "COX7B2"
-- "CSTA"
-- "CTSG"
-- "DCAF4L2"
-- "DEFB119"
-- "DRGX"
-- "DSCR4"
-- "EBPL"
-- "ELMOD1"
-- "ELOC"
-- "ENY2"
-- "FAM107A"
-- "FAM19A5"
-- "FCGR3B"
-- "FGF6"
-- "FHIT"
-- "FOLH1"
-- "GABARAPL1"
-- "GABRB1"
-- "GAST"
-- "GDF6"
-- "GDNF"
-- "GFRA3"
-- "GLI3"
-- "GLO1"
-- "GNAS"
-- "GNRH2"
-- "GPM6B"
-- "GPR26"
-- "GUCA1C"
-- "H2AFV"
-- "H2AFZ"
-- "HCST"
-- "HIST1H1B"
-- "HIST1H1E"
-- "HIST1H2BF"
-- "HIST1H2BO"
-- "HIST1H4D"
-- "HIST1H4E"
-- "HIST1H4G"
-- "HIST2H2AC"
-- "HS3ST2"
-- "HSPB8"
-- "HTN3"
-- "IAPP"
-- "IL21"
-- "IL9"
-- "IRF6"
-- "IRX1"
-- "IYD"
-- "JAM2"
-- "KCNA1"
-- "KCNA6"
-- "KLK15"
-- "KRAS"
-- "KRT4"
-- "KRTAP1-3"
-- "KRTAP12-3"
-- "KRTAP19-2"
-- "KRTAP22-1"
-- "KRTAP4-1"
-- "LCE1C"
-- "LCE2C"
-- "LCE5A"
-- "MAGEB1"
-- "MAGEB2"
-- "MAP1LC3A"
-- "MAP2K4"
-- "MAP2K7"
-- "MED10"
-- "MEF2C"
-- "MMP26"
-- "MRPS36"
-- "MRPS6"
-- "MSRB3"
-- "MT2A"
-- "MTCP1"
-- "MTRNR2L1"
-- "NAA40"
-- "NGF"
-- "NNAT"
-- "NPY1R"
-- "NRN1"
-- "NRXN1"
-- "NRXN2"
-- "NRXN3"
-- "NTF3"
-- "NTM"
-- "NUDCD2"
-- "OCA2"
-- "OR4P4"
-- "OR4S2"
-- "OR5D13"
-- "OR5M11"
-- "OR7D4"
-- "OR8H2"
-- "P2RY6"
-- "PCMTD1"
-- "PI15"
-- "PMEPA1"
-- "PMP22"
-- "PPP1R1C"
-- "PRB4"
-- "PRL"
-- "PRM1"
-- "PROP1"
-- "PRR15L"
-- "PRSS1"
-- "PSG6"
-- "RAP1B"
-- "RARRES3"
-- "RBFOX1"
-- "RBM10"
-- "RETNLB"
-- "RFK"
-- "RNF43"
-- "RPL11"
-- "RPL28"
-- "RPLP2"
-- "RPS28"
-- "RRAS2"
-- "RSPO1"
-- "RYBP"
-- "S100A3"
-- "S100A4"
-- "SCN3B"
-- "SEC14L3"
-- "SH3BGRL3"
-- "SLC35G5"
-- "SMAD3"
-- "SMAD4"
-- "SNRPE"
-- "SOX5"
-- "SPANXC"
-- "SPATA8"
-- "SPI1"
-- "SPRR2A"
-- "SST"
-- "ST6GAL2"
-- "STK11"
-- "TGFBR1"
-- "TGFBR2"
-- "THYN1"
-- "TMEM215"
-- "TMEM52"
-- "TMSB10"
-- "TP53"
-- "TPO"
-- "TPRG1"
-- "TPSD1"
-- "TPTE"
-- "TPTE2"
-- "TRH"
-- "TRIM48"
-- "TSPAN2"
-- "U2AF1"
-- "UBE2D4"
-- "UQCR11"
-- "VCX"
-- "VPS25"
-- "ZFP36L2"
-- "ZFP42"
-- "ZIM2"
-- "ZNF576"
-- "ZNF814"
-- "ZNRF4"
-- "5z-7-oxozeaenol"
-- "AZD 5438"
-- "Alvocidib"
-- "Bortezomib"
-- "Canertinib"
-- "Crizotinib"
-- "D 4476"
-- "Dabrafenib"
-- "Dasatinib"
-- "Dorsomorphin"
-- "EW-7197"
-- "Fedratinib"
-- "GM6001"
-- "GSK1838705A"
-- "HG-9-91-01"
-- "KW2449"
-- "Ki20227"
-- "LDN-193189"
-- "LY2109761"
-- "Lestaurtinib"
-- "NVP-TAE684"
-- "Neratinib"
-- "Nintedanib"
-- "Nutlin 3a"
-- "PKC412"
-- "PLX-4720"
-- "Palbociclib"
-- "Pazopanib"
-- "R406"
-- "SB202190"
-- "SB525334"
-- "SNS-032"
-- "SP600125"
-- "Staurosporine"
-- "Sunitinib"
+- db_refs:
+    HGNC: '18356'
+  name: ACER1
+  search_term: '"ACER1"'
+  type: gene
+- db_refs:
+    HGNC: '28494'
+  name: ACTL9
+  search_term: '"ACTL9"'
+  type: gene
+- db_refs:
+    HGNC: '172'
+  name: ACVR1B
+  search_term: '"ACVR1B"'
+  type: gene
+- db_refs:
+    HGNC: '173'
+  name: ACVR2A
+  search_term: '"ACVR2A"'
+  type: gene
+- db_refs:
+    HGNC: '21172'
+  name: ADAT2
+  search_term: '"ADAT2"'
+  type: gene
+- db_refs:
+    HGNC: '15984'
+  name: APTX
+  search_term: '"APTX"'
+  type: gene
+- db_refs:
+    HGNC: '11110'
+  name: ARID1A
+  search_term: '"ARID1A"'
+  type: gene
+- db_refs:
+    HGNC: '25679'
+  name: ATG101
+  search_term: '"ATG101"'
+  type: gene
+- db_refs:
+    HGNC: '843'
+  name: ATP5MC3
+  search_term: '"ATP5MC3"'
+  type: gene
+- db_refs:
+    HGNC: '30889'
+  name: ATP5MD
+  search_term: '"ATP5MD"'
+  type: gene
+- db_refs:
+    HGNC: '16832'
+  name: ATP6V1F
+  search_term: '"ATP6V1F"'
+  type: gene
+- db_refs:
+    HGNC: '28636'
+  name: B9D2
+  search_term: '"B9D2"'
+  type: gene
+- db_refs:
+    HGNC: '15723'
+  name: BAGE2
+  search_term: '"BAGE2"'
+  type: gene
+- db_refs:
+    HGNC: '1033'
+  name: BDNF
+  search_term: '"BDNF"'
+  type: gene
+- db_refs:
+    HGNC: '33495'
+  name: BLID
+  search_term: '"BLID"'
+  type: gene
+- db_refs:
+    HGNC: '15749'
+  name: BPIFA1
+  search_term: '"BPIFA1"'
+  type: gene
+- db_refs:
+    HGNC: '10623'
+  name: CCL24
+  search_term: '"CCL24"'
+  type: gene
+- db_refs:
+    HGNC: '10627'
+  name: CCL3
+  search_term: '"CCL3"'
+  type: gene
+- db_refs:
+    HGNC: '1583'
+  name: CCND2
+  search_term: '"CCND2"'
+  type: gene
+- db_refs:
+    HGNC: '1659'
+  name: CD33
+  search_term: '"CD33"'
+  type: gene
+- db_refs:
+    HGNC: '1705'
+  name: CD86
+  search_term: '"CD86"'
+  type: gene
+- db_refs:
+    HGNC: '18547'
+  name: CDC42SE2
+  search_term: '"CDC42SE2"'
+  type: gene
+- db_refs:
+    HGNC: '1787'
+  name: CDKN2A
+  search_term: '"CDKN2A"'
+  type: gene
+- db_refs:
+    HGNC: '1866'
+  name: CETN1
+  search_term: '"CETN1"'
+  type: gene
+- db_refs:
+    HGNC: '28314'
+  name: CHCHD7
+  search_term: '"CHCHD7"'
+  type: gene
+- db_refs:
+    HGNC: '1976'
+  name: CIDEA
+  search_term: '"CIDEA"'
+  type: gene
+- db_refs:
+    HGNC: '13257'
+  name: CLEC4A
+  search_term: '"CLEC4A"'
+  type: gene
+- db_refs:
+    HGNC: '26663'
+  name: CNBD1
+  search_term: '"CNBD1"'
+  type: gene
+- db_refs:
+    HGNC: '26802'
+  name: CNIH3
+  search_term: '"CNIH3"'
+  type: gene
+- db_refs:
+    HGNC: '21314'
+  name: COPS9
+  search_term: '"COPS9"'
+  type: gene
+- db_refs:
+    HGNC: '16232'
+  name: COX4I2
+  search_term: '"COX4I2"'
+  type: gene
+- db_refs:
+    HGNC: '24381'
+  name: COX7B2
+  search_term: '"COX7B2"'
+  type: gene
+- db_refs:
+    HGNC: '2481'
+  name: CSTA
+  search_term: '"CSTA"'
+  type: gene
+- db_refs:
+    HGNC: '2532'
+  name: CTSG
+  search_term: '"CTSG"'
+  type: gene
+- db_refs:
+    HGNC: '26657'
+  name: DCAF4L2
+  search_term: '"DCAF4L2"'
+  type: gene
+- db_refs:
+    HGNC: '18099'
+  name: DEFB119
+  search_term: '"DEFB119"'
+  type: gene
+- db_refs:
+    HGNC: '21536'
+  name: DRGX
+  search_term: '"DRGX"'
+  type: gene
+- db_refs:
+    HGNC: '3045'
+  name: DSCR4
+  search_term: '"DSCR4"'
+  type: gene
+- db_refs:
+    HGNC: '18061'
+  name: EBPL
+  search_term: '"EBPL"'
+  type: gene
+- db_refs:
+    HGNC: '25334'
+  name: ELMOD1
+  search_term: '"ELMOD1"'
+  type: gene
+- db_refs:
+    HGNC: '11617'
+  name: ELOC
+  search_term: '"ELOC"'
+  type: gene
+- db_refs:
+    HGNC: '24449'
+  name: ENY2
+  search_term: '"ENY2"'
+  type: gene
+- db_refs:
+    HGNC: '30827'
+  name: FAM107A
+  search_term: '"FAM107A"'
+  type: gene
+- db_refs:
+    HGNC: '21592'
+  name: FAM19A5
+  search_term: '"FAM19A5"'
+  type: gene
+- db_refs:
+    HGNC: '3620'
+  name: FCGR3B
+  search_term: '"FCGR3B"'
+  type: gene
+- db_refs:
+    HGNC: '3684'
+  name: FGF6
+  search_term: '"FGF6"'
+  type: gene
+- db_refs:
+    HGNC: '3701'
+  name: FHIT
+  search_term: '"FHIT"'
+  type: gene
+- db_refs:
+    HGNC: '3788'
+  name: FOLH1
+  search_term: '"FOLH1"'
+  type: gene
+- db_refs:
+    HGNC: '4068'
+  name: GABARAPL1
+  search_term: '"GABARAPL1"'
+  type: gene
+- db_refs:
+    HGNC: '4081'
+  name: GABRB1
+  search_term: '"GABRB1"'
+  type: gene
+- db_refs:
+    HGNC: '4164'
+  name: GAST
+  search_term: '"GAST"'
+  type: gene
+- db_refs:
+    HGNC: '4221'
+  name: GDF6
+  search_term: '"GDF6"'
+  type: gene
+- db_refs:
+    HGNC: '4232'
+  name: GDNF
+  search_term: '"GDNF"'
+  type: gene
+- db_refs:
+    HGNC: '4245'
+  name: GFRA3
+  search_term: '"GFRA3"'
+  type: gene
+- db_refs:
+    HGNC: '4319'
+  name: GLI3
+  search_term: '"GLI3"'
+  type: gene
+- db_refs:
+    HGNC: '4323'
+  name: GLO1
+  search_term: '"GLO1"'
+  type: gene
+- db_refs:
+    HGNC: '4392'
+  name: GNAS
+  search_term: '"GNAS"'
+  type: gene
+- db_refs:
+    HGNC: '4420'
+  name: GNRH2
+  search_term: '"GNRH2"'
+  type: gene
+- db_refs:
+    HGNC: '4461'
+  name: GPM6B
+  search_term: '"GPM6B"'
+  type: gene
+- db_refs:
+    HGNC: '4481'
+  name: GPR26
+  search_term: '"GPR26"'
+  type: gene
+- db_refs:
+    HGNC: '4680'
+  name: GUCA1C
+  search_term: '"GUCA1C"'
+  type: gene
+- db_refs:
+    HGNC: '20664'
+  name: H2AFV
+  search_term: '"H2AFV"'
+  type: gene
+- db_refs:
+    HGNC: '4741'
+  name: H2AFZ
+  search_term: '"H2AFZ"'
+  type: gene
+- db_refs:
+    HGNC: '16977'
+  name: HCST
+  search_term: '"HCST"'
+  type: gene
+- db_refs:
+    HGNC: '4719'
+  name: HIST1H1B
+  search_term: '"HIST1H1B"'
+  type: gene
+- db_refs:
+    HGNC: '4718'
+  name: HIST1H1E
+  search_term: '"HIST1H1E"'
+  type: gene
+- db_refs:
+    HGNC: '4752'
+  name: HIST1H2BF
+  search_term: '"HIST1H2BF"'
+  type: gene
+- db_refs:
+    HGNC: '4758'
+  name: HIST1H2BO
+  search_term: '"HIST1H2BO"'
+  type: gene
+- db_refs:
+    HGNC: '4782'
+  name: HIST1H4D
+  search_term: '"HIST1H4D"'
+  type: gene
+- db_refs:
+    HGNC: '4790'
+  name: HIST1H4E
+  search_term: '"HIST1H4E"'
+  type: gene
+- db_refs:
+    HGNC: '4792'
+  name: HIST1H4G
+  search_term: '"HIST1H4G"'
+  type: gene
+- db_refs:
+    HGNC: '4738'
+  name: HIST2H2AC
+  search_term: '"HIST2H2AC"'
+  type: gene
+- db_refs:
+    HGNC: '5195'
+  name: HS3ST2
+  search_term: '"HS3ST2"'
+  type: gene
+- db_refs:
+    HGNC: '30171'
+  name: HSPB8
+  search_term: '"HSPB8"'
+  type: gene
+- db_refs:
+    HGNC: '5284'
+  name: HTN3
+  search_term: '"HTN3"'
+  type: gene
+- db_refs:
+    HGNC: '5329'
+  name: IAPP
+  search_term: '"IAPP"'
+  type: gene
+- db_refs:
+    HGNC: '6005'
+  name: IL21
+  search_term: '"IL21"'
+  type: gene
+- db_refs:
+    HGNC: '6029'
+  name: IL9
+  search_term: '"IL9"'
+  type: gene
+- db_refs:
+    HGNC: '6121'
+  name: IRF6
+  search_term: '"IRF6"'
+  type: gene
+- db_refs:
+    HGNC: '14358'
+  name: IRX1
+  search_term: '"IRX1"'
+  type: gene
+- db_refs:
+    HGNC: '21071'
+  name: IYD
+  search_term: '"IYD"'
+  type: gene
+- db_refs:
+    HGNC: '14686'
+  name: JAM2
+  search_term: '"JAM2"'
+  type: gene
+- db_refs:
+    HGNC: '6218'
+  name: KCNA1
+  search_term: '"KCNA1"'
+  type: gene
+- db_refs:
+    HGNC: '6225'
+  name: KCNA6
+  search_term: '"KCNA6"'
+  type: gene
+- db_refs:
+    HGNC: '20453'
+  name: KLK15
+  search_term: '"KLK15"'
+  type: gene
+- db_refs:
+    HGNC: '6407'
+  name: KRAS
+  search_term: '"KRAS"'
+  type: gene
+- db_refs:
+    HGNC: '6441'
+  name: KRT4
+  search_term: '"KRT4"'
+  type: gene
+- db_refs:
+    HGNC: '16771'
+  name: KRTAP1-3
+  search_term: '"KRTAP1-3"'
+  type: gene
+- db_refs:
+    HGNC: '20531'
+  name: KRTAP12-3
+  search_term: '"KRTAP12-3"'
+  type: gene
+- db_refs:
+    HGNC: '18937'
+  name: KRTAP19-2
+  search_term: '"KRTAP19-2"'
+  type: gene
+- db_refs:
+    HGNC: '18947'
+  name: KRTAP22-1
+  search_term: '"KRTAP22-1"'
+  type: gene
+- db_refs:
+    HGNC: '18907'
+  name: KRTAP4-1
+  search_term: '"KRTAP4-1"'
+  type: gene
+- db_refs:
+    HGNC: '29464'
+  name: LCE1C
+  search_term: '"LCE1C"'
+  type: gene
+- db_refs:
+    HGNC: '29460'
+  name: LCE2C
+  search_term: '"LCE2C"'
+  type: gene
+- db_refs:
+    HGNC: '16614'
+  name: LCE5A
+  search_term: '"LCE5A"'
+  type: gene
+- db_refs:
+    HGNC: '6808'
+  name: MAGEB1
+  search_term: '"MAGEB1"'
+  type: gene
+- db_refs:
+    HGNC: '6809'
+  name: MAGEB2
+  search_term: '"MAGEB2"'
+  type: gene
+- db_refs:
+    HGNC: '6838'
+  name: MAP1LC3A
+  search_term: '"MAP1LC3A"'
+  type: gene
+- db_refs:
+    HGNC: '6844'
+  name: MAP2K4
+  search_term: '"MAP2K4"'
+  type: gene
+- db_refs:
+    HGNC: '6847'
+  name: MAP2K7
+  search_term: '"MAP2K7"'
+  type: gene
+- db_refs:
+    HGNC: '28760'
+  name: MED10
+  search_term: '"MED10"'
+  type: gene
+- db_refs:
+    HGNC: '6996'
+  name: MEF2C
+  search_term: '"MEF2C"'
+  type: gene
+- db_refs:
+    HGNC: '14249'
+  name: MMP26
+  search_term: '"MMP26"'
+  type: gene
+- db_refs:
+    HGNC: '16631'
+  name: MRPS36
+  search_term: '"MRPS36"'
+  type: gene
+- db_refs:
+    HGNC: '14051'
+  name: MRPS6
+  search_term: '"MRPS6"'
+  type: gene
+- db_refs:
+    HGNC: '27375'
+  name: MSRB3
+  search_term: '"MSRB3"'
+  type: gene
+- db_refs:
+    HGNC: '7406'
+  name: MT2A
+  search_term: '"MT2A"'
+  type: gene
+- db_refs:
+    HGNC: '7423'
+  name: MTCP1
+  search_term: '"MTCP1"'
+  type: gene
+- db_refs:
+    HGNC: '37155'
+  name: MTRNR2L1
+  search_term: '"MTRNR2L1"'
+  type: gene
+- db_refs:
+    HGNC: '25845'
+  name: NAA40
+  search_term: '"NAA40"'
+  type: gene
+- db_refs:
+    HGNC: '7808'
+  name: NGF
+  search_term: '"NGF"'
+  type: gene
+- db_refs:
+    HGNC: '7860'
+  name: NNAT
+  search_term: '"NNAT"'
+  type: gene
+- db_refs:
+    HGNC: '7956'
+  name: NPY1R
+  search_term: '"NPY1R"'
+  type: gene
+- db_refs:
+    HGNC: '17972'
+  name: NRN1
+  search_term: '"NRN1"'
+  type: gene
+- db_refs:
+    HGNC: '8008'
+  name: NRXN1
+  search_term: '"NRXN1"'
+  type: gene
+- db_refs:
+    HGNC: '8009'
+  name: NRXN2
+  search_term: '"NRXN2"'
+  type: gene
+- db_refs:
+    HGNC: '8010'
+  name: NRXN3
+  search_term: '"NRXN3"'
+  type: gene
+- db_refs:
+    HGNC: '8023'
+  name: NTF3
+  search_term: '"NTF3"'
+  type: gene
+- db_refs:
+    HGNC: '17941'
+  name: NTM
+  search_term: '"NTM"'
+  type: gene
+- db_refs:
+    HGNC: '30535'
+  name: NUDCD2
+  search_term: '"NUDCD2"'
+  type: gene
+- db_refs:
+    HGNC: '8101'
+  name: OCA2
+  search_term: '"OCA2"'
+  type: gene
+- db_refs:
+    HGNC: '15180'
+  name: OR4P4
+  search_term: '"OR4P4"'
+  type: gene
+- db_refs:
+    HGNC: '15183'
+  name: OR4S2
+  search_term: '"OR4S2"'
+  type: gene
+- db_refs:
+    HGNC: '15280'
+  name: OR5D13
+  search_term: '"OR5D13"'
+  type: gene
+- db_refs:
+    HGNC: '15291'
+  name: OR5M11
+  search_term: '"OR5M11"'
+  type: gene
+- db_refs:
+    HGNC: '8380'
+  name: OR7D4
+  search_term: '"OR7D4"'
+  type: gene
+- db_refs:
+    HGNC: '15308'
+  name: OR8H2
+  search_term: '"OR8H2"'
+  type: gene
+- db_refs:
+    HGNC: '8543'
+  name: P2RY6
+  search_term: '"P2RY6"'
+  type: gene
+- db_refs:
+    HGNC: '30483'
+  name: PCMTD1
+  search_term: '"PCMTD1"'
+  type: gene
+- db_refs:
+    HGNC: '8946'
+  name: PI15
+  search_term: '"PI15"'
+  type: gene
+- db_refs:
+    HGNC: '14107'
+  name: PMEPA1
+  search_term: '"PMEPA1"'
+  type: gene
+- db_refs:
+    HGNC: '9118'
+  name: PMP22
+  search_term: '"PMP22"'
+  type: gene
+- db_refs:
+    HGNC: '14940'
+  name: PPP1R1C
+  search_term: '"PPP1R1C"'
+  type: gene
+- db_refs:
+    HGNC: '9340'
+  name: PRB4
+  search_term: '"PRB4"'
+  type: gene
+- db_refs:
+    HGNC: '9445'
+  name: PRL
+  search_term: '"PRL"'
+  type: gene
+- db_refs:
+    HGNC: '9447'
+  name: PRM1
+  search_term: '"PRM1"'
+  type: gene
+- db_refs:
+    HGNC: '9455'
+  name: PROP1
+  search_term: '"PROP1"'
+  type: gene
+- db_refs:
+    HGNC: '28149'
+  name: PRR15L
+  search_term: '"PRR15L"'
+  type: gene
+- db_refs:
+    HGNC: '9475'
+  name: PRSS1
+  search_term: '"PRSS1"'
+  type: gene
+- db_refs:
+    HGNC: '9523'
+  name: PSG6
+  search_term: '"PSG6"'
+  type: gene
+- db_refs:
+    HGNC: '9857'
+  name: RAP1B
+  search_term: '"RAP1B"'
+  type: gene
+- db_refs:
+    HGNC: '9869'
+  name: RARRES3
+  search_term: '"RARRES3"'
+  type: gene
+- db_refs:
+    HGNC: '18222'
+  name: RBFOX1
+  search_term: '"RBFOX1"'
+  type: gene
+- db_refs:
+    HGNC: '9896'
+  name: RBM10
+  search_term: '"RBM10"'
+  type: gene
+- db_refs:
+    HGNC: '20388'
+  name: RETNLB
+  search_term: '"RETNLB"'
+  type: gene
+- db_refs:
+    HGNC: '30324'
+  name: RFK
+  search_term: '"RFK"'
+  type: gene
+- db_refs:
+    HGNC: '18505'
+  name: RNF43
+  search_term: '"RNF43"'
+  type: gene
+- db_refs:
+    HGNC: '10301'
+  name: RPL11
+  search_term: '"RPL11"'
+  type: gene
+- db_refs:
+    HGNC: '10330'
+  name: RPL28
+  search_term: '"RPL28"'
+  type: gene
+- db_refs:
+    HGNC: '10377'
+  name: RPLP2
+  search_term: '"RPLP2"'
+  type: gene
+- db_refs:
+    HGNC: '10418'
+  name: RPS28
+  search_term: '"RPS28"'
+  type: gene
+- db_refs:
+    HGNC: '17271'
+  name: RRAS2
+  search_term: '"RRAS2"'
+  type: gene
+- db_refs:
+    HGNC: '21679'
+  name: RSPO1
+  search_term: '"RSPO1"'
+  type: gene
+- db_refs:
+    HGNC: '10480'
+  name: RYBP
+  search_term: '"RYBP"'
+  type: gene
+- db_refs:
+    HGNC: '10493'
+  name: S100A3
+  search_term: '"S100A3"'
+  type: gene
+- db_refs:
+    HGNC: '10494'
+  name: S100A4
+  search_term: '"S100A4"'
+  type: gene
+- db_refs:
+    HGNC: '20665'
+  name: SCN3B
+  search_term: '"SCN3B"'
+  type: gene
+- db_refs:
+    HGNC: '18655'
+  name: SEC14L3
+  search_term: '"SEC14L3"'
+  type: gene
+- db_refs:
+    HGNC: '15568'
+  name: SH3BGRL3
+  search_term: '"SH3BGRL3"'
+  type: gene
+- db_refs:
+    HGNC: '15546'
+  name: SLC35G5
+  search_term: '"SLC35G5"'
+  type: gene
+- db_refs:
+    HGNC: '6769'
+  name: SMAD3
+  search_term: '"SMAD3"'
+  type: gene
+- db_refs:
+    HGNC: '6770'
+  name: SMAD4
+  search_term: '"SMAD4"'
+  type: gene
+- db_refs:
+    HGNC: '11161'
+  name: SNRPE
+  search_term: '"SNRPE"'
+  type: gene
+- db_refs:
+    HGNC: '11201'
+  name: SOX5
+  search_term: '"SOX5"'
+  type: gene
+- db_refs:
+    HGNC: '14331'
+  name: SPANXC
+  search_term: '"SPANXC"'
+  type: gene
+- db_refs:
+    HGNC: '28676'
+  name: SPATA8
+  search_term: '"SPATA8"'
+  type: gene
+- db_refs:
+    HGNC: '11241'
+  name: SPI1
+  search_term: '"SPI1"'
+  type: gene
+- db_refs:
+    HGNC: '11261'
+  name: SPRR2A
+  search_term: '"SPRR2A"'
+  type: gene
+- db_refs:
+    HGNC: '11329'
+  name: SST
+  search_term: '"SST"'
+  type: gene
+- db_refs:
+    HGNC: '10861'
+  name: ST6GAL2
+  search_term: '"ST6GAL2"'
+  type: gene
+- db_refs:
+    HGNC: '11389'
+  name: STK11
+  search_term: '"STK11"'
+  type: gene
+- db_refs:
+    HGNC: '11772'
+  name: TGFBR1
+  search_term: '"TGFBR1"'
+  type: gene
+- db_refs:
+    HGNC: '11773'
+  name: TGFBR2
+  search_term: '"TGFBR2"'
+  type: gene
+- db_refs:
+    HGNC: '29560'
+  name: THYN1
+  search_term: '"THYN1"'
+  type: gene
+- db_refs:
+    HGNC: '33816'
+  name: TMEM215
+  search_term: '"TMEM215"'
+  type: gene
+- db_refs:
+    HGNC: '27916'
+  name: TMEM52
+  search_term: '"TMEM52"'
+  type: gene
+- db_refs:
+    HGNC: '11879'
+  name: TMSB10
+  search_term: '"TMSB10"'
+  type: gene
+- db_refs:
+    HGNC: '11998'
+  name: TP53
+  search_term: '"TP53"'
+  type: gene
+- db_refs:
+    HGNC: '12015'
+  name: TPO
+  search_term: '"TPO"'
+  type: gene
+- db_refs:
+    HGNC: '24759'
+  name: TPRG1
+  search_term: '"TPRG1"'
+  type: gene
+- db_refs:
+    HGNC: '14118'
+  name: TPSD1
+  search_term: '"TPSD1"'
+  type: gene
+- db_refs:
+    HGNC: '12023'
+  name: TPTE
+  search_term: '"TPTE"'
+  type: gene
+- db_refs:
+    HGNC: '17299'
+  name: TPTE2
+  search_term: '"TPTE2"'
+  type: gene
+- db_refs:
+    HGNC: '12298'
+  name: TRH
+  search_term: '"TRH"'
+  type: gene
+- db_refs:
+    HGNC: '19021'
+  name: TRIM48
+  search_term: '"TRIM48"'
+  type: gene
+- db_refs:
+    HGNC: '20659'
+  name: TSPAN2
+  search_term: '"TSPAN2"'
+  type: gene
+- db_refs:
+    HGNC: '12453'
+  name: U2AF1
+  search_term: '"U2AF1"'
+  type: gene
+- db_refs:
+    HGNC: '21647'
+  name: UBE2D4
+  search_term: '"UBE2D4"'
+  type: gene
+- db_refs:
+    HGNC: '30862'
+  name: UQCR11
+  search_term: '"UQCR11"'
+  type: gene
+- db_refs:
+    HGNC: '12667'
+  name: VCX
+  search_term: '"VCX"'
+  type: gene
+- db_refs:
+    HGNC: '28122'
+  name: VPS25
+  search_term: '"VPS25"'
+  type: gene
+- db_refs:
+    HGNC: '1108'
+  name: ZFP36L2
+  search_term: '"ZFP36L2"'
+  type: gene
+- db_refs:
+    HGNC: '30949'
+  name: ZFP42
+  search_term: '"ZFP42"'
+  type: gene
+- db_refs:
+    HGNC: '12875'
+  name: ZIM2
+  search_term: '"ZIM2"'
+  type: gene
+- db_refs:
+    HGNC: '28357'
+  name: ZNF576
+  search_term: '"ZNF576"'
+  type: gene
+- db_refs:
+    HGNC: '33258'
+  name: ZNF814
+  search_term: '"ZNF814"'
+  type: gene
+- db_refs:
+    HGNC: '17726'
+  name: ZNRF4
+  search_term: '"ZNRF4"'
+  type: gene
+- db_refs:
+    HMS-LINCS: '10356'
+    LINCS: LSM-43344
+    PUBCHEM: '68810458'
+  name: 5z-7-oxozeaenol
+  search_term: '"5z-7-oxozeaenol"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91419
+    HMS-LINCS: '10158'
+    LINCS: LSM-1159
+    PUBCHEM: '16747683'
+  name: AZD 5438
+  search_term: '"AZD 5438"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:47344
+    CHEMBL: '428690'
+    HMS-LINCS: '10011'
+    LINCS: LSM-1011
+    PUBCHEM: '5287969'
+  name: Alvocidib
+  search_term: '"Alvocidib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:52717
+    HMS-LINCS: '10241'
+    LINCS: LSM-6281
+    PUBCHEM: '387447'
+  name: Bortezomib
+  search_term: '"Bortezomib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:61399
+    HMS-LINCS: '10120'
+    LINCS: LSM-1120
+    PUBCHEM: '156414'
+  name: Canertinib
+  search_term: '"Canertinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:64310
+    CHEMBL: '601719'
+    HMS-LINCS: '10027'
+    LINCS: LSM-1027
+    PUBCHEM: '11626560'
+  name: Crizotinib
+  search_term: '"Crizotinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91448
+    HMS-LINCS: '10202'
+    LINCS: LSM-1203
+    PUBCHEM: '6419753'
+  name: D 4476
+  search_term: '"D 4476"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:75045
+    HMS-LINCS: '10284'
+    LINCS: LSM-6303
+    PUBCHEM: '44462760'
+  name: Dabrafenib
+  search_term: '"Dabrafenib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:49375
+    CHEMBL: '1421'
+    HMS-LINCS: '10020'
+    LINCS: LSM-1020
+    PUBCHEM: '3062316'
+  name: Dasatinib
+  search_term: '"Dasatinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:78510
+    HMS-LINCS: '10399'
+    PUBCHEM: '11524144'
+  name: Dorsomorphin
+  search_term: '"Dorsomorphin"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10447'
+    PUBCHEM: '54766013'
+  name: EW-7197
+  search_term: '"EW-7197"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91408
+    HMS-LINCS: '10141'
+    LINCS: LSM-1142
+    PUBCHEM: '16722836'
+  name: Fedratinib
+  search_term: '"Fedratinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:137236
+    HMS-LINCS: '10509'
+    PUBCHEM: '132519'
+  name: GM6001
+  search_term: '"GM6001"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:93768
+    HMS-LINCS: '10255'
+    LINCS: LSM-4276
+    PUBCHEM: '25182616'
+  name: GSK1838705A
+  search_term: '"GSK1838705A"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:133818
+    HMS-LINCS: '10340'
+    LINCS: LSM-6343
+    PUBCHEM: '78357808'
+  name: HG-9-91-01
+  search_term: '"HG-9-91-01"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10192'
+    LINCS: LSM-42803
+    PUBCHEM: '67089852'
+  name: KW2449
+  search_term: '"KW2449"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91438
+    HMS-LINCS: '10187'
+    LINCS: LSM-1188
+    PUBCHEM: '57345770'
+  name: Ki20227
+  search_term: '"Ki20227"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91387
+    HMS-LINCS: '10115'
+    LINCS: LSM-1115
+    PUBCHEM: '25195294'
+  name: LDN-193189
+  search_term: '"LDN-193189"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10435'
+    PUBCHEM: '11655119'
+  name: LY2109761
+  search_term: '"LY2109761"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91471
+    HMS-LINCS: '10230'
+    LINCS: LSM-1231
+    PUBCHEM: '126565'
+  name: Lestaurtinib
+  search_term: '"Lestaurtinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91338
+    CHEMBL: '509032'
+    HMS-LINCS: '10024'
+    LINCS: LSM-1024
+    PUBCHEM: '16038120'
+  name: NVP-TAE684
+  search_term: '"NVP-TAE684"'
+  type: drug
+- db_refs:
+    CHEMBL: '180022'
+    HMS-LINCS: '10018'
+    LINCS: LSM-42778
+    PUBCHEM: '53398697'
+  name: Neratinib
+  search_term: '"Neratinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10151'
+    LINCS: LSM-1152
+    PUBCHEM: '56965894'
+  name: Nintedanib
+  search_term: '"Nintedanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95096
+    HMS-LINCS: '10268'
+    LINCS: LSM-6351
+    PUBCHEM: '11433190'
+  name: Nutlin 3a
+  search_term: '"Nutlin 3a"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91464
+    CHEMBL: '338448'
+    HMS-LINCS: '10220'
+    LINCS: LSM-1221
+    PUBCHEM: '16760627'
+  name: PKC412
+  search_term: '"PKC412"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90295
+    HMS-LINCS: '10049'
+    LINCS: LSM-1049
+    PUBCHEM: '24180719'
+  name: PLX-4720
+  search_term: '"PLX-4720"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:85993
+    CHEMBL: '189963'
+    HMS-LINCS: '10071'
+    LINCS: LSM-1071
+    PUBCHEM: '5330286'
+  name: Palbociclib
+  search_term: '"Palbociclib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:71219
+    HMS-LINCS: '10114'
+    LINCS: LSM-1114
+    PUBCHEM: '10113978'
+  name: Pazopanib
+  search_term: '"Pazopanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91348
+    HMS-LINCS: '10040'
+    LINCS: LSM-1040
+    PUBCHEM: '11213558'
+  name: R406
+  search_term: '"R406"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:92952
+    HMS-LINCS: '10441'
+    PUBCHEM: '5353940'
+  name: SB202190
+  search_term: '"SB202190"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91391
+    HMS-LINCS: '10121'
+    LINCS: LSM-1121
+    PUBCHEM: '9967941'
+  name: SB525334
+  search_term: '"SB525334"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91399
+    HMS-LINCS: '10132'
+    LINCS: LSM-1132
+    PUBCHEM: '3025986'
+  name: SNS-032
+  search_term: '"SNS-032"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90695
+    HMS-LINCS: '10162'
+    LINCS: LSM-1163
+    PUBCHEM: '8515'
+  name: SP600125
+  search_term: '"SP600125"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:15738
+    CHEMBL: '388978'
+    HMS-LINCS: '10103'
+    LINCS: LSM-1103
+    PUBCHEM: '44259'
+  name: Staurosporine
+  search_term: '"Staurosporine"'
+  type: drug
+- db_refs:
+    CHEMBL: '535'
+    HMS-LINCS: '10175'
+    LINCS: LSM-42800
+    PUBCHEM: '3086686'
+  name: Sunitinib
+  search_term: '"Sunitinib"'
+  type: drug

--- a/models/prad/config.yaml
+++ b/models/prad/config.yaml
@@ -1,288 +1,1685 @@
 ndex:
   network: caa8c3f6-f6a3-11e8-aaa6-0ac135e8bacf
 search_terms:
-- "A1CF"
-- "ALOX5AP"
-- "AR"
-- "BAGE2"
-- "BANF2"
-- "BCLAF1"
-- "BOLA2"
-- "BRAF"
-- "CA2"
-- "CACNG3"
-- "CCL11"
-- "CCL23"
-- "CCND2"
-- "CD1A"
-- "CD1B"
-- "CD1E"
-- "CD40LG"
-- "CD48"
-- "CDH11"
-- "CDH8"
-- "CDK12"
-- "CDK5"
-- "CDKN1A"
-- "CDKN1B"
-- "CELA3B"
-- "CHEK2"
-- "CLEC1A"
-- "CLEC9A"
-- "CNTN6"
-- "CNTNAP5"
-- "COX7A1"
-- "COX7A2"
-- "COX7C"
-- "CRYBB1"
-- "CSDC2"
-- "CST8"
-- "CTNNA2"
-- "CTNNB1"
-- "CTSC"
-- "CUL3"
-- "CUX1"
-- "CYP11B1"
-- "CYTIP"
-- "CYTL1"
-- "DCAF4L2"
-- "DCDC1"
-- "DDI1"
-- "DLX6"
-- "EDIL3"
-- "EFNA5"
-- "EIF1AX"
-- "ERF"
-- "ERG"
-- "ETV1"
-- "ETV4"
-- "FABP6"
-- "FHIT"
-- "FLRT2"
-- "FOLR3"
-- "FOXA1"
-- "GABRB1"
-- "GAD2"
-- "GAST"
-- "GNAS"
-- "GNGT1"
-- "GPATCH4"
-- "GRIA1"
-- "GRIN2A"
-- "GUCA1A"
-- "GYPB"
-- "GYPC"
-- "HCN1"
-- "HIST1H1A"
-- "HIST1H1C"
-- "HIST1H2BC"
-- "HIST1H2BN"
-- "HIST1H3B"
-- "HIST1H3C"
-- "HIST1H3F"
-- "HIST1H4H"
-- "HIST2H2AC"
-- "HIST2H2BE"
-- "HIST2H2BF"
-- "HIST2H4A"
-- "HOXB13"
-- "HOXD4"
-- "HRAS"
-- "HTR1E"
-- "IDH1"
-- "IFNA16"
-- "IL17A"
-- "JTB"
-- "KCNE3"
-- "KCTD16"
-- "KDM6A"
-- "KIF2B"
-- "KLK2"
-- "KLK3"
-- "KLK8"
-- "KRAS"
-- "KRTAP1-5"
-- "KRTAP13-3"
-- "KRTAP19-6"
-- "KRTAP23-1"
-- "KRTAP9-4"
-- "LCE1B"
-- "LCE1C"
-- "LCE2C"
-- "LCE5A"
-- "LEPROT"
-- "LGALS14"
-- "MACROD2"
-- "MGP"
-- "MORN4"
-- "MRGPRX1"
-- "MRPL14"
-- "MRPL23"
-- "MS4A13"
-- "MSC"
-- "MT-CO1"
-- "MT-CO2"
-- "MT-CYB"
-- "MT-ND1"
-- "MT-ND4"
-- "MT-ND4L"
-- "MT-ND5"
-- "MUC4"
-- "MYEOV"
-- "MYL1"
-- "NBPF1"
-- "NEU2"
-- "NHLH1"
-- "NHLH2"
-- "NKIRAS2"
-- "NKX3-1"
-- "NMUR2"
-- "NPS"
-- "NR2C2AP"
-- "NRXN2"
-- "NRXN3"
-- "NTM"
-- "NUDT11"
-- "OR10Z1"
-- "OR2M3"
-- "OR4C13"
-- "OR4C6"
-- "OR4D5"
-- "OR4N2"
-- "OR4P4"
-- "OR4S2"
-- "OR5AS1"
-- "PAEP"
-- "PAQR4"
-- "PAX5"
-- "PAX6"
-- "PCP4"
-- "PDGFD"
-- "PF4"
-- "PFN2"
-- "PI3"
-- "PID1"
-- "PIK3CA"
-- "PIK3R1"
-- "PMP22"
-- "PPP1R14C"
-- "PRM3"
-- "PTEN"
-- "PTH2"
-- "PYHIN1"
-- "RAB14"
-- "RB1"
-- "REEP1"
-- "RHOA"
-- "RNF152"
-- "RNF181"
-- "RPL11"
-- "RPL22"
-- "RPS5"
-- "RYBP"
-- "SELENOK"
-- "SF3B5"
-- "SMIM3"
-- "SOX17"
-- "SPOP"
-- "SPRR1A"
-- "TMPRSS2"
-- "TNP1"
-- "TP53"
-- "TPD52L3"
-- "TUBA3C"
-- "UQCR11"
-- "VAMP2"
-- "VAPA"
-- "XCL1"
-- "YPEL3"
-- "ZIC4"
-- "ZMAT4"
-- "(s)-CR8"
-- "A66"
-- "ALW-II-38-3"
-- "AS-252424"
-- "AS605240"
-- "AT-7519"
-- "AZ-628"
-- "AZD-6482"
-- "AZD7762"
-- "Alpelisib"
-- "Alvocidib"
-- "BAY61-3606"
-- "Bosutinib"
-- "Buparlisib"
-- "CAL-101"
-- "CGP60474"
-- "CGP74514A"
-- "CUDC-907"
-- "Celecoxib"
-- "Chk2 inhibitor II"
-- "Dabrafenib"
-- "Dactolisib"
-- "Dasatinib"
-- "Dinaciclib"
-- "Enzalutamide"
-- "Foretinib"
-- "GDC-0879"
-- "GDC-0980"
-- "GSK-J1"
-- "GSK-J4"
-- "GSK1059615"
-- "GSK1838705A"
-- "Gefitinib"
-- "Go 6976"
-- "HG-14-10-04"
-- "Imatinib"
-- "KIN001-111"
-- "KIN001-135"
-- "KW2449"
-- "L-779450"
-- "LY294002"
-- "Lestaurtinib"
-- "MK 1775"
-- "Motesanib"
-- "NU7441"
-- "NVP-BGT226"
-- "NVP-TAE226"
-- "NVP-TAE684"
-- "Neratinib"
-- "Nilotinib"
-- "Nutlin 3a"
-- "Olomoucine II"
-- "Omipalisib"
-- "PF562271"
-- "PHA-767491"
-- "PHA-793887"
-- "PI103"
-- "PI3K-IN-1"
-- "PIK-93"
-- "PLX-4720"
-- "Palbociclib"
-- "Pazopanib"
-- "Pictilisib"
-- "Purvalanol A"
-- "R406"
-- "RAF 265"
-- "RGB-286147"
-- "Regorafenib"
-- "Resveratrol"
-- "Rigosertib"
-- "SB 203580"
-- "SB590885"
-- "SNS-032"
-- "Seliciclib"
-- "Sorafenib"
-- "Staurosporine"
-- "Sulindac sulfide"
-- "Sunitinib"
-- "TAK-632"
-- "TPCA-1"
-- "Taselisib"
-- "Torin1"
-- "Torin2"
-- "Vemurafenib"
-- "XL147"
-- "XL765"
-- "XMD11-50"
-- "ZSTK474"
+- db_refs:
+    HGNC: '24086'
+  name: A1CF
+  search_term: '"A1CF"'
+  type: gene
+- db_refs:
+    HGNC: '436'
+  name: ALOX5AP
+  search_term: '"ALOX5AP"'
+  type: gene
+- db_refs:
+    HGNC: '644'
+  name: AR
+  search_term: '"AR"'
+  type: gene
+- db_refs:
+    HGNC: '15723'
+  name: BAGE2
+  search_term: '"BAGE2"'
+  type: gene
+- db_refs:
+    HGNC: '16172'
+  name: BANF2
+  search_term: '"BANF2"'
+  type: gene
+- db_refs:
+    HGNC: '16863'
+  name: BCLAF1
+  search_term: '"BCLAF1"'
+  type: gene
+- db_refs:
+    HGNC: '29488'
+  name: BOLA2
+  search_term: '"BOLA2"'
+  type: gene
+- db_refs:
+    HGNC: '1097'
+  name: BRAF
+  search_term: '"BRAF"'
+  type: gene
+- db_refs:
+    HGNC: '1373'
+  name: CA2
+  search_term: '"CA2"'
+  type: gene
+- db_refs:
+    HGNC: '1407'
+  name: CACNG3
+  search_term: '"CACNG3"'
+  type: gene
+- db_refs:
+    HGNC: '10610'
+  name: CCL11
+  search_term: '"CCL11"'
+  type: gene
+- db_refs:
+    HGNC: '10622'
+  name: CCL23
+  search_term: '"CCL23"'
+  type: gene
+- db_refs:
+    HGNC: '1583'
+  name: CCND2
+  search_term: '"CCND2"'
+  type: gene
+- db_refs:
+    HGNC: '1634'
+  name: CD1A
+  search_term: '"CD1A"'
+  type: gene
+- db_refs:
+    HGNC: '1635'
+  name: CD1B
+  search_term: '"CD1B"'
+  type: gene
+- db_refs:
+    HGNC: '1638'
+  name: CD1E
+  search_term: '"CD1E"'
+  type: gene
+- db_refs:
+    HGNC: '11935'
+  name: CD40LG
+  search_term: '"CD40LG"'
+  type: gene
+- db_refs:
+    HGNC: '1683'
+  name: CD48
+  search_term: '"CD48"'
+  type: gene
+- db_refs:
+    HGNC: '1750'
+  name: CDH11
+  search_term: '"CDH11"'
+  type: gene
+- db_refs:
+    HGNC: '1767'
+  name: CDH8
+  search_term: '"CDH8"'
+  type: gene
+- db_refs:
+    HGNC: '24224'
+  name: CDK12
+  search_term: '"CDK12"'
+  type: gene
+- db_refs:
+    HGNC: '1774'
+  name: CDK5
+  search_term: '"CDK5"'
+  type: gene
+- db_refs:
+    HGNC: '1784'
+  name: CDKN1A
+  search_term: '"CDKN1A"'
+  type: gene
+- db_refs:
+    HGNC: '1785'
+  name: CDKN1B
+  search_term: '"CDKN1B"'
+  type: gene
+- db_refs:
+    HGNC: '15945'
+  name: CELA3B
+  search_term: '"CELA3B"'
+  type: gene
+- db_refs:
+    HGNC: '16627'
+  name: CHEK2
+  search_term: '"CHEK2"'
+  type: gene
+- db_refs:
+    HGNC: '24355'
+  name: CLEC1A
+  search_term: '"CLEC1A"'
+  type: gene
+- db_refs:
+    HGNC: '26705'
+  name: CLEC9A
+  search_term: '"CLEC9A"'
+  type: gene
+- db_refs:
+    HGNC: '2176'
+  name: CNTN6
+  search_term: '"CNTN6"'
+  type: gene
+- db_refs:
+    HGNC: '18748'
+  name: CNTNAP5
+  search_term: '"CNTNAP5"'
+  type: gene
+- db_refs:
+    HGNC: '2287'
+  name: COX7A1
+  search_term: '"COX7A1"'
+  type: gene
+- db_refs:
+    HGNC: '2288'
+  name: COX7A2
+  search_term: '"COX7A2"'
+  type: gene
+- db_refs:
+    HGNC: '2292'
+  name: COX7C
+  search_term: '"COX7C"'
+  type: gene
+- db_refs:
+    HGNC: '2397'
+  name: CRYBB1
+  search_term: '"CRYBB1"'
+  type: gene
+- db_refs:
+    HGNC: '30359'
+  name: CSDC2
+  search_term: '"CSDC2"'
+  type: gene
+- db_refs:
+    HGNC: '2480'
+  name: CST8
+  search_term: '"CST8"'
+  type: gene
+- db_refs:
+    HGNC: '2510'
+  name: CTNNA2
+  search_term: '"CTNNA2"'
+  type: gene
+- db_refs:
+    HGNC: '2514'
+  name: CTNNB1
+  search_term: '"CTNNB1"'
+  type: gene
+- db_refs:
+    HGNC: '2528'
+  name: CTSC
+  search_term: '"CTSC"'
+  type: gene
+- db_refs:
+    HGNC: '2553'
+  name: CUL3
+  search_term: '"CUL3"'
+  type: gene
+- db_refs:
+    HGNC: '2557'
+  name: CUX1
+  search_term: '"CUX1"'
+  type: gene
+- db_refs:
+    HGNC: '2591'
+  name: CYP11B1
+  search_term: '"CYP11B1"'
+  type: gene
+- db_refs:
+    HGNC: '9506'
+  name: CYTIP
+  search_term: '"CYTIP"'
+  type: gene
+- db_refs:
+    HGNC: '24435'
+  name: CYTL1
+  search_term: '"CYTL1"'
+  type: gene
+- db_refs:
+    HGNC: '26657'
+  name: DCAF4L2
+  search_term: '"DCAF4L2"'
+  type: gene
+- db_refs:
+    HGNC: '20625'
+  name: DCDC1
+  search_term: '"DCDC1"'
+  type: gene
+- db_refs:
+    HGNC: '18961'
+  name: DDI1
+  search_term: '"DDI1"'
+  type: gene
+- db_refs:
+    HGNC: '2919'
+  name: DLX6
+  search_term: '"DLX6"'
+  type: gene
+- db_refs:
+    HGNC: '3173'
+  name: EDIL3
+  search_term: '"EDIL3"'
+  type: gene
+- db_refs:
+    HGNC: '3225'
+  name: EFNA5
+  search_term: '"EFNA5"'
+  type: gene
+- db_refs:
+    HGNC: '3250'
+  name: EIF1AX
+  search_term: '"EIF1AX"'
+  type: gene
+- db_refs:
+    HGNC: '3444'
+  name: ERF
+  search_term: '"ERF"'
+  type: gene
+- db_refs:
+    HGNC: '3446'
+  name: ERG
+  search_term: '"ERG"'
+  type: gene
+- db_refs:
+    HGNC: '3490'
+  name: ETV1
+  search_term: '"ETV1"'
+  type: gene
+- db_refs:
+    HGNC: '3493'
+  name: ETV4
+  search_term: '"ETV4"'
+  type: gene
+- db_refs:
+    HGNC: '3561'
+  name: FABP6
+  search_term: '"FABP6"'
+  type: gene
+- db_refs:
+    HGNC: '3701'
+  name: FHIT
+  search_term: '"FHIT"'
+  type: gene
+- db_refs:
+    HGNC: '3761'
+  name: FLRT2
+  search_term: '"FLRT2"'
+  type: gene
+- db_refs:
+    HGNC: '3795'
+  name: FOLR3
+  search_term: '"FOLR3"'
+  type: gene
+- db_refs:
+    HGNC: '5021'
+  name: FOXA1
+  search_term: '"FOXA1"'
+  type: gene
+- db_refs:
+    HGNC: '4081'
+  name: GABRB1
+  search_term: '"GABRB1"'
+  type: gene
+- db_refs:
+    HGNC: '4093'
+  name: GAD2
+  search_term: '"GAD2"'
+  type: gene
+- db_refs:
+    HGNC: '4164'
+  name: GAST
+  search_term: '"GAST"'
+  type: gene
+- db_refs:
+    HGNC: '4392'
+  name: GNAS
+  search_term: '"GNAS"'
+  type: gene
+- db_refs:
+    HGNC: '4411'
+  name: GNGT1
+  search_term: '"GNGT1"'
+  type: gene
+- db_refs:
+    HGNC: '25982'
+  name: GPATCH4
+  search_term: '"GPATCH4"'
+  type: gene
+- db_refs:
+    HGNC: '4571'
+  name: GRIA1
+  search_term: '"GRIA1"'
+  type: gene
+- db_refs:
+    HGNC: '4585'
+  name: GRIN2A
+  search_term: '"GRIN2A"'
+  type: gene
+- db_refs:
+    HGNC: '4678'
+  name: GUCA1A
+  search_term: '"GUCA1A"'
+  type: gene
+- db_refs:
+    HGNC: '4703'
+  name: GYPB
+  search_term: '"GYPB"'
+  type: gene
+- db_refs:
+    HGNC: '4704'
+  name: GYPC
+  search_term: '"GYPC"'
+  type: gene
+- db_refs:
+    HGNC: '4845'
+  name: HCN1
+  search_term: '"HCN1"'
+  type: gene
+- db_refs:
+    HGNC: '4715'
+  name: HIST1H1A
+  search_term: '"HIST1H1A"'
+  type: gene
+- db_refs:
+    HGNC: '4716'
+  name: HIST1H1C
+  search_term: '"HIST1H1C"'
+  type: gene
+- db_refs:
+    HGNC: '4757'
+  name: HIST1H2BC
+  search_term: '"HIST1H2BC"'
+  type: gene
+- db_refs:
+    HGNC: '4749'
+  name: HIST1H2BN
+  search_term: '"HIST1H2BN"'
+  type: gene
+- db_refs:
+    HGNC: '4776'
+  name: HIST1H3B
+  search_term: '"HIST1H3B"'
+  type: gene
+- db_refs:
+    HGNC: '4768'
+  name: HIST1H3C
+  search_term: '"HIST1H3C"'
+  type: gene
+- db_refs:
+    HGNC: '4773'
+  name: HIST1H3F
+  search_term: '"HIST1H3F"'
+  type: gene
+- db_refs:
+    HGNC: '4788'
+  name: HIST1H4H
+  search_term: '"HIST1H4H"'
+  type: gene
+- db_refs:
+    HGNC: '4738'
+  name: HIST2H2AC
+  search_term: '"HIST2H2AC"'
+  type: gene
+- db_refs:
+    HGNC: '4760'
+  name: HIST2H2BE
+  search_term: '"HIST2H2BE"'
+  type: gene
+- db_refs:
+    HGNC: '24700'
+  name: HIST2H2BF
+  search_term: '"HIST2H2BF"'
+  type: gene
+- db_refs:
+    HGNC: '4794'
+  name: HIST2H4A
+  search_term: '"HIST2H4A"'
+  type: gene
+- db_refs:
+    HGNC: '5112'
+  name: HOXB13
+  search_term: '"HOXB13"'
+  type: gene
+- db_refs:
+    HGNC: '5138'
+  name: HOXD4
+  search_term: '"HOXD4"'
+  type: gene
+- db_refs:
+    HGNC: '5173'
+  name: HRAS
+  search_term: '"HRAS"'
+  type: gene
+- db_refs:
+    HGNC: '5291'
+  name: HTR1E
+  search_term: '"HTR1E"'
+  type: gene
+- db_refs:
+    HGNC: '5382'
+  name: IDH1
+  search_term: '"IDH1"'
+  type: gene
+- db_refs:
+    HGNC: '5421'
+  name: IFNA16
+  search_term: '"IFNA16"'
+  type: gene
+- db_refs:
+    HGNC: '5981'
+  name: IL17A
+  search_term: '"IL17A"'
+  type: gene
+- db_refs:
+    HGNC: '6201'
+  name: JTB
+  search_term: '"JTB"'
+  type: gene
+- db_refs:
+    HGNC: '6243'
+  name: KCNE3
+  search_term: '"KCNE3"'
+  type: gene
+- db_refs:
+    HGNC: '29244'
+  name: KCTD16
+  search_term: '"KCTD16"'
+  type: gene
+- db_refs:
+    HGNC: '12637'
+  name: KDM6A
+  search_term: '"KDM6A"'
+  type: gene
+- db_refs:
+    HGNC: '29443'
+  name: KIF2B
+  search_term: '"KIF2B"'
+  type: gene
+- db_refs:
+    HGNC: '6363'
+  name: KLK2
+  search_term: '"KLK2"'
+  type: gene
+- db_refs:
+    HGNC: '6364'
+  name: KLK3
+  search_term: '"KLK3"'
+  type: gene
+- db_refs:
+    HGNC: '6369'
+  name: KLK8
+  search_term: '"KLK8"'
+  type: gene
+- db_refs:
+    HGNC: '6407'
+  name: KRAS
+  search_term: '"KRAS"'
+  type: gene
+- db_refs:
+    HGNC: '16777'
+  name: KRTAP1-5
+  search_term: '"KRTAP1-5"'
+  type: gene
+- db_refs:
+    HGNC: '18925'
+  name: KRTAP13-3
+  search_term: '"KRTAP13-3"'
+  type: gene
+- db_refs:
+    HGNC: '18941'
+  name: KRTAP19-6
+  search_term: '"KRTAP19-6"'
+  type: gene
+- db_refs:
+    HGNC: '18928'
+  name: KRTAP23-1
+  search_term: '"KRTAP23-1"'
+  type: gene
+- db_refs:
+    HGNC: '18902'
+  name: KRTAP9-4
+  search_term: '"KRTAP9-4"'
+  type: gene
+- db_refs:
+    HGNC: '16611'
+  name: LCE1B
+  search_term: '"LCE1B"'
+  type: gene
+- db_refs:
+    HGNC: '29464'
+  name: LCE1C
+  search_term: '"LCE1C"'
+  type: gene
+- db_refs:
+    HGNC: '29460'
+  name: LCE2C
+  search_term: '"LCE2C"'
+  type: gene
+- db_refs:
+    HGNC: '16614'
+  name: LCE5A
+  search_term: '"LCE5A"'
+  type: gene
+- db_refs:
+    HGNC: '29477'
+  name: LEPROT
+  search_term: '"LEPROT"'
+  type: gene
+- db_refs:
+    HGNC: '30054'
+  name: LGALS14
+  search_term: '"LGALS14"'
+  type: gene
+- db_refs:
+    HGNC: '16126'
+  name: MACROD2
+  search_term: '"MACROD2"'
+  type: gene
+- db_refs:
+    HGNC: '7060'
+  name: MGP
+  search_term: '"MGP"'
+  type: gene
+- db_refs:
+    HGNC: '24001'
+  name: MORN4
+  search_term: '"MORN4"'
+  type: gene
+- db_refs:
+    HGNC: '17962'
+  name: MRGPRX1
+  search_term: '"MRGPRX1"'
+  type: gene
+- db_refs:
+    HGNC: '14279'
+  name: MRPL14
+  search_term: '"MRPL14"'
+  type: gene
+- db_refs:
+    HGNC: '10322'
+  name: MRPL23
+  search_term: '"MRPL23"'
+  type: gene
+- db_refs:
+    HGNC: '16674'
+  name: MS4A13
+  search_term: '"MS4A13"'
+  type: gene
+- db_refs:
+    HGNC: '7321'
+  name: MSC
+  search_term: '"MSC"'
+  type: gene
+- db_refs:
+    HGNC: '7419'
+  name: MT-CO1
+  search_term: '"MT-CO1"'
+  type: gene
+- db_refs:
+    HGNC: '7421'
+  name: MT-CO2
+  search_term: '"MT-CO2"'
+  type: gene
+- db_refs:
+    HGNC: '7427'
+  name: MT-CYB
+  search_term: '"MT-CYB"'
+  type: gene
+- db_refs:
+    HGNC: '7455'
+  name: MT-ND1
+  search_term: '"MT-ND1"'
+  type: gene
+- db_refs:
+    HGNC: '7459'
+  name: MT-ND4
+  search_term: '"MT-ND4"'
+  type: gene
+- db_refs:
+    HGNC: '7460'
+  name: MT-ND4L
+  search_term: '"MT-ND4L"'
+  type: gene
+- db_refs:
+    HGNC: '7461'
+  name: MT-ND5
+  search_term: '"MT-ND5"'
+  type: gene
+- db_refs:
+    HGNC: '7514'
+  name: MUC4
+  search_term: '"MUC4"'
+  type: gene
+- db_refs:
+    HGNC: '7563'
+  name: MYEOV
+  search_term: '"MYEOV"'
+  type: gene
+- db_refs:
+    HGNC: '7582'
+  name: MYL1
+  search_term: '"MYL1"'
+  type: gene
+- db_refs:
+    HGNC: '26088'
+  name: NBPF1
+  search_term: '"NBPF1"'
+  type: gene
+- db_refs:
+    HGNC: '7759'
+  name: NEU2
+  search_term: '"NEU2"'
+  type: gene
+- db_refs:
+    HGNC: '7817'
+  name: NHLH1
+  search_term: '"NHLH1"'
+  type: gene
+- db_refs:
+    HGNC: '7818'
+  name: NHLH2
+  search_term: '"NHLH2"'
+  type: gene
+- db_refs:
+    HGNC: '17898'
+  name: NKIRAS2
+  search_term: '"NKIRAS2"'
+  type: gene
+- db_refs:
+    HGNC: '7838'
+  name: NKX3-1
+  search_term: '"NKX3-1"'
+  type: gene
+- db_refs:
+    HGNC: '16454'
+  name: NMUR2
+  search_term: '"NMUR2"'
+  type: gene
+- db_refs:
+    HGNC: '33940'
+  name: NPS
+  search_term: '"NPS"'
+  type: gene
+- db_refs:
+    HGNC: '30763'
+  name: NR2C2AP
+  search_term: '"NR2C2AP"'
+  type: gene
+- db_refs:
+    HGNC: '8009'
+  name: NRXN2
+  search_term: '"NRXN2"'
+  type: gene
+- db_refs:
+    HGNC: '8010'
+  name: NRXN3
+  search_term: '"NRXN3"'
+  type: gene
+- db_refs:
+    HGNC: '17941'
+  name: NTM
+  search_term: '"NTM"'
+  type: gene
+- db_refs:
+    HGNC: '18011'
+  name: NUDT11
+  search_term: '"NUDT11"'
+  type: gene
+- db_refs:
+    HGNC: '14996'
+  name: OR10Z1
+  search_term: '"OR10Z1"'
+  type: gene
+- db_refs:
+    HGNC: '8269'
+  name: OR2M3
+  search_term: '"OR2M3"'
+  type: gene
+- db_refs:
+    HGNC: '15169'
+  name: OR4C13
+  search_term: '"OR4C13"'
+  type: gene
+- db_refs:
+    HGNC: '14743'
+  name: OR4C6
+  search_term: '"OR4C6"'
+  type: gene
+- db_refs:
+    HGNC: '14852'
+  name: OR4D5
+  search_term: '"OR4D5"'
+  type: gene
+- db_refs:
+    HGNC: '14742'
+  name: OR4N2
+  search_term: '"OR4N2"'
+  type: gene
+- db_refs:
+    HGNC: '15180'
+  name: OR4P4
+  search_term: '"OR4P4"'
+  type: gene
+- db_refs:
+    HGNC: '15183'
+  name: OR4S2
+  search_term: '"OR4S2"'
+  type: gene
+- db_refs:
+    HGNC: '15261'
+  name: OR5AS1
+  search_term: '"OR5AS1"'
+  type: gene
+- db_refs:
+    HGNC: '8573'
+  name: PAEP
+  search_term: '"PAEP"'
+  type: gene
+- db_refs:
+    HGNC: '26386'
+  name: PAQR4
+  search_term: '"PAQR4"'
+  type: gene
+- db_refs:
+    HGNC: '8619'
+  name: PAX5
+  search_term: '"PAX5"'
+  type: gene
+- db_refs:
+    HGNC: '8620'
+  name: PAX6
+  search_term: '"PAX6"'
+  type: gene
+- db_refs:
+    HGNC: '8742'
+  name: PCP4
+  search_term: '"PCP4"'
+  type: gene
+- db_refs:
+    HGNC: '30620'
+  name: PDGFD
+  search_term: '"PDGFD"'
+  type: gene
+- db_refs:
+    HGNC: '8861'
+  name: PF4
+  search_term: '"PF4"'
+  type: gene
+- db_refs:
+    HGNC: '8882'
+  name: PFN2
+  search_term: '"PFN2"'
+  type: gene
+- db_refs:
+    HGNC: '8947'
+  name: PI3
+  search_term: '"PI3"'
+  type: gene
+- db_refs:
+    HGNC: '26084'
+  name: PID1
+  search_term: '"PID1"'
+  type: gene
+- db_refs:
+    HGNC: '8975'
+  name: PIK3CA
+  search_term: '"PIK3CA"'
+  type: gene
+- db_refs:
+    HGNC: '8979'
+  name: PIK3R1
+  search_term: '"PIK3R1"'
+  type: gene
+- db_refs:
+    HGNC: '9118'
+  name: PMP22
+  search_term: '"PMP22"'
+  type: gene
+- db_refs:
+    HGNC: '14952'
+  name: PPP1R14C
+  search_term: '"PPP1R14C"'
+  type: gene
+- db_refs:
+    HGNC: '13732'
+  name: PRM3
+  search_term: '"PRM3"'
+  type: gene
+- db_refs:
+    HGNC: '9588'
+  name: PTEN
+  search_term: '"PTEN"'
+  type: gene
+- db_refs:
+    HGNC: '30828'
+  name: PTH2
+  search_term: '"PTH2"'
+  type: gene
+- db_refs:
+    HGNC: '28894'
+  name: PYHIN1
+  search_term: '"PYHIN1"'
+  type: gene
+- db_refs:
+    HGNC: '16524'
+  name: RAB14
+  search_term: '"RAB14"'
+  type: gene
+- db_refs:
+    HGNC: '9884'
+  name: RB1
+  search_term: '"RB1"'
+  type: gene
+- db_refs:
+    HGNC: '25786'
+  name: REEP1
+  search_term: '"REEP1"'
+  type: gene
+- db_refs:
+    HGNC: '667'
+  name: RHOA
+  search_term: '"RHOA"'
+  type: gene
+- db_refs:
+    HGNC: '26811'
+  name: RNF152
+  search_term: '"RNF152"'
+  type: gene
+- db_refs:
+    HGNC: '28037'
+  name: RNF181
+  search_term: '"RNF181"'
+  type: gene
+- db_refs:
+    HGNC: '10301'
+  name: RPL11
+  search_term: '"RPL11"'
+  type: gene
+- db_refs:
+    HGNC: '10315'
+  name: RPL22
+  search_term: '"RPL22"'
+  type: gene
+- db_refs:
+    HGNC: '10426'
+  name: RPS5
+  search_term: '"RPS5"'
+  type: gene
+- db_refs:
+    HGNC: '10480'
+  name: RYBP
+  search_term: '"RYBP"'
+  type: gene
+- db_refs:
+    HGNC: '30394'
+  name: SELENOK
+  search_term: '"SELENOK"'
+  type: gene
+- db_refs:
+    HGNC: '21083'
+  name: SF3B5
+  search_term: '"SF3B5"'
+  type: gene
+- db_refs:
+    HGNC: '30248'
+  name: SMIM3
+  search_term: '"SMIM3"'
+  type: gene
+- db_refs:
+    HGNC: '18122'
+  name: SOX17
+  search_term: '"SOX17"'
+  type: gene
+- db_refs:
+    HGNC: '11254'
+  name: SPOP
+  search_term: '"SPOP"'
+  type: gene
+- db_refs:
+    HGNC: '11259'
+  name: SPRR1A
+  search_term: '"SPRR1A"'
+  type: gene
+- db_refs:
+    HGNC: '11876'
+  name: TMPRSS2
+  search_term: '"TMPRSS2"'
+  type: gene
+- db_refs:
+    HGNC: '11951'
+  name: TNP1
+  search_term: '"TNP1"'
+  type: gene
+- db_refs:
+    HGNC: '11998'
+  name: TP53
+  search_term: '"TP53"'
+  type: gene
+- db_refs:
+    HGNC: '23382'
+  name: TPD52L3
+  search_term: '"TPD52L3"'
+  type: gene
+- db_refs:
+    HGNC: '12408'
+  name: TUBA3C
+  search_term: '"TUBA3C"'
+  type: gene
+- db_refs:
+    HGNC: '30862'
+  name: UQCR11
+  search_term: '"UQCR11"'
+  type: gene
+- db_refs:
+    HGNC: '12643'
+  name: VAMP2
+  search_term: '"VAMP2"'
+  type: gene
+- db_refs:
+    HGNC: '12648'
+  name: VAPA
+  search_term: '"VAPA"'
+  type: gene
+- db_refs:
+    HGNC: '10645'
+  name: XCL1
+  search_term: '"XCL1"'
+  type: gene
+- db_refs:
+    HGNC: '18327'
+  name: YPEL3
+  search_term: '"YPEL3"'
+  type: gene
+- db_refs:
+    HGNC: '20393'
+  name: ZIC4
+  search_term: '"ZIC4"'
+  type: gene
+- db_refs:
+    HGNC: '25844'
+  name: ZMAT4
+  search_term: '"ZMAT4"'
+  type: gene
+- db_refs:
+    CHEBI: CHEBI:95340
+    HMS-LINCS: '10350'
+    LINCS: LSM-6707
+    PUBCHEM: '25211051'
+  name: (s)-CR8
+  search_term: '"(s)-CR8"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91449
+    HMS-LINCS: '10203'
+    LINCS: LSM-1204
+    PUBCHEM: '42636535'
+  name: A66
+  search_term: '"A66"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91324
+    HMS-LINCS: '10002'
+    LINCS: LSM-1002
+    PUBCHEM: '24880028'
+  name: ALW-II-38-3
+  search_term: '"ALW-II-38-3"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10240'
+    LINCS: LSM-4263
+    PUBCHEM: '56965900'
+  name: AS-252424
+  search_term: '"AS-252424"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10054'
+    LINCS: LSM-42784
+    PUBCHEM: '24906273'
+  name: AS605240
+  search_term: '"AS605240"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91326
+    CHEMBL: '445813'
+    HMS-LINCS: '10004'
+    LINCS: LSM-1004
+    PUBCHEM: '11338033'
+  name: AT-7519
+  search_term: '"AT-7519"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91354
+    HMS-LINCS: '10050'
+    LINCS: LSM-1050
+    PUBCHEM: '11676786'
+  name: AZ-628
+  search_term: '"AZ-628"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91359
+    HMS-LINCS: '10059'
+    LINCS: LSM-1059
+    PUBCHEM: '44137675'
+  name: AZD-6482
+  search_term: '"AZD-6482"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91328
+    HMS-LINCS: '10006'
+    LINCS: LSM-1006
+    PUBCHEM: '67077825'
+  name: AZD7762
+  search_term: '"AZD7762"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:93752
+    HMS-LINCS: '10233'
+    LINCS: LSM-4256
+    PUBCHEM: '56649450'
+  name: Alpelisib
+  search_term: '"Alpelisib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:47344
+    CHEMBL: '428690'
+    HMS-LINCS: '10011'
+    LINCS: LSM-1011
+    PUBCHEM: '5287969'
+  name: Alvocidib
+  search_term: '"Alvocidib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91426
+    CHEMBL: '1190711'
+    HMS-LINCS: '10166'
+    LINCS: LSM-1167
+    PUBCHEM: '10200390'
+  name: BAY61-3606
+  search_term: '"BAY61-3606"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:39112
+    HMS-LINCS: '10189'
+    LINCS: LSM-1190
+    PUBCHEM: '5328940'
+  name: Bosutinib
+  search_term: '"Bosutinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:71954
+    HMS-LINCS: '10147'
+    LINCS: LSM-1148
+    PUBCHEM: '16654980'
+  name: Buparlisib
+  search_term: '"Buparlisib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:82701
+    HMS-LINCS: '10204'
+    LINCS: LSM-1205
+    PUBCHEM: '11625818'
+  name: CAL-101
+  search_term: '"CAL-101"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91339
+    CHEMBL: '300389'
+    HMS-LINCS: '10025'
+    LINCS: LSM-1025
+    PUBCHEM: '644215'
+  name: CGP60474
+  search_term: '"CGP60474"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95342
+    HMS-LINCS: '10355'
+    LINCS: LSM-6711
+    PUBCHEM: '9908173'
+  name: CGP74514A
+  search_term: '"CGP74514A"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10371'
+    PUBCHEM: '54575456'
+  name: CUDC-907
+  search_term: '"CUDC-907"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:41423
+    HMS-LINCS: '10503'
+    PUBCHEM: '2662'
+  name: Celecoxib
+  search_term: '"Celecoxib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10504'
+    PUBCHEM: '9969021'
+  name: Chk2 inhibitor II
+  search_term: '"Chk2 inhibitor II"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:75045
+    HMS-LINCS: '10284'
+    LINCS: LSM-6303
+    PUBCHEM: '44462760'
+  name: Dabrafenib
+  search_term: '"Dabrafenib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:71952
+    HMS-LINCS: '10232'
+    LINCS: LSM-4255
+    PUBCHEM: '11977753'
+  name: Dactolisib
+  search_term: '"Dactolisib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:49375
+    CHEMBL: '1421'
+    HMS-LINCS: '10020'
+    LINCS: LSM-1020
+    PUBCHEM: '3062316'
+  name: Dasatinib
+  search_term: '"Dasatinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95060
+    HMS-LINCS: '10287'
+    LINCS: LSM-6306
+    PUBCHEM: '46926350'
+  name: Dinaciclib
+  search_term: '"Dinaciclib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:68534
+    HMS-LINCS: '10353'
+    LINCS: LSM-6254
+    PUBCHEM: '15951529'
+  name: Enzalutamide
+  search_term: '"Enzalutamide"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91418
+    HMS-LINCS: '10157'
+    LINCS: LSM-1158
+    PUBCHEM: '42642645'
+  name: Foretinib
+  search_term: '"Foretinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10181'
+    LINCS: LSM-42801
+    PUBCHEM: '57519545'
+  name: GDC-0879
+  search_term: '"GDC-0879"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:93753
+    HMS-LINCS: '10234'
+    LINCS: LSM-4257
+    PUBCHEM: '66694608'
+  name: GDC-0980
+  search_term: '"GDC-0980"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10321'
+    LINCS: LSM-44939
+  name: GSK-J1
+  search_term: '"GSK-J1"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95077
+    HMS-LINCS: '10323'
+    LINCS: LSM-6328
+    PUBCHEM: '71729975'
+  name: GSK-J4
+  search_term: '"GSK-J4"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10172'
+    LINCS: LSM-1173
+    PUBCHEM: '71317162'
+  name: GSK1059615
+  search_term: '"GSK1059615"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:93768
+    HMS-LINCS: '10255'
+    LINCS: LSM-4276
+    PUBCHEM: '25182616'
+  name: GSK1838705A
+  search_term: '"GSK1838705A"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:49668
+    HMS-LINCS: '10098'
+    LINCS: LSM-1098
+    PUBCHEM: '123631'
+  name: Gefitinib
+  search_term: '"Gefitinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:51913
+    CHEMBL: '302449'
+    HMS-LINCS: '10210'
+    LINCS: LSM-1211
+    PUBCHEM: '3501'
+  name: Go 6976
+  search_term: '"Go 6976"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95092
+    HMS-LINCS: '10342'
+    LINCS: LSM-6345
+    PUBCHEM: '56655374'
+  name: HG-14-10-04
+  search_term: '"HG-14-10-04"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:45783
+    CHEMBL: '941'
+    HMS-LINCS: '10023'
+    LINCS: LSM-1023
+    PUBCHEM: '5291'
+  name: Imatinib
+  search_term: '"Imatinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91457
+    CHEMBL: '197603'
+    HMS-LINCS: '10213'
+    LINCS: LSM-1214
+    PUBCHEM: '9549184'
+  name: KIN001-111
+  search_term: '"KIN001-111"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91459
+    CHEMBL: '373751'
+    HMS-LINCS: '10215'
+    LINCS: LSM-1216
+    PUBCHEM: '11626927'
+  name: KIN001-135
+  search_term: '"KIN001-135"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10192'
+    LINCS: LSM-42803
+    PUBCHEM: '67089852'
+  name: KW2449
+  search_term: '"KW2449"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:93773
+    HMS-LINCS: '10262'
+    LINCS: LSM-4283
+    PUBCHEM: '9950176'
+  name: L-779450
+  search_term: '"L-779450"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:65329
+    HMS-LINCS: '10510'
+    PUBCHEM: '3973'
+  name: LY294002
+  search_term: '"LY294002"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91471
+    HMS-LINCS: '10230'
+    LINCS: LSM-1231
+    PUBCHEM: '126565'
+  name: Lestaurtinib
+  search_term: '"Lestaurtinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91414
+    HMS-LINCS: '10152'
+    LINCS: LSM-1153
+    PUBCHEM: '24856436'
+  name: MK 1775
+  search_term: '"MK 1775"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:51098
+    HMS-LINCS: '10042'
+    LINCS: LSM-1042
+    PUBCHEM: '11667893'
+  name: Motesanib
+  search_term: '"Motesanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91361
+    CHEMBL: '188678'
+    HMS-LINCS: '10061'
+    LINCS: LSM-1061
+    PUBCHEM: '11327430'
+  name: NU7441
+  search_term: '"NU7441"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10349'
+    LINCS: LSM-6710
+  name: NVP-BGT226
+  search_term: '"NVP-BGT226"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91452
+    HMS-LINCS: '10207'
+    LINCS: LSM-1208
+    PUBCHEM: '9934347'
+  name: NVP-TAE226
+  search_term: '"NVP-TAE226"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91338
+    CHEMBL: '509032'
+    HMS-LINCS: '10024'
+    LINCS: LSM-1024
+    PUBCHEM: '16038120'
+  name: NVP-TAE684
+  search_term: '"NVP-TAE684"'
+  type: drug
+- db_refs:
+    CHEMBL: '180022'
+    HMS-LINCS: '10018'
+    LINCS: LSM-42778
+    PUBCHEM: '53398697'
+  name: Neratinib
+  search_term: '"Neratinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:52172
+    CHEMBL: '255863'
+    HMS-LINCS: '10099'
+    LINCS: LSM-1099
+    PUBCHEM: '644241'
+  name: Nilotinib
+  search_term: '"Nilotinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95096
+    HMS-LINCS: '10268'
+    LINCS: LSM-6351
+    PUBCHEM: '11433190'
+  name: Nutlin 3a
+  search_term: '"Nutlin 3a"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95098
+    HMS-LINCS: '10344'
+    LINCS: LSM-6356
+    PUBCHEM: '10067756'
+  name: Olomoucine II
+  search_term: '"Olomoucine II"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95093
+    HMS-LINCS: '10146'
+    LINCS: LSM-1147
+    PUBCHEM: '25167777'
+  name: Omipalisib
+  search_term: '"Omipalisib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91370
+    HMS-LINCS: '10072'
+    LINCS: LSM-1072
+    PUBCHEM: '11713159'
+  name: PF562271
+  search_term: '"PF562271"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95058
+    HMS-LINCS: '10285'
+    LINCS: LSM-6304
+    PUBCHEM: '11715767'
+  name: PHA-767491
+  search_term: '"PHA-767491"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91371
+    HMS-LINCS: '10073'
+    LINCS: LSM-1073
+    PUBCHEM: '46191454'
+  name: PHA-793887
+  search_term: '"PHA-793887"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90524
+    CHEMBL: '538346'
+    HMS-LINCS: '10126'
+    LINCS: LSM-1126
+    PUBCHEM: '9884685'
+  name: PI103
+  search_term: '"PI103"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:71958
+    HMS-LINCS: '10173'
+    LINCS: LSM-1174
+    PUBCHEM: '49867926'
+  name: PI3K-IN-1
+  search_term: '"PI3K-IN-1"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10190'
+    LINCS: LSM-1191
+    PUBCHEM: '6852167'
+  name: PIK-93
+  search_term: '"PIK-93"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90295
+    HMS-LINCS: '10049'
+    LINCS: LSM-1049
+    PUBCHEM: '24180719'
+  name: PLX-4720
+  search_term: '"PLX-4720"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:85993
+    CHEMBL: '189963'
+    HMS-LINCS: '10071'
+    LINCS: LSM-1071
+    PUBCHEM: '5330286'
+  name: Palbociclib
+  search_term: '"Palbociclib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:71219
+    HMS-LINCS: '10114'
+    LINCS: LSM-1114
+    PUBCHEM: '10113978'
+  name: Pazopanib
+  search_term: '"Pazopanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:65326
+    CHEMBL: '521851'
+    HMS-LINCS: '10047'
+    LINCS: LSM-1047
+    PUBCHEM: '17755052'
+  name: Pictilisib
+  search_term: '"Pictilisib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:47600
+    HMS-LINCS: '10273'
+    LINCS: LSM-3118
+    PUBCHEM: '456214'
+  name: Purvalanol A
+  search_term: '"Purvalanol A"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91348
+    HMS-LINCS: '10040'
+    LINCS: LSM-1040
+    PUBCHEM: '11213558'
+  name: R406
+  search_term: '"R406"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91451
+    HMS-LINCS: '10206'
+    LINCS: LSM-1207
+    PUBCHEM: '11656518'
+  name: RAF 265
+  search_term: '"RAF 265"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10468'
+    PUBCHEM: '9549301'
+  name: RGB-286147
+  search_term: '"RGB-286147"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:68647
+    HMS-LINCS: '10225'
+    LINCS: LSM-1226
+    PUBCHEM: '11167602'
+  name: Regorafenib
+  search_term: '"Regorafenib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:45713
+    HMS-LINCS: '10318'
+    LINCS: LSM-42917
+    PUBCHEM: '445154'
+  name: Resveratrol
+  search_term: '"Resveratrol"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10184'
+    LINCS: LSM-44954
+  name: Rigosertib
+  search_term: '"Rigosertib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90705
+    HMS-LINCS: '10167'
+    LINCS: LSM-1168
+    PUBCHEM: '176155'
+  name: SB 203580
+  search_term: '"SB 203580"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10046'
+    LINCS: LSM-42746
+    PUBCHEM: '53239990'
+  name: SB590885
+  search_term: '"SB590885"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91399
+    HMS-LINCS: '10132'
+    LINCS: LSM-1132
+    PUBCHEM: '3025986'
+  name: SNS-032
+  search_term: '"SNS-032"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:45307
+    CHEMBL: '14762'
+    HMS-LINCS: '10001'
+    LINCS: LSM-1001
+    PUBCHEM: '160355'
+  name: Seliciclib
+  search_term: '"Seliciclib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:50924
+    CHEMBL: '1336'
+    HMS-LINCS: '10008'
+    LINCS: LSM-1008
+    PUBCHEM: '216239'
+  name: Sorafenib
+  search_term: '"Sorafenib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:15738
+    CHEMBL: '388978'
+    HMS-LINCS: '10103'
+    LINCS: LSM-1103
+    PUBCHEM: '44259'
+  name: Staurosporine
+  search_term: '"Staurosporine"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95256
+    HMS-LINCS: '10518'
+    PUBCHEM: '5352624'
+  name: Sulindac sulfide
+  search_term: '"Sulindac sulfide"'
+  type: drug
+- db_refs:
+    CHEMBL: '535'
+    HMS-LINCS: '10175'
+    LINCS: LSM-42800
+    PUBCHEM: '3086686'
+  name: Sunitinib
+  search_term: '"Sunitinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10409'
+    PUBCHEM: '46209401'
+  name: TAK-632
+  search_term: '"TAK-632"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91403
+    HMS-LINCS: '10136'
+    LINCS: LSM-1136
+    PUBCHEM: '9903786'
+  name: TPCA-1
+  search_term: '"TPCA-1"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10445'
+    LINCS: LSM-45140
+    PUBCHEM: '51001932'
+  name: Taselisib
+  search_term: '"Taselisib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:84327
+    HMS-LINCS: '10079'
+    LINCS: LSM-1079
+    PUBCHEM: '49836027'
+  name: Torin1
+  search_term: '"Torin1"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90682
+    HMS-LINCS: '10080'
+    LINCS: LSM-1080
+    PUBCHEM: '51358113'
+  name: Torin2
+  search_term: '"Torin2"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:63637
+    HMS-LINCS: '10068'
+    LINCS: LSM-1068
+    PUBCHEM: '42611257'
+  name: Vemurafenib
+  search_term: '"Vemurafenib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91411
+    HMS-LINCS: '10148'
+    LINCS: LSM-1149
+    PUBCHEM: '52914932'
+  name: XL147
+  search_term: '"XL147"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:124914
+    HMS-LINCS: '10357'
+    LINCS: LSM-36356
+    PUBCHEM: '16123056'
+  name: XL765
+  search_term: '"XL765"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:78413
+    HMS-LINCS: '10086'
+    LINCS: LSM-1086
+    PUBCHEM: '46843906'
+  name: XMD11-50
+  search_term: '"XMD11-50"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90545
+    HMS-LINCS: '10053'
+    LINCS: LSM-1053
+    PUBCHEM: '11647372'
+  name: ZSTK474
+  search_term: '"ZSTK474"'
+  type: drug

--- a/models/skcm/config.yaml
+++ b/models/skcm/config.yaml
@@ -1,233 +1,1250 @@
 ndex:
   network: da832549-f6a3-11e8-aaa6-0ac135e8bacf
 search_terms:
-- "ACTRT1"
-- "ADAM7"
-- "ADAMDEC1"
-- "ADH1A"
-- "ADH1B"
-- "ADH1C"
-- "ANGPT1"
-- "APCS"
-- "BAGE2"
-- "BMP5"
-- "BRAF"
-- "BRINP3"
-- "C6"
-- "C8B"
-- "CA1"
-- "CACNG3"
-- "CADM2"
-- "CAPSL"
-- "CAPZA3"
-- "CCL8"
-- "CD1C"
-- "CDH6"
-- "CDKN2A"
-- "CDR1"
-- "CFHR2"
-- "CFHR5"
-- "CLEC5A"
-- "CLVS1"
-- "CRISP2"
-- "CRISP3"
-- "CRP"
-- "CYLC2"
-- "CYP2C18"
-- "CYP2C19"
-- "CYP2C8"
-- "CYP2C9"
-- "DAB1"
-- "DCC"
-- "DCDC1"
-- "DEFA6"
-- "DEFB115"
-- "DEFB118"
-- "DEFB119"
-- "DNAJC5B"
-- "DPPA2"
-- "DPPA3"
-- "DPPA5"
-- "DPRX"
-- "DUSP22"
-- "DYNAP"
-- "FAM170A"
-- "FAM19A1"
-- "FAM83B"
-- "FCER1A"
-- "FGF12"
-- "FHIT"
-- "FUT9"
-- "FYB2"
-- "GABRG1"
-- "GALNT13"
-- "GALNT17"
-- "GALP"
-- "GFRAL"
-- "GIMAP1"
-- "GIMAP6"
-- "GIMAP7"
-- "GK2"
-- "GLRB"
-- "GLYATL1"
-- "GML"
-- "GNGT2"
-- "GPX5"
-- "GRM3"
-- "GYPB"
-- "HBG2"
-- "HCRTR2"
-- "HIST1H2AA"
-- "HNF4G"
-- "HTN3"
-- "IL17A"
-- "IL36A"
-- "IL36B"
-- "IL37"
-- "IL7R"
-- "ISX"
-- "KCNB2"
-- "KHDRBS2"
-- "LACRT"
-- "LAMP5"
-- "LCE1B"
-- "LCE1E"
-- "LILRA1"
-- "LILRB4"
-- "LINC01559"
-- "LLCFC1"
-- "LRRC3B"
-- "LRTM1"
-- "LUZP2"
-- "MAGEA10"
-- "MAGEC1"
-- "MARCO"
-- "MMP26"
-- "MRAP2"
-- "MRGPRX1"
-- "MSR1"
-- "MUC7"
-- "MYF6"
-- "MYL1"
-- "NEUROD4"
-- "NMS"
-- "NPSR1"
-- "NRAS"
-- "NREP"
-- "NRXN1"
-- "NRXN3"
-- "OPRPN"
-- "OR10K2"
-- "OR13C8"
-- "OR2F1"
-- "OR2L2"
-- "OR2M3"
-- "OR4C13"
-- "OR4E2"
-- "OR4K1"
-- "OR4K2"
-- "OR4M1"
-- "OR4M2"
-- "OR4N2"
-- "OR51B5"
-- "OR52A5"
-- "OR52J3"
-- "OR5D13"
-- "OR9A4"
-- "PAK5"
-- "PARM1"
-- "PCED1B"
-- "PCP4"
-- "PCP4L1"
-- "PDE1A"
-- "PENK"
-- "PGK2"
-- "PPP6C"
-- "PRB2"
-- "PRB3"
-- "PRB4"
-- "PRRG3"
-- "PRSS1"
-- "PRSS37"
-- "PSG5"
-- "PSG9"
-- "PTEN"
-- "PTH2"
-- "RAB27B"
-- "RAC1"
-- "RBFOX1"
-- "REG3G"
-- "RETNLB"
-- "RGS7"
-- "RIT2"
-- "RNF152"
-- "RPL22"
-- "S100A12"
-- "S100A8"
-- "SAMD7"
-- "SDR16C5"
-- "SERPINB3"
-- "SERPINB4"
-- "SERPINB7"
-- "SERPINI2"
-- "SGCZ"
-- "SLC10A2"
-- "SLC30A8"
-- "SMR3A"
-- "SMR3B"
-- "SNCAIP"
-- "SPATA8"
-- "SPOCK3"
-- "SPRR2G"
-- "ST6GAL2"
-- "SYNDIG1"
-- "SYT10"
-- "TAS2R38"
-- "TAS2R60"
-- "TLL1"
-- "TMEM176A"
-- "TP53"
-- "TP63"
-- "TPTE"
-- "TPTE2"
-- "TRAT1"
-- "TRHR"
-- "TSHB"
-- "UGT2B28"
-- "UGT2B4"
-- "ZBED2"
-- "ZMAT4"
-- "ZNF385D"
-- "ALW-II-38-3"
-- "AZ-628"
-- "AZD7762"
-- "BMS-536924"
-- "Baicalein"
-- "Dabrafenib"
-- "Dasatinib"
-- "GDC-0879"
-- "GM6001"
-- "GSK 690693"
-- "IKK16"
-- "Imatinib"
-- "KW2449"
-- "L-779450"
-- "Lestaurtinib"
-- "Motesanib"
-- "NVP-TAE684"
-- "Nilotinib"
-- "Nutlin 3a"
-- "PF-3758309"
-- "PLX-4720"
-- "PRT062607"
-- "Pazopanib"
-- "R406"
-- "RAF 265"
-- "Regorafenib"
-- "SB 203580"
-- "SB590885"
-- "Sorafenib"
-- "Staurosporine"
-- "Sunitinib"
-- "TAK-632"
-- "Vemurafenib"
+- db_refs:
+    HGNC: '24027'
+  name: ACTRT1
+  search_term: '"ACTRT1"'
+  type: gene
+- db_refs:
+    HGNC: '214'
+  name: ADAM7
+  search_term: '"ADAM7"'
+  type: gene
+- db_refs:
+    HGNC: '16299'
+  name: ADAMDEC1
+  search_term: '"ADAMDEC1"'
+  type: gene
+- db_refs:
+    HGNC: '249'
+  name: ADH1A
+  search_term: '"ADH1A"'
+  type: gene
+- db_refs:
+    HGNC: '250'
+  name: ADH1B
+  search_term: '"ADH1B"'
+  type: gene
+- db_refs:
+    HGNC: '251'
+  name: ADH1C
+  search_term: '"ADH1C"'
+  type: gene
+- db_refs:
+    HGNC: '484'
+  name: ANGPT1
+  search_term: '"ANGPT1"'
+  type: gene
+- db_refs:
+    HGNC: '584'
+  name: APCS
+  search_term: '"APCS"'
+  type: gene
+- db_refs:
+    HGNC: '15723'
+  name: BAGE2
+  search_term: '"BAGE2"'
+  type: gene
+- db_refs:
+    HGNC: '1072'
+  name: BMP5
+  search_term: '"BMP5"'
+  type: gene
+- db_refs:
+    HGNC: '1097'
+  name: BRAF
+  search_term: '"BRAF"'
+  type: gene
+- db_refs:
+    HGNC: '22393'
+  name: BRINP3
+  search_term: '"BRINP3"'
+  type: gene
+- db_refs:
+    HGNC: '1339'
+  name: C6
+  search_term: '"C6"'
+  type: gene
+- db_refs:
+    HGNC: '1353'
+  name: C8B
+  search_term: '"C8B"'
+  type: gene
+- db_refs:
+    HGNC: '1368'
+  name: CA1
+  search_term: '"CA1"'
+  type: gene
+- db_refs:
+    HGNC: '1407'
+  name: CACNG3
+  search_term: '"CACNG3"'
+  type: gene
+- db_refs:
+    HGNC: '29849'
+  name: CADM2
+  search_term: '"CADM2"'
+  type: gene
+- db_refs:
+    HGNC: '28375'
+  name: CAPSL
+  search_term: '"CAPSL"'
+  type: gene
+- db_refs:
+    HGNC: '24205'
+  name: CAPZA3
+  search_term: '"CAPZA3"'
+  type: gene
+- db_refs:
+    HGNC: '10635'
+  name: CCL8
+  search_term: '"CCL8"'
+  type: gene
+- db_refs:
+    HGNC: '1636'
+  name: CD1C
+  search_term: '"CD1C"'
+  type: gene
+- db_refs:
+    HGNC: '1765'
+  name: CDH6
+  search_term: '"CDH6"'
+  type: gene
+- db_refs:
+    HGNC: '1787'
+  name: CDKN2A
+  search_term: '"CDKN2A"'
+  type: gene
+- db_refs:
+    HGNC: '1798'
+  name: CDR1
+  search_term: '"CDR1"'
+  type: gene
+- db_refs:
+    HGNC: '4890'
+  name: CFHR2
+  search_term: '"CFHR2"'
+  type: gene
+- db_refs:
+    HGNC: '24668'
+  name: CFHR5
+  search_term: '"CFHR5"'
+  type: gene
+- db_refs:
+    HGNC: '2054'
+  name: CLEC5A
+  search_term: '"CLEC5A"'
+  type: gene
+- db_refs:
+    HGNC: '23139'
+  name: CLVS1
+  search_term: '"CLVS1"'
+  type: gene
+- db_refs:
+    HGNC: '12024'
+  name: CRISP2
+  search_term: '"CRISP2"'
+  type: gene
+- db_refs:
+    HGNC: '16904'
+  name: CRISP3
+  search_term: '"CRISP3"'
+  type: gene
+- db_refs:
+    HGNC: '2367'
+  name: CRP
+  search_term: '"CRP"'
+  type: gene
+- db_refs:
+    HGNC: '2583'
+  name: CYLC2
+  search_term: '"CYLC2"'
+  type: gene
+- db_refs:
+    HGNC: '2620'
+  name: CYP2C18
+  search_term: '"CYP2C18"'
+  type: gene
+- db_refs:
+    HGNC: '2621'
+  name: CYP2C19
+  search_term: '"CYP2C19"'
+  type: gene
+- db_refs:
+    HGNC: '2622'
+  name: CYP2C8
+  search_term: '"CYP2C8"'
+  type: gene
+- db_refs:
+    HGNC: '2623'
+  name: CYP2C9
+  search_term: '"CYP2C9"'
+  type: gene
+- db_refs:
+    HGNC: '2661'
+  name: DAB1
+  search_term: '"DAB1"'
+  type: gene
+- db_refs:
+    HGNC: '2701'
+  name: DCC
+  search_term: '"DCC"'
+  type: gene
+- db_refs:
+    HGNC: '20625'
+  name: DCDC1
+  search_term: '"DCDC1"'
+  type: gene
+- db_refs:
+    HGNC: '2765'
+  name: DEFA6
+  search_term: '"DEFA6"'
+  type: gene
+- db_refs:
+    HGNC: '18096'
+  name: DEFB115
+  search_term: '"DEFB115"'
+  type: gene
+- db_refs:
+    HGNC: '16196'
+  name: DEFB118
+  search_term: '"DEFB118"'
+  type: gene
+- db_refs:
+    HGNC: '18099'
+  name: DEFB119
+  search_term: '"DEFB119"'
+  type: gene
+- db_refs:
+    HGNC: '24138'
+  name: DNAJC5B
+  search_term: '"DNAJC5B"'
+  type: gene
+- db_refs:
+    HGNC: '19197'
+  name: DPPA2
+  search_term: '"DPPA2"'
+  type: gene
+- db_refs:
+    HGNC: '19199'
+  name: DPPA3
+  search_term: '"DPPA3"'
+  type: gene
+- db_refs:
+    HGNC: '19201'
+  name: DPPA5
+  search_term: '"DPPA5"'
+  type: gene
+- db_refs:
+    HGNC: '32166'
+  name: DPRX
+  search_term: '"DPRX"'
+  type: gene
+- db_refs:
+    HGNC: '16077'
+  name: DUSP22
+  search_term: '"DUSP22"'
+  type: gene
+- db_refs:
+    HGNC: '26808'
+  name: DYNAP
+  search_term: '"DYNAP"'
+  type: gene
+- db_refs:
+    HGNC: '27963'
+  name: FAM170A
+  search_term: '"FAM170A"'
+  type: gene
+- db_refs:
+    HGNC: '21587'
+  name: FAM19A1
+  search_term: '"FAM19A1"'
+  type: gene
+- db_refs:
+    HGNC: '21357'
+  name: FAM83B
+  search_term: '"FAM83B"'
+  type: gene
+- db_refs:
+    HGNC: '3609'
+  name: FCER1A
+  search_term: '"FCER1A"'
+  type: gene
+- db_refs:
+    HGNC: '3668'
+  name: FGF12
+  search_term: '"FGF12"'
+  type: gene
+- db_refs:
+    HGNC: '3701'
+  name: FHIT
+  search_term: '"FHIT"'
+  type: gene
+- db_refs:
+    HGNC: '4020'
+  name: FUT9
+  search_term: '"FUT9"'
+  type: gene
+- db_refs:
+    HGNC: '27295'
+  name: FYB2
+  search_term: '"FYB2"'
+  type: gene
+- db_refs:
+    HGNC: '4086'
+  name: GABRG1
+  search_term: '"GABRG1"'
+  type: gene
+- db_refs:
+    HGNC: '23242'
+  name: GALNT13
+  search_term: '"GALNT13"'
+  type: gene
+- db_refs:
+    HGNC: '16347'
+  name: GALNT17
+  search_term: '"GALNT17"'
+  type: gene
+- db_refs:
+    HGNC: '24840'
+  name: GALP
+  search_term: '"GALP"'
+  type: gene
+- db_refs:
+    HGNC: '32789'
+  name: GFRAL
+  search_term: '"GFRAL"'
+  type: gene
+- db_refs:
+    HGNC: '23237'
+  name: GIMAP1
+  search_term: '"GIMAP1"'
+  type: gene
+- db_refs:
+    HGNC: '21918'
+  name: GIMAP6
+  search_term: '"GIMAP6"'
+  type: gene
+- db_refs:
+    HGNC: '22404'
+  name: GIMAP7
+  search_term: '"GIMAP7"'
+  type: gene
+- db_refs:
+    HGNC: '4291'
+  name: GK2
+  search_term: '"GK2"'
+  type: gene
+- db_refs:
+    HGNC: '4329'
+  name: GLRB
+  search_term: '"GLRB"'
+  type: gene
+- db_refs:
+    HGNC: '30519'
+  name: GLYATL1
+  search_term: '"GLYATL1"'
+  type: gene
+- db_refs:
+    HGNC: '4375'
+  name: GML
+  search_term: '"GML"'
+  type: gene
+- db_refs:
+    HGNC: '4412'
+  name: GNGT2
+  search_term: '"GNGT2"'
+  type: gene
+- db_refs:
+    HGNC: '4557'
+  name: GPX5
+  search_term: '"GPX5"'
+  type: gene
+- db_refs:
+    HGNC: '4595'
+  name: GRM3
+  search_term: '"GRM3"'
+  type: gene
+- db_refs:
+    HGNC: '4703'
+  name: GYPB
+  search_term: '"GYPB"'
+  type: gene
+- db_refs:
+    HGNC: '4832'
+  name: HBG2
+  search_term: '"HBG2"'
+  type: gene
+- db_refs:
+    HGNC: '4849'
+  name: HCRTR2
+  search_term: '"HCRTR2"'
+  type: gene
+- db_refs:
+    HGNC: '18729'
+  name: HIST1H2AA
+  search_term: '"HIST1H2AA"'
+  type: gene
+- db_refs:
+    HGNC: '5026'
+  name: HNF4G
+  search_term: '"HNF4G"'
+  type: gene
+- db_refs:
+    HGNC: '5284'
+  name: HTN3
+  search_term: '"HTN3"'
+  type: gene
+- db_refs:
+    HGNC: '5981'
+  name: IL17A
+  search_term: '"IL17A"'
+  type: gene
+- db_refs:
+    HGNC: '15562'
+  name: IL36A
+  search_term: '"IL36A"'
+  type: gene
+- db_refs:
+    HGNC: '15564'
+  name: IL36B
+  search_term: '"IL36B"'
+  type: gene
+- db_refs:
+    HGNC: '15563'
+  name: IL37
+  search_term: '"IL37"'
+  type: gene
+- db_refs:
+    HGNC: '6024'
+  name: IL7R
+  search_term: '"IL7R"'
+  type: gene
+- db_refs:
+    HGNC: '28084'
+  name: ISX
+  search_term: '"ISX"'
+  type: gene
+- db_refs:
+    HGNC: '6232'
+  name: KCNB2
+  search_term: '"KCNB2"'
+  type: gene
+- db_refs:
+    HGNC: '18114'
+  name: KHDRBS2
+  search_term: '"KHDRBS2"'
+  type: gene
+- db_refs:
+    HGNC: '16430'
+  name: LACRT
+  search_term: '"LACRT"'
+  type: gene
+- db_refs:
+    HGNC: '16097'
+  name: LAMP5
+  search_term: '"LAMP5"'
+  type: gene
+- db_refs:
+    HGNC: '16611'
+  name: LCE1B
+  search_term: '"LCE1B"'
+  type: gene
+- db_refs:
+    HGNC: '29466'
+  name: LCE1E
+  search_term: '"LCE1E"'
+  type: gene
+- db_refs:
+    HGNC: '6602'
+  name: LILRA1
+  search_term: '"LILRA1"'
+  type: gene
+- db_refs:
+    HGNC: '6608'
+  name: LILRB4
+  search_term: '"LILRB4"'
+  type: gene
+- db_refs:
+    HGNC: '26598'
+  name: LINC01559
+  search_term: '"LINC01559"'
+  type: gene
+- db_refs:
+    HGNC: '21750'
+  name: LLCFC1
+  search_term: '"LLCFC1"'
+  type: gene
+- db_refs:
+    HGNC: '28105'
+  name: LRRC3B
+  search_term: '"LRRC3B"'
+  type: gene
+- db_refs:
+    HGNC: '25023'
+  name: LRTM1
+  search_term: '"LRTM1"'
+  type: gene
+- db_refs:
+    HGNC: '23206'
+  name: LUZP2
+  search_term: '"LUZP2"'
+  type: gene
+- db_refs:
+    HGNC: '6797'
+  name: MAGEA10
+  search_term: '"MAGEA10"'
+  type: gene
+- db_refs:
+    HGNC: '6812'
+  name: MAGEC1
+  search_term: '"MAGEC1"'
+  type: gene
+- db_refs:
+    HGNC: '6895'
+  name: MARCO
+  search_term: '"MARCO"'
+  type: gene
+- db_refs:
+    HGNC: '14249'
+  name: MMP26
+  search_term: '"MMP26"'
+  type: gene
+- db_refs:
+    HGNC: '21232'
+  name: MRAP2
+  search_term: '"MRAP2"'
+  type: gene
+- db_refs:
+    HGNC: '17962'
+  name: MRGPRX1
+  search_term: '"MRGPRX1"'
+  type: gene
+- db_refs:
+    HGNC: '7376'
+  name: MSR1
+  search_term: '"MSR1"'
+  type: gene
+- db_refs:
+    HGNC: '7518'
+  name: MUC7
+  search_term: '"MUC7"'
+  type: gene
+- db_refs:
+    HGNC: '7566'
+  name: MYF6
+  search_term: '"MYF6"'
+  type: gene
+- db_refs:
+    HGNC: '7582'
+  name: MYL1
+  search_term: '"MYL1"'
+  type: gene
+- db_refs:
+    HGNC: '13802'
+  name: NEUROD4
+  search_term: '"NEUROD4"'
+  type: gene
+- db_refs:
+    HGNC: '32203'
+  name: NMS
+  search_term: '"NMS"'
+  type: gene
+- db_refs:
+    HGNC: '23631'
+  name: NPSR1
+  search_term: '"NPSR1"'
+  type: gene
+- db_refs:
+    HGNC: '7989'
+  name: NRAS
+  search_term: '"NRAS"'
+  type: gene
+- db_refs:
+    HGNC: '16834'
+  name: NREP
+  search_term: '"NREP"'
+  type: gene
+- db_refs:
+    HGNC: '8008'
+  name: NRXN1
+  search_term: '"NRXN1"'
+  type: gene
+- db_refs:
+    HGNC: '8010'
+  name: NRXN3
+  search_term: '"NRXN3"'
+  type: gene
+- db_refs:
+    HGNC: '17279'
+  name: OPRPN
+  search_term: '"OPRPN"'
+  type: gene
+- db_refs:
+    HGNC: '14826'
+  name: OR10K2
+  search_term: '"OR10K2"'
+  type: gene
+- db_refs:
+    HGNC: '15103'
+  name: OR13C8
+  search_term: '"OR13C8"'
+  type: gene
+- db_refs:
+    HGNC: '8246'
+  name: OR2F1
+  search_term: '"OR2F1"'
+  type: gene
+- db_refs:
+    HGNC: '8266'
+  name: OR2L2
+  search_term: '"OR2L2"'
+  type: gene
+- db_refs:
+    HGNC: '8269'
+  name: OR2M3
+  search_term: '"OR2M3"'
+  type: gene
+- db_refs:
+    HGNC: '15169'
+  name: OR4C13
+  search_term: '"OR4C13"'
+  type: gene
+- db_refs:
+    HGNC: '8297'
+  name: OR4E2
+  search_term: '"OR4E2"'
+  type: gene
+- db_refs:
+    HGNC: '14726'
+  name: OR4K1
+  search_term: '"OR4K1"'
+  type: gene
+- db_refs:
+    HGNC: '14728'
+  name: OR4K2
+  search_term: '"OR4K2"'
+  type: gene
+- db_refs:
+    HGNC: '14735'
+  name: OR4M1
+  search_term: '"OR4M1"'
+  type: gene
+- db_refs:
+    HGNC: '15373'
+  name: OR4M2
+  search_term: '"OR4M2"'
+  type: gene
+- db_refs:
+    HGNC: '14742'
+  name: OR4N2
+  search_term: '"OR4N2"'
+  type: gene
+- db_refs:
+    HGNC: '19599'
+  name: OR51B5
+  search_term: '"OR51B5"'
+  type: gene
+- db_refs:
+    HGNC: '19580'
+  name: OR52A5
+  search_term: '"OR52A5"'
+  type: gene
+- db_refs:
+    HGNC: '14799'
+  name: OR52J3
+  search_term: '"OR52J3"'
+  type: gene
+- db_refs:
+    HGNC: '15280'
+  name: OR5D13
+  search_term: '"OR5D13"'
+  type: gene
+- db_refs:
+    HGNC: '15095'
+  name: OR9A4
+  search_term: '"OR9A4"'
+  type: gene
+- db_refs:
+    HGNC: '15916'
+  name: PAK5
+  search_term: '"PAK5"'
+  type: gene
+- db_refs:
+    HGNC: '24536'
+  name: PARM1
+  search_term: '"PARM1"'
+  type: gene
+- db_refs:
+    HGNC: '28255'
+  name: PCED1B
+  search_term: '"PCED1B"'
+  type: gene
+- db_refs:
+    HGNC: '8742'
+  name: PCP4
+  search_term: '"PCP4"'
+  type: gene
+- db_refs:
+    HGNC: '20448'
+  name: PCP4L1
+  search_term: '"PCP4L1"'
+  type: gene
+- db_refs:
+    HGNC: '8774'
+  name: PDE1A
+  search_term: '"PDE1A"'
+  type: gene
+- db_refs:
+    HGNC: '8831'
+  name: PENK
+  search_term: '"PENK"'
+  type: gene
+- db_refs:
+    HGNC: '8898'
+  name: PGK2
+  search_term: '"PGK2"'
+  type: gene
+- db_refs:
+    HGNC: '9323'
+  name: PPP6C
+  search_term: '"PPP6C"'
+  type: gene
+- db_refs:
+    HGNC: '9338'
+  name: PRB2
+  search_term: '"PRB2"'
+  type: gene
+- db_refs:
+    HGNC: '9339'
+  name: PRB3
+  search_term: '"PRB3"'
+  type: gene
+- db_refs:
+    HGNC: '9340'
+  name: PRB4
+  search_term: '"PRB4"'
+  type: gene
+- db_refs:
+    HGNC: '30798'
+  name: PRRG3
+  search_term: '"PRRG3"'
+  type: gene
+- db_refs:
+    HGNC: '9475'
+  name: PRSS1
+  search_term: '"PRSS1"'
+  type: gene
+- db_refs:
+    HGNC: '29211'
+  name: PRSS37
+  search_term: '"PRSS37"'
+  type: gene
+- db_refs:
+    HGNC: '9522'
+  name: PSG5
+  search_term: '"PSG5"'
+  type: gene
+- db_refs:
+    HGNC: '9526'
+  name: PSG9
+  search_term: '"PSG9"'
+  type: gene
+- db_refs:
+    HGNC: '9588'
+  name: PTEN
+  search_term: '"PTEN"'
+  type: gene
+- db_refs:
+    HGNC: '30828'
+  name: PTH2
+  search_term: '"PTH2"'
+  type: gene
+- db_refs:
+    HGNC: '9767'
+  name: RAB27B
+  search_term: '"RAB27B"'
+  type: gene
+- db_refs:
+    HGNC: '9801'
+  name: RAC1
+  search_term: '"RAC1"'
+  type: gene
+- db_refs:
+    HGNC: '18222'
+  name: RBFOX1
+  search_term: '"RBFOX1"'
+  type: gene
+- db_refs:
+    HGNC: '29595'
+  name: REG3G
+  search_term: '"REG3G"'
+  type: gene
+- db_refs:
+    HGNC: '20388'
+  name: RETNLB
+  search_term: '"RETNLB"'
+  type: gene
+- db_refs:
+    HGNC: '10003'
+  name: RGS7
+  search_term: '"RGS7"'
+  type: gene
+- db_refs:
+    HGNC: '10017'
+  name: RIT2
+  search_term: '"RIT2"'
+  type: gene
+- db_refs:
+    HGNC: '26811'
+  name: RNF152
+  search_term: '"RNF152"'
+  type: gene
+- db_refs:
+    HGNC: '10315'
+  name: RPL22
+  search_term: '"RPL22"'
+  type: gene
+- db_refs:
+    HGNC: '10489'
+  name: S100A12
+  search_term: '"S100A12"'
+  type: gene
+- db_refs:
+    HGNC: '10498'
+  name: S100A8
+  search_term: '"S100A8"'
+  type: gene
+- db_refs:
+    HGNC: '25394'
+  name: SAMD7
+  search_term: '"SAMD7"'
+  type: gene
+- db_refs:
+    HGNC: '30311'
+  name: SDR16C5
+  search_term: '"SDR16C5"'
+  type: gene
+- db_refs:
+    HGNC: '10569'
+  name: SERPINB3
+  search_term: '"SERPINB3"'
+  type: gene
+- db_refs:
+    HGNC: '10570'
+  name: SERPINB4
+  search_term: '"SERPINB4"'
+  type: gene
+- db_refs:
+    HGNC: '13902'
+  name: SERPINB7
+  search_term: '"SERPINB7"'
+  type: gene
+- db_refs:
+    HGNC: '8945'
+  name: SERPINI2
+  search_term: '"SERPINI2"'
+  type: gene
+- db_refs:
+    HGNC: '14075'
+  name: SGCZ
+  search_term: '"SGCZ"'
+  type: gene
+- db_refs:
+    HGNC: '10906'
+  name: SLC10A2
+  search_term: '"SLC10A2"'
+  type: gene
+- db_refs:
+    HGNC: '20303'
+  name: SLC30A8
+  search_term: '"SLC30A8"'
+  type: gene
+- db_refs:
+    HGNC: '19216'
+  name: SMR3A
+  search_term: '"SMR3A"'
+  type: gene
+- db_refs:
+    HGNC: '17326'
+  name: SMR3B
+  search_term: '"SMR3B"'
+  type: gene
+- db_refs:
+    HGNC: '11139'
+  name: SNCAIP
+  search_term: '"SNCAIP"'
+  type: gene
+- db_refs:
+    HGNC: '28676'
+  name: SPATA8
+  search_term: '"SPATA8"'
+  type: gene
+- db_refs:
+    HGNC: '13565'
+  name: SPOCK3
+  search_term: '"SPOCK3"'
+  type: gene
+- db_refs:
+    HGNC: '11267'
+  name: SPRR2G
+  search_term: '"SPRR2G"'
+  type: gene
+- db_refs:
+    HGNC: '10861'
+  name: ST6GAL2
+  search_term: '"ST6GAL2"'
+  type: gene
+- db_refs:
+    HGNC: '15885'
+  name: SYNDIG1
+  search_term: '"SYNDIG1"'
+  type: gene
+- db_refs:
+    HGNC: '19266'
+  name: SYT10
+  search_term: '"SYT10"'
+  type: gene
+- db_refs:
+    HGNC: '9584'
+  name: TAS2R38
+  search_term: '"TAS2R38"'
+  type: gene
+- db_refs:
+    HGNC: '20639'
+  name: TAS2R60
+  search_term: '"TAS2R60"'
+  type: gene
+- db_refs:
+    HGNC: '11843'
+  name: TLL1
+  search_term: '"TLL1"'
+  type: gene
+- db_refs:
+    HGNC: '24930'
+  name: TMEM176A
+  search_term: '"TMEM176A"'
+  type: gene
+- db_refs:
+    HGNC: '11998'
+  name: TP53
+  search_term: '"TP53"'
+  type: gene
+- db_refs:
+    HGNC: '15979'
+  name: TP63
+  search_term: '"TP63"'
+  type: gene
+- db_refs:
+    HGNC: '12023'
+  name: TPTE
+  search_term: '"TPTE"'
+  type: gene
+- db_refs:
+    HGNC: '17299'
+  name: TPTE2
+  search_term: '"TPTE2"'
+  type: gene
+- db_refs:
+    HGNC: '30698'
+  name: TRAT1
+  search_term: '"TRAT1"'
+  type: gene
+- db_refs:
+    HGNC: '12299'
+  name: TRHR
+  search_term: '"TRHR"'
+  type: gene
+- db_refs:
+    HGNC: '12372'
+  name: TSHB
+  search_term: '"TSHB"'
+  type: gene
+- db_refs:
+    HGNC: '13479'
+  name: UGT2B28
+  search_term: '"UGT2B28"'
+  type: gene
+- db_refs:
+    HGNC: '12553'
+  name: UGT2B4
+  search_term: '"UGT2B4"'
+  type: gene
+- db_refs:
+    HGNC: '20710'
+  name: ZBED2
+  search_term: '"ZBED2"'
+  type: gene
+- db_refs:
+    HGNC: '25844'
+  name: ZMAT4
+  search_term: '"ZMAT4"'
+  type: gene
+- db_refs:
+    HGNC: '26191'
+  name: ZNF385D
+  search_term: '"ZNF385D"'
+  type: gene
+- db_refs:
+    CHEBI: CHEBI:91324
+    HMS-LINCS: '10002'
+    LINCS: LSM-1002
+    PUBCHEM: '24880028'
+  name: ALW-II-38-3
+  search_term: '"ALW-II-38-3"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91354
+    HMS-LINCS: '10050'
+    LINCS: LSM-1050
+    PUBCHEM: '11676786'
+  name: AZ-628
+  search_term: '"AZ-628"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91328
+    HMS-LINCS: '10006'
+    LINCS: LSM-1006
+    PUBCHEM: '67077825'
+  name: AZD7762
+  search_term: '"AZD7762"'
+  type: drug
+- db_refs:
+    CHEMBL: '401930'
+    HMS-LINCS: '10209'
+    LINCS: LSM-1210
+    PUBCHEM: '68925359'
+  name: BMS-536924
+  search_term: '"BMS-536924"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:2979
+    HMS-LINCS: '10343'
+    LINCS: LSM-6355
+    PUBCHEM: '5281605'
+  name: Baicalein
+  search_term: '"Baicalein"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:75045
+    HMS-LINCS: '10284'
+    LINCS: LSM-6303
+    PUBCHEM: '44462760'
+  name: Dabrafenib
+  search_term: '"Dabrafenib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:49375
+    CHEMBL: '1421'
+    HMS-LINCS: '10020'
+    LINCS: LSM-1020
+    PUBCHEM: '3062316'
+  name: Dasatinib
+  search_term: '"Dasatinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10181'
+    LINCS: LSM-42801
+    PUBCHEM: '57519545'
+  name: GDC-0879
+  search_term: '"GDC-0879"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:137236
+    HMS-LINCS: '10509'
+    PUBCHEM: '132519'
+  name: GM6001
+  search_term: '"GM6001"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91396
+    HMS-LINCS: '10128'
+    LINCS: LSM-1128
+    PUBCHEM: '16048642'
+  name: GSK 690693
+  search_term: '"GSK 690693"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:92257
+    HMS-LINCS: '10228'
+    LINCS: LSM-2309
+    PUBCHEM: '9549298'
+  name: IKK16
+  search_term: '"IKK16"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:45783
+    CHEMBL: '941'
+    HMS-LINCS: '10023'
+    LINCS: LSM-1023
+    PUBCHEM: '5291'
+  name: Imatinib
+  search_term: '"Imatinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10192'
+    LINCS: LSM-42803
+    PUBCHEM: '67089852'
+  name: KW2449
+  search_term: '"KW2449"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:93773
+    HMS-LINCS: '10262'
+    LINCS: LSM-4283
+    PUBCHEM: '9950176'
+  name: L-779450
+  search_term: '"L-779450"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91471
+    HMS-LINCS: '10230'
+    LINCS: LSM-1231
+    PUBCHEM: '126565'
+  name: Lestaurtinib
+  search_term: '"Lestaurtinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:51098
+    HMS-LINCS: '10042'
+    LINCS: LSM-1042
+    PUBCHEM: '11667893'
+  name: Motesanib
+  search_term: '"Motesanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91338
+    CHEMBL: '509032'
+    HMS-LINCS: '10024'
+    LINCS: LSM-1024
+    PUBCHEM: '16038120'
+  name: NVP-TAE684
+  search_term: '"NVP-TAE684"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:52172
+    CHEMBL: '255863'
+    HMS-LINCS: '10099'
+    LINCS: LSM-1099
+    PUBCHEM: '644241'
+  name: Nilotinib
+  search_term: '"Nilotinib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:95096
+    HMS-LINCS: '10268'
+    LINCS: LSM-6351
+    PUBCHEM: '11433190'
+  name: Nutlin 3a
+  search_term: '"Nutlin 3a"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:93751
+    HMS-LINCS: '10231'
+    LINCS: LSM-4254
+    PUBCHEM: '25227462'
+  name: PF-3758309
+  search_term: '"PF-3758309"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90295
+    HMS-LINCS: '10049'
+    LINCS: LSM-1049
+    PUBCHEM: '24180719'
+  name: PLX-4720
+  search_term: '"PLX-4720"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10406'
+    PUBCHEM: '44462758'
+  name: PRT062607
+  search_term: '"PRT062607"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:71219
+    HMS-LINCS: '10114'
+    LINCS: LSM-1114
+    PUBCHEM: '10113978'
+  name: Pazopanib
+  search_term: '"Pazopanib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91348
+    HMS-LINCS: '10040'
+    LINCS: LSM-1040
+    PUBCHEM: '11213558'
+  name: R406
+  search_term: '"R406"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:91451
+    HMS-LINCS: '10206'
+    LINCS: LSM-1207
+    PUBCHEM: '11656518'
+  name: RAF 265
+  search_term: '"RAF 265"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:68647
+    HMS-LINCS: '10225'
+    LINCS: LSM-1226
+    PUBCHEM: '11167602'
+  name: Regorafenib
+  search_term: '"Regorafenib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:90705
+    HMS-LINCS: '10167'
+    LINCS: LSM-1168
+    PUBCHEM: '176155'
+  name: SB 203580
+  search_term: '"SB 203580"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10046'
+    LINCS: LSM-42746
+    PUBCHEM: '53239990'
+  name: SB590885
+  search_term: '"SB590885"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:50924
+    CHEMBL: '1336'
+    HMS-LINCS: '10008'
+    LINCS: LSM-1008
+    PUBCHEM: '216239'
+  name: Sorafenib
+  search_term: '"Sorafenib"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:15738
+    CHEMBL: '388978'
+    HMS-LINCS: '10103'
+    LINCS: LSM-1103
+    PUBCHEM: '44259'
+  name: Staurosporine
+  search_term: '"Staurosporine"'
+  type: drug
+- db_refs:
+    CHEMBL: '535'
+    HMS-LINCS: '10175'
+    LINCS: LSM-42800
+    PUBCHEM: '3086686'
+  name: Sunitinib
+  search_term: '"Sunitinib"'
+  type: drug
+- db_refs:
+    HMS-LINCS: '10409'
+    PUBCHEM: '46209401'
+  name: TAK-632
+  search_term: '"TAK-632"'
+  type: drug
+- db_refs:
+    CHEBI: CHEBI:63637
+    HMS-LINCS: '10068'
+    LINCS: LSM-1068
+    PUBCHEM: '42611257'
+  name: Vemurafenib
+  search_term: '"Vemurafenib"'
+  type: drug

--- a/scripts/priors_from_muts.py
+++ b/scripts/priors_from_muts.py
@@ -55,7 +55,7 @@ if __name__ == '__main__':
         cancer_terms, drug_terms = get_terms(ctype)
         gene_names = [g.name for g in cancer_terms]
         drug_names = [d.name for d in drug_terms]
-        prior_stmts = get_stmts_for_gene_list(gene_names, drug_names)
-        save_prior(prior_stmts)
         terms = cancer_terms + drug_terms
         save_config(ctype, terms)
+        #prior_stmts = get_stmts_for_gene_list(gene_names, drug_names)
+        #save_prior(prior_stmts)

--- a/scripts/priors_from_muts.py
+++ b/scripts/priors_from_muts.py
@@ -1,7 +1,8 @@
 import yaml
 import pickle
 import datetime
-from emmaa.model import EmmaaStatement, EmmaaModel
+from emmaa.model import EmmaaModel
+from emmaa.statements import EmmaaStatement
 from emmaa.priors.prior_stmts import get_stmts_for_gene_list
 from emmaa.priors.cancer_prior import TcgaCancerPrior
 
@@ -20,8 +21,6 @@ def load_config(ctype):
     with open(fname, 'r') as fh:
         config = yaml.load(fh)
     # TODO: make the search term entries here SearchTerm objects
-    for term in config.get('search_terms', []):
-        pass
     return config
 
 


### PR DESCRIPTION
This PR enhances the format of the model configs to use SearchTerm objects instead of just a simple string. This allows keeping track of the type, grounding and canonical name of prior terms in addition to actual search strings.