### PR TITLE
Fix the model testing lambda framework

### DIFF
--- a/emmaa/aws_lambda/script.py
+++ b/emmaa/aws_lambda/script.py
@@ -10,10 +10,7 @@ in this directory.
 """
 
 import boto3
-
-# Note that all non-standard imports will need to be added to the update script
-# including secondary, tertiary, and so forth imports.
-from emmaa.util import make_date_str
+from datetime import datetime
 
 JOB_DEF = 'emmaa_jobdef'
 QUEUE = 'run_db_lite_queue'
@@ -80,7 +77,8 @@ def lambda_handler(event, context):
                         '--project', PROJECT, '--purpose', PURPOSE,
                         core_command]
             }
-        ret = batch.submit_job(jobName=f'{model_name}_{make_date_str()}',
+        now_str = datetime.utcnow().strftime('%Y%m%d_%H%M%S')
+        ret = batch.submit_job(jobName=f'{model_name}_{now_str}',
                                jobQueue=QUEUE, jobDefinition=JOB_DEF,
                                containerOverrides=cont_overrides)
         job_id = ret['jobId']

--- a/emmaa/aws_lambda/update.py
+++ b/emmaa/aws_lambda/update.py
@@ -17,8 +17,6 @@ def upload_function():
                  'emmaa/%s/script.py' % path.basename(HERE))
         zf.write(path.join(HERE, '__init__.py'),
                  'emmaa/%s/__init__.py' % path.basename(HERE))
-        zf.write(path.join(HERE, path.pardir, 'util.py'),
-                 'emmaa/util.py')
         zf.write(path.join(HERE, path.pardir, '__init__.py'),
                  'emmaa/__init__.py')
 


### PR DESCRIPTION
Remove all dependency on `util.py` from the lambda script, and correspondingly from the files uploaded in `update.py`. This prevents unresolvable dependencies from creeping in through `util.py`.