### PR TITLE
Statistic for EMMAA dashboard

### DIFF
--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -1,51 +1,74 @@
 import json
 import logging
 from collections import defaultdict
-from util import get_s3_client, find_latest_s3_files
-# load test results from s3
-# find number of passed tests in one test
-# find passed tests for n tests
-
-
-def load_test_results_from_s3(key):
-    client = get_s3_client()
-    logger.info(f'Loading test results from {key}')
-    obj = client.get_object(Bucket='emmaa', Key=key)
-    test_results = json.loads(obj['Body'].read().decode('utf8'))
-    return test_results
+from util import find_latest_s3_files, load_test_results_from_s3
+from indra.statements.statements import Statement
 
 
 class TestRound():
-    def __init__(key):
+    def __init__(self, key):
         self.key = key
         self.test_results = load_test_results_from_s3(key)
 
+    def has_path(self, result):
+        return result['result_json']['path_found']
+
     def get_total_tests(self):
-        return len(self.test_results)
+        return len(self.test_results)-1
 
     def get_number_passed_tests(self):
         path_count = 0
-        for res in self.test_results:
-                if res['result_json']['path_found']:
-                    path_count += 1
+        for result in self.test_results[1:]:
+            if self.has_path(result):
+                path_count += 1
         return path_count
 
     def passed_over_total(self):
-        return self.get_passed_tests()/self.get_passed_tests()
+        return self.get_number_passed_tests()/self.get_total_tests()
+
+    def get_number_statements(self):
+        return self.test_results[0]['number_of_statements']
+
+    def get_statements(self):
+        return self.test_results[0]['statements']
+
+    def get_passed_tests(self):
+        # change to english!
+        passed_tests = []
+        for result in self.test_results[1:]:
+            if self.has_path(result):
+                passed_tests.append(Statement._from_json(res['test_json']))
+        return passed_tests
+
+    def get_path_descriptions(self):
+        path_descriptions = []
+        for res in self.test_results[1:]:
+            if res['result_json']['path_found']:
+                path_descriptions.append(res['english_result'])
+
+    def find_numeric_delta(self, other_round, one_round_numeric_func):
+        return self.one_round_func() - other_round.one_round_numeric_func()
+
+    def find_content_delta(self, other_round, one_round_content_func):
+        changed_items = {'added': [], 'removed': []}
+        for item in self.one_round_content_func():
+            if item not in other_round.one_round_content_func():
+                changed_items['added'].append(item)
+        for item in other_round.one_round_content_func():
+            if item not in self.one_round_content_func():
+                changed_items['removed'].append(item)
+        return changed_items
 
 
-def run_for_multiple_rounds(number_of_tests, model_name, get_data):
-    # get_data - some function that gets some data for one test round
+def run_for_multiple_rounds(number_of_tests, model_name, one_round_func):
     keys = find_latest_s3_files(
            number_of_tests, 'emmaa',
            f'results/{model_name}results_', extension='.json')
     data = []
     for key in keys:
-        test_results = load_test_results_from_s3(key)
-        current_data = get_data(test_results)
+        tr = TestRound(key)
+        current_data = tr.one_round_func()
         data.append(current_data)
     return data
 
-
-# def find_delta(current_results, previous_results):
-    
+# def find_delta()

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -1,0 +1,51 @@
+import json
+import logging
+from collections import defaultdict
+from util import get_s3_client, find_latest_s3_files
+# load test results from s3
+# find number of passed tests in one test
+# find passed tests for n tests
+
+
+def load_test_results_from_s3(key):
+    client = get_s3_client()
+    logger.info(f'Loading test results from {key}')
+    obj = client.get_object(Bucket='emmaa', Key=key)
+    test_results = json.loads(obj['Body'].read().decode('utf8'))
+    return test_results
+
+
+class TestRound():
+    def __init__(key):
+        self.key = key
+        self.test_results = load_test_results_from_s3(key)
+
+    def get_total_tests(self):
+        return len(self.test_results)
+
+    def get_number_passed_tests(self):
+        path_count = 0
+        for res in self.test_results:
+                if res['result_json']['path_found']:
+                    path_count += 1
+        return path_count
+
+    def passed_over_total(self):
+        return self.get_passed_tests()/self.get_passed_tests()
+
+
+def run_for_multiple_rounds(number_of_tests, model_name, get_data):
+    # get_data - some function that gets some data for one test round
+    keys = find_latest_s3_files(
+           number_of_tests, 'emmaa',
+           f'results/{model_name}results_', extension='.json')
+    data = []
+    for key in keys:
+        test_results = load_test_results_from_s3(key)
+        current_data = get_data(test_results)
+        data.append(current_data)
+    return data
+
+
+# def find_delta(current_results, previous_results):
+    

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -11,6 +11,7 @@ class TestRound():
         self.key = key
         self.test_results = load_test_results_from_s3(key)
 
+    # Model Summary
     def get_statements(self):
         return self.test_results[0]['statements']
 
@@ -21,7 +22,20 @@ class TestRound():
         return statement_types
 
     def get_agents(self):
-        # add agent count
+        agent_count = defaultdict(int)
+        agent_types = ['subj', 'obj', 'sub', 'enz', 'agent']
+
+        def get_agent_name(stmt, agent_type):
+            return stmt[agent_type]['name']
+
+        for stmt in self.get_statements():
+            for agent_type in agent_types:
+                if agent_type in stmt.keys():
+                    agent_count[get_agent_name(stmt, agent_type)] += 1
+            if 'members' in stmt.keys():
+                for member in stmt['members']:
+                    agent_count[member['name']] += 1
+        return agent_count
 
     def get_support(self):
         stmts_evidence = {}
