### PR TITLE
S3 json upload

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -144,7 +144,7 @@ class EmmaaModel(object):
                           Key=fname+'.pkl')
         # Dump as json
         client.put_object(Body=str.encode(json.dumps(stmts_to_json(
-            self.stmts))), Bucket='emmaa', Key=fname+'.json')
+            self.stmts)), encoding='utf8'), Bucket='emmaa', Key=fname+'.json')
 
     @classmethod
     def load_from_s3(klass, model_name):

--- a/emmaa/statements.py
+++ b/emmaa/statements.py
@@ -20,3 +20,11 @@ class EmmaaStatement(object):
     def __repr__(self):
         return '%s(%s, %s, %s)' % (self.__class__.__name__, self.stmt,
                                    self.date, self.search_terms)
+
+    def to_json(self, use_sbo=False):
+        # Get json representation of statement
+        json_stmt = self.stmt.to_json(use_sbo=use_sbo)
+        # Stringify source hashes: JavaScript can't handle int's of length > 16
+        for ev in json_stmt['evidence']:
+            ev['source_hash'] = str(ev['source_hash'])
+        return json_stmt

--- a/scripts/generate_simple_model_test.py
+++ b/scripts/generate_simple_model_test.py
@@ -1,6 +1,7 @@
 import pickle
 import datetime
 import yaml
+import json
 import boto3
 from indra.statements import *
 from indra.sources import trips
@@ -42,12 +43,16 @@ if __name__ == '__main__':
     model_name = 'test'
     model, config = generate_model(model_name)
     test = generate_test()
-    # Upload model to S3
+    # Upload model to S3 as yaml and json
     model.save_to_s3()
     s3_client = boto3.client('s3')
     config_yaml = yaml.dump(config)
     s3_client.put_object(Body=config_yaml.encode('utf8'),
                          Key='models/%s/config.yaml' % model_name,
+                         Bucket='emmaa')
+    config_json = json.dumps(config)
+    s3_client.put_object(Body=config_json.encode('utf8'),
+                         Key='models/%s/config.json' % model_name,
                          Bucket='emmaa')
     # Upload test to S3
     test_key = 'tests/simple_model_test.pkl'


### PR DESCRIPTION
This PR adds json upload capabilities to the emmaa code. With models uploaded as jsons, they are more accessible by client side javascript.

Specific updates:

- Adds the method `to_json()` in the  `EmmaaStatement` class, allowing `indra.statements.smts_to_json` to be used on the `EmmaaStatement` class.
- Upload of models as jsons alongside pickles in `emmaa/model.py`
- Upload of test model config as both yaml and json in `scripts/generate_simple_model_test.py`