### PR TITLE
Assembled entities

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -206,7 +206,17 @@ class EmmaaModel(object):
             agents += [a for a in stmt.agent_list() if a is not None]
         return agents
 
-    def assemble_pysb(self, belief_cutoff=0.8):
+    def get_assembled_entities(self, belief_cutoff=None):
+        """Return a list of Agent objects that the assembled model contains."""
+        if not self.assembled_stmts:
+            self.run_assembly(
+                belief_cutoff=belief_cutoff, filter_ungrounded=True)
+        agents = []
+        for stmt in self.assembled_stmts:
+            agents += [a for a in stmt.agent_list() if a is not None]
+        return agents
+
+    def assemble_pysb(self, belief_cutoff=None):
         """Assemble the model into PySB and return the assembled model."""
         self.run_assembly(belief_cutoff=belief_cutoff, filter_ungrounded=True)
         pa = PysbAssembler()

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -42,7 +42,8 @@ class ModelManager(object):
     def __init__(self, model, belief_cutoff=None):
         self.model = model
         self.pysb_model = self.model.assemble_pysb(belief_cutoff=belief_cutoff)
-        self.entities = self.model.get_entities()
+        self.entities = self.model.get_assembled_entities(
+            belief_cutoff=belief_cutoff)
         self.applicable_tests = []
         self.test_results = []
         self.model_checker = ModelChecker(self.pysb_model)


### PR DESCRIPTION
This PR adds a method get_assembled_entities() to EmmaaModel class. The assembled entities are then used to check applicability of a test to a model. I also set default value of belief_cutoff to None and used 0.8 value only when calling run_model_tests_from_s3 function. 