### PR TITLE
Optimize model test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ venv.bak/
 .vscode/settings.json
 
 *.zip
+.DS_Store

--- a/emmaa/aws_lambda_functions/analyze_changes_on_s3.py
+++ b/emmaa/aws_lambda_functions/analyze_changes_on_s3.py
@@ -16,7 +16,7 @@ JOB_DEF = 'emmaa_jobdef'
 QUEUE = 'emmaa-models-update-test'
 PROJECT = 'aske'
 PURPOSE = 'update-emmaa-results'
-BRANCH = None
+BRANCH = 'origin/master'
 
 
 def lambda_handler(event, context):

--- a/emmaa/aws_lambda_functions/model_updates.py
+++ b/emmaa/aws_lambda_functions/model_updates.py
@@ -1,7 +1,7 @@
 """The AWS Lambda emmaa-model-update definition.
 
-This file contains the function that starts model update cycle. It must be 
-placed on AWS Lambda, which can either be done manually (not recommended) or by 
+This file contains the function that starts model update cycle. It must be
+placed on AWS Lambda, which can either be done manually (not recommended) or by
 running:
 
 $ python update_lambda.py model_updates.py emmaa-model-update
@@ -16,7 +16,7 @@ JOB_DEF = 'emmaa_jobdef'
 QUEUE = 'emmaa-models-update-test'
 PROJECT = 'aske'
 PURPOSE = 'update-emmaa-models'
-BRANCH = None
+BRANCH = 'origin/master'
 
 
 def lambda_handler(event, context):

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -129,12 +129,12 @@ class EmmaaModel(object):
             The list of assembled INDRA Statements.
         """
         stmts = self.get_indra_stmts()
-        if filter_ungrounded:
-            stmts = ac.filter_grounded_only(stmts)
         stmts = ac.filter_no_hypothesis(stmts)
         stmts = ac.map_grounding(stmts)
-        stmts = ac.map_sequence(stmts)
+        if filter_ungrounded:
+            stmts = ac.filter_grounded_only(stmts)
         stmts = ac.filter_human_only(stmts)
+        stmts = ac.map_sequence(stmts)
         stmts = ac.run_preassembly(stmts, return_toplevel=False)
         if belief_cutoff is not None:
             stmts = ac.filter_belief(stmts, belief_cutoff)

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -101,7 +101,7 @@ class TestManager(object):
 
     def make_tests(self, test_connector):
         """
-        Generate a list of applicable tests for each model with a given test 
+        Generate a list of applicable tests for each model with a given test
         connector.
 
         Parameters
@@ -111,7 +111,8 @@ class TestManager(object):
         """
         logger.info(f'Checking applicability of {len(self.tests)} tests to '
                     f'{len(self.model_managers)} models')
-        for model_manager, test in itertools.product(self.model_managers, self.tests):
+        for model_manager, test in itertools.product(self.model_managers,
+                                                     self.tests):
             logger.info(f'Checking applicability of test {test.stmt}')
             if test_connector.applicable(model_manager, test):
                 model_manager.add_test(test)
@@ -120,8 +121,8 @@ class TestManager(object):
                 logger.info(f'Test {test.stmt} is not applicable')
         logger.info(f'Created tests for {len(self.model_managers)} models.')
         for model_manager in self.model_managers:
-            logger.info(f'Created {len(model_manager.applicable_tests)} tests for '
-                        f'{model_manager.model.name} model.')
+            logger.info(f'Created {len(model_manager.applicable_tests)} tests '
+                        f'for {model_manager.model.name} model.')
 
     def run_tests(self):
         """Run tests for a list of model-test pairs"""
@@ -183,7 +184,6 @@ class StatementCheckingTest(EmmaaTest):
         # Add entities as a property if we can reload tests on s3.
         # self.entities = self.get_entities()
 
