### PR TITLE
Model configuration with JSON

### DIFF
--- a/dashboard/emmaaFunctions.js
+++ b/dashboard/emmaaFunctions.js
@@ -330,7 +330,7 @@ function populateTestResultTable(tableBody, json) {
 function listModelInfo(modelInfoTableBody, keyMapArray, bucket, model, endsWith) {
   console.log('listModelInfo(modelInfoTableBody, keyMapArray, bucket, model, endsWith)')
   // 1. Last updated: get from listing models using already created function
-  // 2. NDEX link-out: read yaml as plain text and reg-exp match your way to the NDEX if
+  // 2. NDEX link-out: read from config
   // 3. Possibly listing nodes and edges info (Q: from where? A: From the json files that don't exist yet)
 
   // Get an array of the models for model
@@ -346,10 +346,10 @@ function listModelInfo(modelInfoTableBody, keyMapArray, bucket, model, endsWith)
   }
   modelInfoTableBody.appendChild(addToRow(['Last updated', lastUpdated]))
 
-  var yamlURL = 'https://s3.amazonaws.com/' + bucket + '/models/' + model + '/config.json';
-  console.log('Loading model json from ' + yamlURL)
-  var yamlPromise = $.ajax({
-    url: yamlURL,
+  var configURL = 'https://s3.amazonaws.com/' + bucket + '/models/' + model + '/config.json';
+  console.log('Loading model json from ' + configURL)
+  var configPromise = $.ajax({
+    url: configURL,
     dataType: "json",
     success: function(json) {
       console.log('success! Here is your model json ndex id: ')
@@ -358,11 +358,11 @@ function listModelInfo(modelInfoTableBody, keyMapArray, bucket, model, endsWith)
       let link = document.createElement('a');
       link.textContent = ndexID;
       link.href = 'http://www.ndexbio.org/#/network/' + ndexID;
-      
+
       tableRow = addToRow(['Network on NDEX', '']);
       tableRow.children[1].innerHTML = null;
       tableRow.children[1].appendChild(link);
-      
+
       modelInfoTableBody.appendChild(tableRow);
       }
   });

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,7 +3,6 @@ sphinx_rtd_theme
 mock
 boto3
 indra
-pyyaml
 jsonpickle
 kappy
 fnvhash

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -217,7 +217,7 @@ class EmmaaModel(object):
             Latest instance of EmmaaModel with the given name, loaded from S3.
         """
         config = load_config_from_s3(model_name)
-        stmts = load_model_from_s3(model_name)
+        stmts = load_stmts_from_s3(model_name)
         em = klass(model_name, config)
         em.stmts = stmts
         return em
@@ -302,7 +302,7 @@ def save_config_to_s3(model_name, config):
                       Bucket='emmaa', Key=config_key)
 
 
-def load_model_from_s3(model_name):
+def load_stmts_from_s3(model_name):
     """Return the list of EMMAA Statements constituting the latest model.
 
     Parameters

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -281,6 +281,25 @@ def load_config_from_s3(model_name):
     return config
 
 
+def save_config_to_s3(model_name, config):
+    """Upload config settings for a model to S3.
+
+    Parameters
+    ----------
+    model_name : str
+        The name of the model whose config should be saved to S3.
+    config : dict
+        A JSON dict of configurations for the model.
+    """
+    client = get_s3_client()
+    base_key = f'models/{model_name}'
+    config_key = f'{base_key}/config.json'
+    logger.info(f'Saving model config to {config_key}')
+    client.put_object(Body=str.encode(json.dumps(config, indent=1),
+                                      encoding='utf8'),
+                      Bucket='emmaa', Key=config_key)
+
+
 def load_model_from_s3(model_name):
     """Return the list of EMMAA Statements constituting the latest model.
 

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -277,7 +277,7 @@ def load_config_from_s3(model_name):
     config_key = f'{base_key}/config.json'
     logger.info(f'Loading model config from {config_key}')
     obj = client.get_object(Bucket='emmaa', Key=config_key)
-    config = json.load(obj['Body'].read().decode('utf8'))
+    config = json.loads(obj['Body'].read().decode('utf8'))
     return config
 
 

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -51,11 +51,10 @@ class ModelManager(object):
     model_checker : indra.explanation.model_checker.ModelChecker
         A ModelChecker to check PySB model
     """
-    def __init__(self, model, belief_cutoff=None):
+    def __init__(self, model):
         self.model = model
-        self.pysb_model = self.model.assemble_pysb(belief_cutoff=belief_cutoff)
-        self.entities = self.model.get_assembled_entities(
-            belief_cutoff=belief_cutoff)
+        self.pysb_model = self.model.assemble_pysb()
+        self.entities = self.model.get_assembled_entities()
         self.applicable_tests = []
         self.test_results = []
         self.model_checker = ModelChecker(self.pysb_model)
@@ -312,9 +311,8 @@ def save_model_manager_to_s3(model_name, model_manager):
                       Key=f'results/{model_name}/latest_model_manager.pkl')
 
 
-def run_model_tests_from_s3(model_name, test_name, belief_cutoff=0.8,
-                            upload_mm=True, upload_results=True,
-                            upload_stats=True):
+def run_model_tests_from_s3(model_name, test_name, upload_mm=True,
+                            upload_results=True, upload_stats=True):
     """Run a given set of tests on a given model, both loaded from S3.
 
     After loading both the model and the set of tests, model/test overlap
@@ -341,7 +339,7 @@ def run_model_tests_from_s3(model_name, test_name, belief_cutoff=0.8,
     """
     model = EmmaaModel.load_from_s3(model_name)
     tests = load_tests_from_s3(test_name)
-    mm = ModelManager(model, belief_cutoff=belief_cutoff)
+    mm = ModelManager(model)
     if upload_mm:
         save_model_manager_to_s3(model_name, mm)
     tm = TestManager([mm], tests)

--- a/emmaa/tests/test_model_tests.py
+++ b/emmaa/tests/test_model_tests.py
@@ -28,7 +28,7 @@ def test_load_tests_from_s3():
 
 def test_run_tests_from_s3():
     (mm, sg) = run_model_tests_from_s3(
-        'test', 'simple_model_test.pkl', belief_cutoff=None, upload_mm=False,
+        'test', 'simple_model_test.pkl', upload_mm=False,
         upload_results=False, upload_stats=False)
     assert isinstance(mm, ModelManager)
     assert isinstance(mm.model, EmmaaModel)

--- a/scripts/emmaa_model_from_stmts.py
+++ b/scripts/emmaa_model_from_stmts.py
@@ -1,13 +1,11 @@
-import argparse
-import datetime
-import yaml
 import json
 import boto3
+import argparse
+import datetime
 from indra.databases import ndex_client
 from indra.assemblers.cx import CxAssembler
 from indra.tools import assemble_corpus as ac
 from emmaa.model import EmmaaModel
-from emmaa.priors import SearchTerm
 from emmaa.statements import to_emmaa_stmts
 
 
@@ -48,9 +46,9 @@ def create_upload_model(model_name, full_name, indra_stmts, ndex_id=None):
     # Upload model to S3 with config as YAML and JSON
     emmaa_model.save_to_s3()
     s3_client = boto3.client('s3')
-    config_yaml = yaml.dump(config_dict)
-    s3_client.put_object(Body=config_yaml.encode('utf8'),
-                         Key='models/%s/config.yaml' % model_name,
+    config_json = json.dumps(config_dict)
+    s3_client.put_object(Body=config_json.encode('utf8'),
+                         Key='models/%s/config.json' % model_name,
                          Bucket='emmaa')
     config_json = json.dumps(config_dict)
     s3_client.put_object(Body=config_json.encode('utf8'),

--- a/scripts/generate_simple_model_test.py
+++ b/scripts/generate_simple_model_test.py
@@ -1,6 +1,5 @@
 import pickle
 import datetime
-import yaml
 import json
 import boto3
 from indra.statements import *
@@ -43,14 +42,10 @@ if __name__ == '__main__':
     model_name = 'test'
     model, config = generate_model(model_name)
     test = generate_test()
-    # Upload model to S3 as yaml and json
+    # Upload model to S3 as json
     model.save_to_s3()
     s3_client = boto3.client('s3')
-    config_yaml = yaml.dump(config)
-    s3_client.put_object(Body=config_yaml.encode('utf8'),
-                         Key='models/%s/config.yaml' % model_name,
-                         Bucket='emmaa')
-    config_json = json.dumps(config)
+    config_json = json.dumps(config, indent=1)
     s3_client.put_object(Body=config_json.encode('utf8'),
                          Key='models/%s/config.json' % model_name,
                          Bucket='emmaa')

--- a/scripts/priors_from_muts.py
+++ b/scripts/priors_from_muts.py
@@ -1,4 +1,3 @@
-import yaml
 import json
 import pickle
 import datetime
@@ -33,19 +32,19 @@ def get_top_genes(ctype, k):
 
 
 def load_config(ctype):
-    fname = f'../models/{ctype}/config.yaml'
+    fname = f'../models/{ctype}/config.json'
     with open(fname, 'r') as fh:
-        config = yaml.load(fh)
+        config = json.load(fh)
     # TODO: make the search term entries here SearchTerm objects
     return config
 
 
 def save_config(ctype, terms):
-    fname = f'../models/{ctype}/config.yaml'
+    fname = f'../models/{ctype}/config.json'
     config = load_config(ctype)
     config['search_terms'] = [term.to_json() for term in terms]
     with open(fname, 'w') as fh:
-        yaml.dump(config, fh, default_flow_style=False)
+        json.dump(config, fh, indent=1)
 
 
 def save_prior(ctype, stmts):

--- a/scripts/upload_to_s3.py
+++ b/scripts/upload_to_s3.py
@@ -1,4 +1,4 @@
-import yaml
+import json
 import pickle
 import datetime
 from emmaa.model import EmmaaModel
@@ -8,8 +8,8 @@ from emmaa.statements import EmmaaStatement
 def update_cancer(cancer_type):
     """Update the model for the given cancer.
 
-    A yaml config file must be present for the given cancer type, located in
-    the models/<cancer_type>/config.yaml.
+    A JSON config file must be present for the given cancer type, located in
+    the models/<cancer_type>/config.json.
 
     Parameters
     ----------
@@ -20,7 +20,7 @@ def update_cancer(cancer_type):
     print(cancer_type)
     with open(f'models/{cancer_type}/prior_stmts.pkl', 'rb') as fh:
         stmts = pickle.load(fh)
-    config = yaml.load(open(f'models/{cancer_type}/config.yaml', 'r'))
+    config = json.load(open(f'models/{cancer_type}/config.json', 'r'))
     em = EmmaaModel(cancer_type, config)
     ess = [EmmaaStatement(st, datetime.datetime.now(), []) for st in stmts]
     em.add_statements(ess)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='emmaa',
         'Programming Language :: Python :: 3.7'
         ],
       packages=find_packages(),
-      install_requires=['indra', 'boto3', 'pyyaml', 'jsonpickle', 'kappy',
-                        'pygraphviz', 'fnvhash'],
+      install_requires=['indra', 'boto3', 'jsonpickle', 'kappy', 'pygraphviz',
+                        'fnvhash'],
       extras_require={'test': ['nose', 'coverage', 'python-coveralls']}
       )


### PR DESCRIPTION
This PR removes the YAML configuration approach and replaces it with JSON. The new JSON configuration contains the following entries:
- search_terms (pre-existing): a list of SearchTerm objects serialized into JSON
- name (pre-existing): the code name of the model, e.g. "aml"
- human_readable_name (new): the display name used for the model
- assembly (new): a dict of assembly configuration parameters including
   - belief_cutoff
   - filter_ungrounded
   - filter_direct
   - mechanism_linking
- ndex (pre-existing)
   - network: the ID of the NDEx network for the model

Note that this PR does not remove the use of model_meta from the JS and REST API code, these will need to be done by @kkaris and @pagreene as a follow up to this. Once those changes are in place, we can delete the config.yaml files and the meta_model jsons.