@@ -29,6 +43,7 @@ class TestRound():
             stmts_evidence[stmt['id']] = len(stmt.evidence)
         return stmts_evidence
 
+    # Test Summary
     def has_path(self, result):
         return result['result_json']['path_found']
 
@@ -62,6 +77,7 @@ class TestRound():
                 path_descriptions.append(result['english_result'])
         return path_descriptions
 
+    # Deltas
     def find_numeric_delta(self, other_round, one_round_numeric_func):
         return self.one_round_func() - other_round.one_round_numeric_func()
 

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -69,7 +69,7 @@ class TestRound(object):
 
     def get_stmt_hashes(self):
         """Return a list of hashes for all statements in a model."""
-        return [stmt.get_hash() for stmt in self.statements]
+        return [str(stmt.get_hash()) for stmt in self.statements]
 
     def get_statement_types(self):
         """Return a sorted list of tuples containing a statement type and a 
@@ -93,16 +93,16 @@ class TestRound(object):
     def get_statements_by_evidence(self):
         """Return a sorted list of tuples containing a statement hash and a
         number of times this statement occured in a model."""
-        stmts_evhasheence = {}
+        stmts_evidence = {}
         for stmt in self.statements:
-            stmts_evhasheence[stmt.get_hash()] = len(stmt.evhasheence)
-        return sorted(stmts_evhasheence.items(), key=lambda x: x[1], reverse=True)
+            stmts_evidence[str(stmt.get_hash())] = len(stmt.evidence)
+        return sorted(stmts_evidence.items(), key=lambda x: x[1], reverse=True)
 
     def get_english_statements_by_hash(self):
         """Return a dictionary mapping a statement and its English description."""
         stmts_by_hash = {}
         for stmt in self.statements:
-            stmts_by_hash[stmt.get_hash()] = self.get_english_statement(stmt)
+            stmts_by_hash[str(stmt.get_hash())] = self.get_english_statement(stmt)
         return stmts_by_hash
 
     def get_english_statement(self, stmt):
@@ -115,14 +115,14 @@ class TestRound(object):
     # Test Summary Methods
     def get_applied_test_hashes(self):
         """Return a list of hashes for all applied tests."""
-        return [test.get_hash() for test in self.tests]
+        return [str(test.get_hash()) for test in self.tests]
 
     def get_passed_test_hashes(self):
         """Return a list of hashes for passed tests."""
         passed_tests = []
         for ix, result in enumerate(self.test_results):
             if result.path_found:
-                passed_tests.append(self.tests[ix].get_hash())
+                passed_tests.append(str(self.tests[ix].get_hash()))
         return passed_tests
 
     def get_total_applied_tests(self):
@@ -141,7 +141,7 @@ class TestRound(object):
         """Return a dictionary mapping a test hash and its English description."""
         tests_by_hash = {}
         for test in self.tests:
-            tests_by_hash[test.get_hash()] = self.get_english_statement(test)
+            tests_by_hash[str(test.get_hash())] = self.get_english_statement(test)
         return tests_by_hash
 
     def get_path_descriptions(self):
@@ -150,7 +150,7 @@ class TestRound(object):
         paths = {}
         for ix, result in enumerate(self.test_results):
             if result.path_found:
-                paths[self.tests[ix].get_hash()] = (
+                paths[str(self.tests[ix].get_hash())] = (
                     self.json_results[ix+1]['english_result'])
         return paths
 
@@ -287,7 +287,7 @@ class StatsGenerator(object):
             return
         self.make_model_delta()
         self.make_tests_delta()
-        
+
     def make_model_summary(self):
         """Add latest model state summary to json_stats."""
         self.json_stats['model_summary'] = {
@@ -295,7 +295,7 @@ class StatsGenerator(object):
             'number_of_statements': self.latest_round.get_total_statements(),
             'stmts_type_distr': self.latest_round.get_statement_types(),
             'agent_distr': self.latest_round.get_agent_distribution(),
-            'stmts_by_evhasheence': self.latest_round.get_statements_by_evidence(),
+            'stmts_by_evidence': self.latest_round.get_statements_by_evidence(),
             'english_stmts': self.latest_round.get_english_statements_by_hash(),
             'earlier_number_of_statements': [
                 stats['model_summary']['number_of_statements']
@@ -308,7 +308,7 @@ class StatsGenerator(object):
             'number_applied_tests': self.latest_round.get_total_applied_tests(),
             'number_passed_tests': self.latest_round.get_number_passed_tests(),
             'passed_ratio': self.latest_round.passed_over_total(),
-            'tests_by_hashe': self.latest_round.get_english_tests(),
+            'tests_by_hash': self.latest_round.get_english_tests(),
             'passed_tests': self.latest_round.get_passed_test_hashes(),
             'paths': self.latest_round.get_path_descriptions(),
             'earlier_applied_tests': [

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -28,7 +28,7 @@ class TestRound(object):
     json_results : list[dict]
         A list of JSON formatted dictionaries to store information about the
         test results. The first dictionary contains information about the model.
-        Each consequent dictionary contains information about a single test
+        Each consecutive dictionary contains information about a single test
         applied to the model and test results.
 
     Attributes

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -4,24 +4,39 @@ from collections import defaultdict
 from util import (find_latest_s3_files, find_latest_s3_file,
                   find_second_latest_s3_file, load_test_results_from_s3)
 from indra.statements.statements import Statement
+from indra.assemblers.english.assembler import EnglishAssembler
 
-
-class TestRound():
+CONTENT_TYPE_FUNCTION_MAPPING = {
+    'statements': ('get_stmt_ids', 'get_english_statement_by_id'),
+    'applied_tests': ('get_applied_test_ids', 'get_english_test_by_id'),
+    'passed_tests': ('get_passed_test_ids', 'get_english_test_by_id'),
+    'paths': ('get_passed_test_ids', 'get_path_by_id')
+}
+class TestRound(object):
     def __init__(self, key):
         self.key = key
         self.test_results = load_test_results_from_s3(key)
 
     # Model Summary
+    def get_stmt_id(self, stmt):
+        return str(stmt['id'])
+
+    def get_number_statements(self):
+        return self.test_results[0]['number_of_statements']
+
     def get_statements(self):
         return self.test_results[0]['statements']
+
+    def get_stmt_ids(self):
+        return [self.get_stmt_id(stmt) for stmt in self.get_statements()]
 
     def get_statement_types(self):
         statement_types = defaultdict(int)
         for stmt in self.get_statements():
             statement_types[stmt['type']] += 1
-        return statement_types
+        return sorted(statement_types.items(), key=lambda x: x[1], reverse=True)
 
-    def get_agents(self):
+    def get_agent_distribution(self):
         agent_count = defaultdict(int)
         agent_types = ['subj', 'obj', 'sub', 'enz', 'agent']
 
@@ -35,66 +50,172 @@ class TestRound():
             if 'members' in stmt.keys():
                 for member in stmt['members']:
                     agent_count[member['name']] += 1
-        return agent_count
+        return sorted(agent_count.items(), key=lambda x: x[1], reverse=True)
 
-    def get_support(self):
+    def get_statements_by_evidence(self):
         stmts_evidence = {}
         for stmt in self.get_statements():
-            stmts_evidence[stmt['id']] = len(stmt.evidence)
-        return stmts_evidence
+            stmts_evidence[self.get_stmt_id(stmt)] = len(stmt.evidence)
+        return sorted(stmts_evidence.items(), key=lambda x: x[1], reverse=True)
+
+    def get_english_statements(self):
+        stmts_by_id = {}
+        for stmt in self.get_statements():
+            standard_stmt = Statement._from_json(stmt)
+            ea = EnglishAssembler([standard_stmt])
+            stmts_by_id[self.get_stmt_id(stmt)] = ea.make_model()
+        return stmts_by_id
+
+    def get_english_statement_by_id(self, stmt_id):
+        return self.get_english_statements[stmt_id]
 
     # Test Summary
     def has_path(self, result):
         return result['result_json']['path_found']
 
-    def get_total_tests(self):
+    def get_test_id(self, result):
+        return str(result['test_json']['id'])
+
+    def get_applied_test_ids(self):
+        return [self.get_test_id for result in self.test_results[1:]]
+
+    def get_total_applied_tests(self):
         return len(self.test_results)-1
 
     def get_number_passed_tests(self):
-        path_count = 0
-        for result in self.test_results[1:]:
-            if self.has_path(result):
-                path_count += 1
-        return path_count
+        return len(self.get_passed_test_ids)
 
     def passed_over_total(self):
-        return self.get_number_passed_tests()/self.get_total_tests()
+        return self.get_number_passed_tests()/self.get_total_applied_tests()
 
-    def get_number_statements(self):
-        return self.test_results[0]['number_of_statements']
+    def get_english_tests(self):
+        tests_by_id = {}
+        for result in self.test_results[1:]:
+            tests_by_id[self.get_test_id(result)] = result['english_test']
+        return tests_by_id
 
-    def get_passed_tests(self):
+    def get_english_test_by_id(self, test_id):
+        return self.get_english_tests[test_id]
+
+    def get_passed_test_ids(self):
         passed_tests = []
         for result in self.test_results[1:]:
             if self.has_path(result):
-                passed_tests.append(result['english_test'])
+                passed_tests.append(self.get_test_id(result))
         return passed_tests
 
     def get_path_descriptions(self):
-        path_descriptions = []
+        paths = {}
         for result in self.test_results[1:]:
             if self.has_path(result):
-                path_descriptions.append(result['english_result'])
-        return path_descriptions
+                paths[self.get_test_id(result)] = result['english_result']
+        return paths
+
+    def get_path_by_id(self, test_id):
+        return self.get_path_descriptions[test_id]
 
     # Deltas
     def find_numeric_delta(self, other_round, one_round_numeric_func):
-        return self.one_round_func() - other_round.one_round_numeric_func()
+        # return self.one_round_func() - other_round.one_round_numeric_func()
+        return getattr(self, one_round_numeric_func)()
+                       - getattr(other_round, one_round_numeric_func)()
 
-    def find_content_delta(self, other_round, one_round_content_func):
-        changed_items = {'added': [], 'removed': []}
-        for item in self.one_round_content_func():
-            if item not in other_round.one_round_content_func():
-                changed_items['added'].append(item)
-        for item in other_round.one_round_content_func():
-            if item not in self.one_round_content_func():
-                changed_items['removed'].append(item)
-        return changed_items
+    def find_stmts_delta(self, other_round):
+        latest_ids = self.get_stmt_ids()
+        previous_ids = other_round.get_stmt_ids()
+        added_ids = list(set(latest_ids) - set(previous_ids))
+        removed_ids = list(set(previous_ids) - set(latest_ids))
+        added_stmts = [self.get_english_statement_by_id(stmt_id) 
+                       for stmt_id in added_ids]
+        removed_stmts = [other_round.get_english_statement_by_id(stmt_id)
+                         for stmt_id in removed_ids]
+        return {'added_stmts': added_stmts, 'removed_stmts': removed_stmts}
+
+    def find_applied_tests_delta(self, other_round):
+        latest_test_ids = self.get_applied_test_ids()
+        previous_test_ids = other_round.get_applied_test_ids()
+        added_test_ids = list(set(latest_test_ids) - set(previous_test_ids))
+        removed_test_ids = list(set(previous_test_ids) - set(latest_test_ids))
+        added_tests = [self.get_english_test_by_id(test_id)
+                       for test_id in added_test_ids]
+        removed_tests = [other_round.get_english_test_by_id(test_id)
+                         for test_id in removed_test_ids]
+        return {'added_tests': added_tests, 'removed_tests': removed_tests}
+
+    def find_pass_fail_delta(self, other_round):
+        latest_passed_ids = self.get_passed_test_ids()
+        previous_passed_ids = other_round.get_passed_test_ids()
+        new_passed_ids = list(set(latest_passed_ids) - set(previous_passed_ids))
+        new_failed_ids = list(set(previous_passed_ids) - set(latest_passed_ids))
+        new_passed_tests = [self.get_english_test_by_id(test_id)
+                            for test_id in new_passed_ids]
+        new_failed_tests = [other_round.get_english_test_by_id(test_id)
+                            for test_id in new_failed_ids]
+        return {'new_passed_tests': new_passed_tests, 
+                'new_failed_tests': new_failed_tests}
+
+    def find
+    def find_content_delta(self, other_round, content_type):
+        """content_type: statements, applied_tests, passed_tests, paths?
+        get_ids: statements - get_stmt_ids()
+        """
+        
 
 
-def run_for_multiple_rounds(number_of_tests, model_name, one_round_func):
+class StatsGenerator(object):
+    def __init__(self, model_name, number_of_rounds=10):
+        self.model_name = model_name
+        self.number_of_rounds = number_of_rounds
+        self.latest_round = TestRound(find_latest_s3_file(
+            'emmaa', f'results/{model_name}/results_', extension='.json'))
+        self.previous_round = TestRound(ind_second_latest_s3_file('emmaa',
+            f'results/{model_name}/results_', extension='.json'))
+        self.json_stats = {}
+
+    def make_model_summary(self):
+        json_stats['model_summary'] = {
+            'model_name': model_name,
+            'number_of_statements': self.latest_round.get_number_statements(),
+            'stmts_type_distr': self.latest_round.get_statement_types(),
+            'agent_distr': self.latest_round.get_agent_distribution(),
+            'stmts_by_evidence': self.latest_round.get_statements_by_evidence(),
+            'english_stmts': self.latest_round.get_english_statements()
+        }
+
+    def make_test_summary(self):
+        json_stats['test_round_summary'] = {
+            'number_applied_tests': self.latest_round.get_total_applied_tests(),
+            'number_passed_tests': self.latest_round.get_number_passed_tests(),
+            'passed_ratio': self.latest_round.passed_over_total(),
+            'tests_by_id': self.latest_round.get_english_test_by_id(),
+            'passed_tests': self.latest_round.get_passed_test_ids(),
+            'paths': self.latest_round.get_path_descriptions_by_test_id()
+        }
+
+    def make_model_delta(self):
+        json_stats['model_delta'] = {
+            'number_of_statements_delta': self.latest_round.find_numeric_delta(
+                self.previous_round, 'get_number_statements'),
+            'statements_delta': self.latest_round.find_stmts_delta(
+                                self.previous_round),
+       }
+
+    def make_tests_delta(self):
+        json_stats['tests_delta'] = {
+            'number_applied_tests_delta': self.latest_round.find_numeric_delta(
+                self.previous_round, 'get_total_applied_tests'),
+            'number_passed_tests_delta': self.latest_round.find_numeric_delta(
+                self.previous_round, 'get_number_passed_tests'),
+            'passed_ratio_delta': self.latest_round.find_numeric_delta(
+                self.previous_round, 'passed_over_total'),
+            'applied_tests_delta'
+            'pass_fail_delta'
+            'new_paths'
+        }
+
+def run_for_multiple_rounds(number_of_rounds, model_name, one_round_func):
     keys = find_latest_s3_files(
-           number_of_tests, 'emmaa',
+           number_of_rounds, 'emmaa',
            f'results/{model_name}results_', extension='.json')
     data = []
     for key in keys:
@@ -102,13 +223,3 @@ def run_for_multiple_rounds(number_of_tests, model_name, one_round_func):
         current_data = tr.one_round_func()
         data.append(current_data)
     return data
-
-
-def get_deltas(model_name):
-    latest_key = find_latest_s3_file('emmaa', f'results/{model_name}/results_',
-                                     extension='.json')
-    previous_key = find_second_latest_s3_file('emmaa',
-                                              f'results/{model_name}/results_',
-                                              extension='.json')
-    latest_round = TestRound(latest_key)
-    previous_round = TestRound(previous_key)

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -155,16 +155,28 @@ class TestRound(object):
 
 
 class StatsGenerator(object):
-    def __init__(self, model_name):
+    def __init__(self, model_name, latest_round=None, previous_round=None):
         self.model_name = model_name
-        self.latest_round = TestRound.load_from_s3_key(
-            find_latest_s3_file(
-                'emmaa', f'results/{model_name}/results_', extension='.json'))
-        self.previous_round = TestRound.load_from_s3_key(
-            find_second_latest_s3_file(
-                'emmaa', f'results/{model_name}/results_', extension='.json'))
+        if not latest_round:
+            self.latest_round = self._get_latest_round()
+        else:
+            self.latest_round = latest_round
+        if not previous_round:
+            self.previous_round = self._get_previous_round()
+        else:
+            self.previous_round = previous_round
         self.json_stats = {}
 
+    def _get_latest_round(self):
+        tr = TestRound.load_from_s3_key(find_latest_s3_file(
+            'emmaa', f'results/{self.model_name}/results_', extension='.json'))
+        return tr
+
+    def _get_previous_round(self):
+        tr = TestRound.load_from_s3_key(find_second_latest_s3_file(
+            'emmaa', f'results/{self.model_name}/results_', extension='.json'))
+        return tr
+        
     def make_model_summary(self):
         json_stats['model_summary'] = {
             'model_name': self.model_name,

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -179,27 +179,27 @@ class StatsGenerator(object):
         return tr
         
     def make_model_summary(self):
-        json_stats['model_summary'] = {
+        self.json_stats['model_summary'] = {
             'model_name': self.model_name,
             'number_of_statements': self.latest_round.get_total_statements(),
             'stmts_type_distr': self.latest_round.get_statement_types(),
             'agent_distr': self.latest_round.get_agent_distribution(),
             'stmts_by_evidence': self.latest_round.get_statements_by_evidence(),
-            'english_stmts': self.latest_round.get_english_statements()
+            'english_stmts': self.latest_round.get_english_statements_by_hash()
         }
 
     def make_test_summary(self):
-        json_stats['test_round_summary'] = {
+        self.json_stats['test_round_summary'] = {
             'number_applied_tests': self.latest_round.get_total_applied_tests(),
             'number_passed_tests': self.latest_round.get_number_passed_tests(),
             'passed_ratio': self.latest_round.passed_over_total(),
             'tests_by_id': self.latest_round.get_english_tests(),
-            'passed_tests': self.latest_round.get_passed_test_ids(),
+            'passed_tests': self.latest_round.get_passed_test_hashes(),
             'paths': self.latest_round.get_path_descriptions()
         }
 
     def make_model_delta(self):
-        json_stats['model_delta'] = {
+        self.json_stats['model_delta'] = {
             'number_of_statements_delta': self.latest_round.find_numeric_delta(
                 self.previous_round, 'get_total_statements'),
             'statements_delta': self.latest_round.find_content_delta(
@@ -207,7 +207,7 @@ class StatsGenerator(object):
         }
 
     def make_tests_delta(self):
-        json_stats['tests_delta'] = {
+        self.json_stats['tests_delta'] = {
             'number_applied_tests_delta': self.latest_round.find_numeric_delta(
                 self.previous_round, 'get_total_applied_tests'),
             'number_passed_tests_delta': self.latest_round.find_numeric_delta(

--- a/emmaa/aws_lambda_functions/analyze_changes_on_s3.py
+++ b/emmaa/aws_lambda_functions/analyze_changes_on_s3.py
@@ -70,7 +70,7 @@ def lambda_handler(event, context):
         if BRANCH is not None:
             core_command += f' --branch {BRANCH}'
         core_command += (' python scripts/run_model_tests_from_s3.py'
-                         f' --model {model_name} --test small_corpus_tests.pkl')
+                         f' --model {model_name} --test large_corpus_tests.pkl')
         print(core_command)
         cont_overrides = {
             'command': ['python', '-m', 'indra.util.aws', 'run_in_batch',

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -39,6 +39,8 @@ class EmmaaModel(object):
         A list of SearchTerm objects containing the search terms used in the model
     ndex_network : str
         The identifier of the NDEx network corresponding to the model.
+    assembled_stmts : list[indra.statements.Statement]
+        A list of assembled INDRA Statements
     """
     def __init__(self, name, config):
         self.name = name

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -59,8 +59,7 @@ class ModelManager(object):
         self.test_results.append(result)
 
     def run_one_test(self, test):