-    # probably won't need this method
     def check(self, model_checker, pysb_model):
         """Use a model checker to check if a given model satisfies the test."""
         res = model_checker.check_statement(self.stmt)

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -76,11 +76,6 @@ class TestManager(object):
             logger.info(f'Created {len(model.applicable_tests)} tests for '
                         f'{model.model.name} model.')
 
-    # def run_tests(self):
-    #     """Run tests for a list of model-test pairs"""
-    #     for (model, test) in self.pairs_to_test:
-    #         self.test_results.append(test.check(model))
-
     def run_tests(self):
         """Run tests for a list of model-test pairs"""
         for model in self.models:
@@ -136,16 +131,6 @@ class EmmaaTest(object):
 class StatementCheckingTest(EmmaaTest):
     """Represent an EMMAA test condition that checks a PySB-assembled model
     against an INDRA Statement."""
-    # def __init__(self, stmt):
-    #     self.stmt = stmt
-
-    # def check(self, model):
-    #     """Use a model checker to check if a given model satisfies the test."""
-    #     pysb_model = model.assemble_pysb()
-    #     mc = ModelChecker(pysb_model, [self.stmt])
-    #     res = mc.check_statement(self.stmt)
-    #     return res
-
     def __init__(self, stmt):
         self.stmt = stmt
         # TODO

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -21,6 +21,10 @@ class ModelManager(object):
         self.entities = self.model.get_entities()
         self.applicable_tests = []
         self.test_results = []
+        self.mc = ModelChecker(self.pysb_model)
+
+    def get_im(self):
+        self.mc.get_im(self.pysb_model)
     
     def add_test(self, test):
         self.applicable_tests.append(test)
@@ -79,8 +83,14 @@ class TestManager(object):
     def run_tests(self):
         """Run tests for a list of model-test pairs"""
         for model in self.models:
-            for test in model.applicable_tests:
-                model.add_result(test.check(model.pysb_model))
+            model.mc.add_statements(
+                [test.stmt for test in model.applicable_tests])
+            model.get_im()
+            results = model.mc.check_model()
+            for result in results:
+                model.add_result(result[1])  
+            # for test in model.applicable_tests:
+            #     model.add_result(test.check(model.pysb_model))
 
     def results_to_json(self):
         results_json = []

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -32,6 +32,13 @@ class ModelManager(object):
     def add_result(self, result):
         self.test_results.append(result)
 
+    def run_tests(self):
+        mc.add_statements([test.stmt for test in model.applicable_tests])
+        self.get_im()
+        results = mc.check_model()
+        for (stmt, result) in results:
+            model.add_result(result)
+
     def results_to_json(self):
         pickler = jsonpickle.pickler.Pickler()
         results_json = []        
@@ -83,12 +90,7 @@ class TestManager(object):
     def run_tests(self):
         """Run tests for a list of model-test pairs"""
         for model in self.models:
-            model.mc.add_statements(
-                [test.stmt for test in model.applicable_tests])
-            model.get_im()
-            results = model.mc.check_model()
-            for result in results:
-                model.add_result(result[1])  
+            model.run_tests()
             # for test in model.applicable_tests:
             #     model.add_result(test.check(model.pysb_model))
 

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -33,11 +33,16 @@ class ModelManager(object):
         self.test_results.append(result)
 
     def run_tests(self):
-        mc.add_statements([test.stmt for test in model.applicable_tests])
+        self.mc.add_statements([test.stmt for test in self.applicable_tests])
         self.get_im()
-        results = mc.check_model()
+        results = self.mc.check_model()
         for (stmt, result) in results:
-            model.add_result(result)
+            self.add_result(result)
+        # second version:
+        # self.mc.add_statements([test.stmt for test in self.applicable_tests])
+        # self.get_im()
+        # for test in self.applicable_tests:
+        #   self.add_result(test.check(self.mc, self.pysb_model))  
 
     def results_to_json(self):
         pickler = jsonpickle.pickler.Pickler()