-        """
-        Run one test. Recommended for testing only.
+        """Run one test. Recommended for testing only.
         Use run_tests() to run all tests.
         """
         return test.check(self.model_checker, self.pysb_model)
@@ -89,8 +88,7 @@ class ModelManager(object):
         return result.path_found
 
     def get_english_result(self, result):
-        """
-        Get English description of a path if it was found.
+        """Get English description of a path if it was found.
         Return an empty string otherwise.
         """
         if self.has_path(result):
@@ -136,8 +134,7 @@ class TestManager(object):
         self.tests = tests
 
     def make_tests(self, test_connector):
-        """
-        Generate a list of applicable tests for each model with a given test
+        """Generate a list of applicable tests for each model with a given test
         connector.
 
         Parameters

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -109,6 +109,7 @@ class ModelManager(object):
             results_json.append({
                    'test_type': test.__class__.__name__,
                    'test_json': test.to_json(),
+                   'english_test': test.get_english_description(),
                    'result_json': pickler.flatten(self.test_results[ix]),
                    'english_result': self.get_english_result(
                                      self.test_results[ix])})
@@ -216,6 +217,11 @@ class StatementCheckingTest(EmmaaTest):
     def get_entities(self):
         """Return a list of entities that the test checks for."""
         return self.stmt.agent_list()
+
+    def get_english_description(self):
+        """Return an English representation of a statement."""
+        ea = EnglishAssembler(self.stmt)
+        return ea.make_model()
 
     def to_json(self):
         return self.stmt.to_json()

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -278,9 +278,9 @@ def run_model_tests_from_s3(model_name, test_name, upload_results=True):
 
     Returns
     -------
-    emmaa.model_tests.TestManager
-        Instance of TestManager containing the model/test pairs and the
-        test results.
+    emmaa.model_tests.ModelManager
+        Instance of ModelManager containing the model data, list of applied
+        tests and the test results.
     """
     model = EmmaaModel.load_from_s3(model_name)
     tests = load_tests_from_s3(test_name)
@@ -298,4 +298,4 @@ def run_model_tests_from_s3(model_name, test_name, upload_results=True):
         logger.info(f'Uploading test results to {result_key}')
         client.put_object(Bucket='emmaa', Key=result_key,
                           Body=results_json_str.encode('utf8'))
-    return tm
+    return mm

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -227,7 +227,7 @@ class StatementCheckingTest(EmmaaTest):
 
     def get_english_description(self):
         """Return an English representation of a test."""
-        ea = EnglishAssembler(self.stmt)
+        ea = EnglishAssembler([self.stmt])
         return ea.make_model()
 
     def to_json(self):

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -101,10 +101,12 @@ class ModelManager(object):
         """Put test results to json format."""
         pickler = jsonpickle.pickler.Pickler()
         results_json = []
+        results_json.append({                   
+            'model_name': self.model.name,
+            'statements': self.model.assembled_stmts,
+            'number_of_statements': len(self.model.assembled_stmts)})
         for ix, test in enumerate(self.applicable_tests):
             results_json.append({
-                   'model_name': self.model.name,
-                   'number_of_statements': self.model.assembled_stmts
                    'test_type': test.__class__.__name__,
                    'test_json': test.to_json(),
                    'result_json': pickler.flatten(self.test_results[ix]),

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -110,8 +110,7 @@ class ModelManager(object):
         results_json = []
         results_json.append({                   
             'model_name': self.model.name,
-            'statements': self.assembled_stmts_to_json(),
-            'number_of_statements': len(self.model.assembled_stmts)})
+            'statements': self.assembled_stmts_to_json()})
         for ix, test in enumerate(self.applicable_tests):
             results_json.append({
                    'test_type': test.__class__.__name__,

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -115,7 +115,6 @@ class ModelManager(object):
             results_json.append({
                    'test_type': test.__class__.__name__,
                    'test_json': test.to_json(),
-                   'english_test': test.get_english_description(),
                    'result_json': pickler.flatten(self.test_results[ix]),
                    'english_result': self.get_english_result(
                                      self.test_results[ix])})
@@ -223,11 +222,6 @@ class StatementCheckingTest(EmmaaTest):
     def get_entities(self):
         """Return a list of entities that the test checks for."""
         return self.stmt.agent_list()
-
-    def get_english_description(self):
-        """Return an English representation of a test."""
-        ea = EnglishAssembler([self.stmt])
-        return ea.make_model()
 
     def to_json(self):
         return self.stmt.to_json()

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -104,6 +104,7 @@ class ModelManager(object):
         for ix, test in enumerate(self.applicable_tests):
             results_json.append({
                    'model_name': self.model.name,
+                   'number_of_statements': self.model.assembled_stmts
                    'test_type': test.__class__.__name__,
                    'test_json': test.to_json(),
                    'result_json': pickler.flatten(self.test_results[ix]),

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -97,13 +97,20 @@ class ModelManager(object):
             return self.make_english_result(result)
         return []
 
+    def assembled_stmts_to_json(self):
+        """Put assembled statements to JSON format."""
+        stmts = []
+        for stmt in self.model.assembled_stmts:
+            stmts.append(stmt.to_json())
+        return stmts
+
     def results_to_json(self):
         """Put test results to json format."""
         pickler = jsonpickle.pickler.Pickler()
         results_json = []
         results_json.append({                   
             'model_name': self.model.name,
-            'statements': self.model.assembled_stmts,
+            'statements': self.assembled_stmts_to_json(),
             'number_of_statements': len(self.model.assembled_stmts)})
         for ix, test in enumerate(self.applicable_tests):
             results_json.append({
@@ -219,7 +226,7 @@ class StatementCheckingTest(EmmaaTest):
         return self.stmt.agent_list()
 
     def get_english_description(self):
-        """Return an English representation of a statement."""
+        """Return an English representation of a test."""
         ea = EnglishAssembler(self.stmt)
         return ea.make_model()
 

--- a/emmaa/tests/test_model_tests.py
+++ b/emmaa/tests/test_model_tests.py
@@ -1,13 +1,21 @@
-from indra.explanation.model_checker import PathResult
+from indra.explanation.model_checker import PathResult, ModelChecker
+from indra.statements.statements import Statement
+from emmaa.model import EmmaaModel
 from emmaa.model_tests import (StatementCheckingTest, run_model_tests_from_s3,
-                               load_tests_from_s3, TestManager)
+                               load_tests_from_s3, ModelManager)
+from emmaa.analyze_tests_results import TestRound, StatsGenerator
 
 # Tell nose to not run tests in the imported modules
 StatementCheckingTest.__test__ = False
 run_model_tests_from_s3.__test__ = False
 load_tests_from_s3.__test__ = False
-TestManager.__test__ = False
+ModelManager.__test__ = False
 PathResult.__test__ = False
+EmmaaModel.__test__ = False
+ModelChecker.__test__ = False
+TestRound.__test__ = False
+StatsGenerator.__test__ = False
+Statement.__test__ = False
 
 
 def test_load_tests_from_s3():
@@ -19,9 +27,20 @@ def test_load_tests_from_s3():
 
 
 def test_run_tests_from_s3():
-    tm = run_model_tests_from_s3('test', 'simple_model_test.pkl',
-                                 upload_results=False)
-    assert isinstance(tm, TestManager)
-    assert len(tm.model_managers[0].applicable_tests) == 1
-    assert len(tm.model_managers[0].test_results) == 1
-    assert isinstance(tm.model_managers[0].test_results[0], PathResult)
+    (mm, sg) = run_model_tests_from_s3(
+        'test', 'simple_model_test.pkl', belief_cutoff=None,
+        upload_results=False, upload_stats=False)
+    assert isinstance(mm, ModelManager)
+    assert isinstance(mm.model, EmmaaModel)
+    assert isinstance(mm.model_checker, ModelChecker)
+    assert isinstance(mm.test_results[0], PathResult)
+    assert isinstance(mm.applicable_tests[0], StatementCheckingTest)
+    assert len(mm.applicable_tests) == 1
+    assert len(mm.test_results) == 1
+    assert isinstance(sg, StatsGenerator)
+    assert isinstance(sg.latest_round, TestRound)
+    assert isinstance(sg.latest_round.test_results[0], PathResult)
+    assert isinstance(sg.latest_round.statements[0], Statement)
+    assert len(sg.latest_round.statements) == 2
+    assert len(sg.latest_round.test_results) == 1
+    assert len(sg.latest_round.tests) == 1

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -54,15 +54,21 @@ def sort_s3_files_by_date(bucket, prefix, extension=None):
 def find_latest_s3_file(bucket, prefix, extension=None):
     """Return the key of the file with latest date string on an S3 path"""
     files = sort_s3_files_by_date(bucket, prefix, extension)
-    latest = files[0]['Key']
-    return latest
+    try:
+        latest = files[0]['Key']
+        return latest
+    except IndexError:
+        print('File is not found.')
 
 
 def find_second_latest_s3_file(bucket, prefix, extension=None):
     """Return the key of the file with second latest date string on an S3 path"""
     files = sort_s3_files_by_date(bucket, prefix, extension)
-    latest = files[1]['Key']
-    return latest
+    try:
+        latest = files[1]['Key']
+        return latest
+    except IndexError:
+        print("File is not found.")
 
 
 def find_latest_s3_files(number_of_files, bucket, prefix, extension=None):

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -1,11 +1,13 @@
 import os
 import boto3
+import logging
 from datetime import datetime
 from botocore import UNSIGNED
 from botocore.client import Config
 
 
 FORMAT = '%Y-%m-%d-%H-%M-%S'
+logger = logging.getLogger(__name__)
 
 
 def get_date_from_str(date_str):
@@ -58,7 +60,7 @@ def find_latest_s3_file(bucket, prefix, extension=None):
         latest = files[0]['Key']
         return latest
     except IndexError:
-        print('File is not found.')
+        logger.info('File is not found.')
 
 
 def find_second_latest_s3_file(bucket, prefix, extension=None):
@@ -68,7 +70,7 @@ def find_second_latest_s3_file(bucket, prefix, extension=None):
         latest = files[1]['Key']
         return latest
     except IndexError:
-        print("File is not found.")
+        logger.info("File is not found.")
 
 
 def find_latest_s3_files(number_of_files, bucket, prefix, extension=None):

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -78,14 +78,6 @@ def find_latest_s3_files(number_of_files, bucket, prefix, extension=None):
     return keys
 
 
-def load_test_results_from_s3(key):
-    client = get_s3_client()
-    logger.info(f'Loading test results from {key}')
-    obj = client.get_object(Bucket='emmaa', Key=key)
-    test_results = json.loads(obj['Body'].read().decode('utf8'))
-    return test_results
-
-
 def get_s3_client(unsigned=True):
     """Return a boto3 S3 client with optional unsigned config.
 

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -32,8 +32,11 @@ def make_date_str(date=None):
     return date.strftime(FORMAT)
 
 