@@ -91,8 +96,6 @@ class TestManager(object):
         """Run tests for a list of model-test pairs"""
         for model in self.models:
             model.run_tests()
-            # for test in model.applicable_tests:
-            #     model.add_result(test.check(model.pysb_model))
 
     def results_to_json(self):
         results_json = []
@@ -149,10 +152,10 @@ class StatementCheckingTest(EmmaaTest):
         # Add entities as a property if we can reload tests on s3.
         # self.entities = self.get_entities()
 
-    def check(self, pysb_model):
+    # probably won't need this method
+    def check(self, model_checker, pysb_model):
         """Use a model checker to check if a given model satisfies the test."""
-        mc = ModelChecker(pysb_model, [self.stmt])
-        res = mc.check_statement(self.stmt)
+        res = model_checker.check_statement(self.stmt)
         return res
 
     def get_entities(self):

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -112,6 +112,9 @@ class ScopeTestConnector(TestConnector):
         """Return True of all test entities are in the set of model entities"""
         model_entities = model.entities
         test_entities = test.get_entities()
+        # TODO
+        # After adding entities as a property to StatementCheckingTest(), use
+        # test_entities = test.entities
         return ScopeTestConnector._overlap(model_entities, test_entities)
 
     @staticmethod
@@ -145,7 +148,9 @@ class StatementCheckingTest(EmmaaTest):
 
     def __init__(self, stmt):
         self.stmt = stmt
-        self.entities = self.get_entities()
+        # TODO
+        # Add entities as a property if we can reload tests on s3.
+        # self.entities = self.get_entities()
 
     def check(self, pysb_model):
         """Use a model checker to check if a given model satisfies the test."""

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -155,7 +155,7 @@ class ScopeTestConnector(TestConnector):
         model_entities = model.entities
         test_entities = test.get_entities()
         # TODO
-        # After adding entities as a property to StatementCheckingTest(), use
+        # After adding entities as an attribute to StatementCheckingTest(), use
         # test_entities = test.entities
         return ScopeTestConnector._overlap(model_entities, test_entities)
 

--- a/emmaa/tests/test_model_tests.py
+++ b/emmaa/tests/test_model_tests.py
@@ -22,7 +22,6 @@ def test_run_tests_from_s3():
     tm = run_model_tests_from_s3('test', 'simple_model_test.pkl',
                                  upload_results=False)
     assert isinstance(tm, TestManager)
-    assert len(tm.pairs_to_test) == 1
-    assert len(tm.test_results) == 1
-    assert isinstance(tm.test_results[0], PathResult)
-
+    assert len(tm.model_managers[0].applicable_tests) == 1
+    assert len(tm.model_managers[0].test_results) == 1
+    assert isinstance(tm.model_managers.test_results[0], PathResult)

--- a/emmaa/tests/test_model_tests.py
+++ b/emmaa/tests/test_model_tests.py
@@ -24,4 +24,4 @@ def test_run_tests_from_s3():
     assert isinstance(tm, TestManager)
     assert len(tm.model_managers[0].applicable_tests) == 1
     assert len(tm.model_managers[0].test_results) == 1
-    assert isinstance(tm.model_managers.test_results[0], PathResult)
+    assert isinstance(tm.model_managers[0].test_results[0], PathResult)


### PR DESCRIPTION
This PR optimizes the model test structure and running time. A new class ModelManager has been added to store all attributes of a model together and generate them only once. 

Changes to the test:
- PySB model, model entities, and model checker are generated once at instanciation of ModelManager.
- After applicable tests are added, an influence map is generated once for all tests.
- Tests are now run for a list of applicable tests.
- TestManager takes a list of ModelManager objects now instead of list of EmmaaModels (every ModelManager has an EmmaaModel along with other attributes).

Suggestion: I also want to make test entities be generated only once at instantiation. To do that we need to reload small_corpus_tests.pkl to s3 with the updated class definition. I can do that if everything else looks ok.