-def find_latest_s3_file(bucket, prefix, extension=None):
-    """Return the key of the file with latest date string on an S3 path"""
+def sort_s3_files_by_date(bucket, prefix, extension=None):
+    """
+    Return the list of keys of the files on an S3 path sorted by date starting
+    with the most recent one.
+    """
     def process_key(key):
         fname_with_extension = os.path.basename(key)
         fname = os.path.splitext(fname_with_extension)[0]
@@ -45,8 +48,27 @@ def find_latest_s3_file(bucket, prefix, extension=None):
     if extension:
         files = [file for file in files if file['Key'].endswith(extension)]
     files = sorted(files, key=lambda f: process_key(f['Key']), reverse=True)
+    return files
+
+
+def find_latest_s3_file(bucket, prefix, extension=None):
+    """Return the key of the file with latest date string on an S3 path"""
+    files = sort_s3_files_by_date(bucket, prefix, extension)
     latest = files[0]['Key']
     return latest
+
+
+def find_latest_s3_files(number_of_files, bucket, prefix, extension=None):
+    """
+    Return the keys of the specified number of files with latest date strings
+    on an S3 path.
+    """
+    files = sort_s3_files_by_date(bucket, prefix, extension)
+    keys = []
+    for ix in range(number_of_files):
+        keys.append(files[ix]['Key'])
+    keys.reverse()
+    return keys
 
 
 def get_s3_client(unsigned=True):

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -68,7 +68,7 @@ def find_second_latest_s3_file(bucket, prefix, extension=None):
 def find_latest_s3_files(number_of_files, bucket, prefix, extension=None):
     """
     Return the keys of the specified number of files with latest date strings
-    on an S3 path.
+    on an S3 path sorted by date starting with the earliest one.
     """
     files = sort_s3_files_by_date(bucket, prefix, extension)
     keys = []
@@ -76,6 +76,11 @@ def find_latest_s3_files(number_of_files, bucket, prefix, extension=None):
         keys.append(files[ix]['Key'])
     keys.reverse()
     return keys
+
+
+def find_number_of_files_on_s3(bucket, prefix, extension=None):
+    files = sort_s3_files_by_date(bucket, prefix, extension)
+    return len(files)
 
 
 def get_s3_client(unsigned=True):

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -58,6 +58,13 @@ def find_latest_s3_file(bucket, prefix, extension=None):
     return latest
 
 
+def find_second_latest_s3_file(bucket, prefix, extension=None):
+    """Return the key of the file with second latest date string on an S3 path"""
+    files = sort_s3_files_by_date(bucket, prefix, extension)
+    latest = files[1]['Key']
+    return latest
+
+
 def find_latest_s3_files(number_of_files, bucket, prefix, extension=None):
     """
     Return the keys of the specified number of files with latest date strings
@@ -69,6 +76,14 @@ def find_latest_s3_files(number_of_files, bucket, prefix, extension=None):
         keys.append(files[ix]['Key'])
     keys.reverse()
     return keys
+
+
+def load_test_results_from_s3(key):
+    client = get_s3_client()
+    logger.info(f'Loading test results from {key}')
+    obj = client.get_object(Bucket='emmaa', Key=key)
+    test_results = json.loads(obj['Body'].read().decode('utf8'))
+    return test_results
 
 
 def get_s3_client(unsigned=True):

--- a/scripts/get_model_test_stats.py
+++ b/scripts/get_model_test_stats.py
@@ -7,7 +7,7 @@ from emmaa.util import find_latest_s3_file, get_s3_client
 logger = logging.getLogger(__name__)
 
 
-def load_latest_test_results_from_s3(model_name):
+def load_test_results_from_s3(model_name):
     base_key = f'results/{model_name}'
     latest_result_key = find_latest_s3_file('emmaa', f'{base_key}/results_',
                                             extension='.json')
@@ -20,7 +20,7 @@ def load_latest_test_results_from_s3(model_name):
 
 def show_statistics(model_name):
     try:
-        test_results = load_latest_test_results_from_s3(model_name)
+        test_results = load_test_results_from_s3(model_name)
     except IndexError:
         print('No test results for ' + model_name + ' model available.')
     else:

--- a/scripts/get_model_test_stats.py
+++ b/scripts/get_model_test_stats.py
@@ -7,7 +7,7 @@ from emmaa.util import find_latest_s3_file, get_s3_client
 logger = logging.getLogger(__name__)
 
 
-def load_test_results_from_s3(model_name):
+def load_latest_test_results_from_s3(model_name):
     base_key = f'results/{model_name}'
     latest_result_key = find_latest_s3_file('emmaa', f'{base_key}/results_',
                                             extension='.json')
@@ -20,7 +20,7 @@ def load_test_results_from_s3(model_name):
 
 def show_statistics(model_name):
     try:
-        test_results = load_test_results_from_s3(model_name)
+        test_results = load_latest_test_results_from_s3(model_name)
     except IndexError:
         print('No test results for ' + model_name + ' model available.')
     else:

--- a/scripts/run_model_tests_from_s3.py
+++ b/scripts/run_model_tests_from_s3.py
@@ -12,5 +12,6 @@ if __name__ == '__main__':
                              'runs all available tests against the model.')
     args = parser.parse_args()
 
-    run_model_tests_from_s3(args.model, args.test, upload_results=True)
+    run_model_tests_from_s3(
+        args.model, args.test, upload_results=True, upload_stats=True)
 


### PR DESCRIPTION
This PR generates model and test statistics for EMMAA dashboard. This step will be executed after each test run and it will upload additional JSON file to S3. The following statistics is generated:

- Model Summary: 
-- name
-- number of statements
-- statement types distribution
-- agents distribution
-- statements (hashes) with evidence count
-- English assembled statements mapped to hashes

- Test Summary:
-- number of applied tests
-- number of passed tests
-- ratio of passed tests over total applied
-- English descriptions of tests mapped to hashes
-- hashes of passed tests
-- English descriptions of found paths mapped to test hashes

- Model Delta between two latest rounds:
-- number of statements
-- actual added and removed statements (English)

- Test Delta between two latest round:
-- number of applied tests
-- number of passed tests
-- passed tests ratio
-- added and removed applied tests (English)
-- new passed and new failed tests (English)
-- new paths found and previous paths (for previously passed and now failed tests) (English)

- Changes over time:
-- number of statements
-- number of applied tests
-- number of passed tests
-- ratio of passed tests

Other small changes in this PR are changing the format of model test output to provide better data for statistics and adding a few util functions to access any files on S3 (not only latest).
