### PR TITLE
Handle test configuration from config.json

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -45,6 +45,7 @@ class EmmaaModel(object):
         self.name = name
         self.stmts = []
         self.assembly_config = {}
+        self.test_config = {}
         self.search_terms = []
         self.ndex_network = None
         self._load_config(config)
@@ -80,6 +81,8 @@ class EmmaaModel(object):
             self.ndex_network = None
         if 'assembly' in config:
             self.assembly_config = config['assembly']
+        if 'test' in config:
+            self.test_config = config['test']
 
     def search_literature(self, date_limit=None):
         """Search for the model's search terms in the literature.

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -108,7 +108,8 @@ class ModelManager(object):
 
     def answer_query(self, stmt):
         """Answer user query with a path if it is found."""
-        test = StatementCheckingTest(stmt)
+        test = StatementCheckingTest(stmt,
+            self.model.test_config.get('statement_checking'))
         if ScopeTestConnector.applicable(self, test):
             result = self.run_one_test(test)
             return self.process_response(result)
@@ -120,7 +121,8 @@ class ModelManager(object):
         responses = {}
         applicable_queries = []
         for stmt in stmts:
-            test = StatementCheckingTest(stmt)
+            test = StatementCheckingTest(stmt,
+                self.model.test_config.get('statement_checking'))
             if ScopeTestConnector.applicable(self, test):
                 applicable_queries.append(test)
             else:
@@ -256,8 +258,9 @@ class EmmaaTest(object):
 class StatementCheckingTest(EmmaaTest):
     """Represent an EMMAA test condition that checks a PySB-assembled model
     against an INDRA Statement."""
-    def __init__(self, stmt):
+    def __init__(self, stmt, configs):
         self.stmt = stmt
+        self.configs = {} if not configs else configs
         # TODO
         # Add entities as a property if we can reload tests on s3.
         # self.entities = self.get_entities()
@@ -267,7 +270,11 @@ class StatementCheckingTest(EmmaaTest):
         # model_checker.statements = []
         # model_checker.add_statements([self.stmt])
         # model_checker.get_im(force_update=True)
-        res = model_checker.check_statement(self.stmt)
+        max_path_length = self.configs.get('max_path_length', 5)
+        max_paths = self.configs.get('max_paths', 1)
+        res = model_checker.check_statement(self.stmt,
+            max_path_length=max_path_length,
+            max_paths=max_paths)
         return res
 
     def get_entities(self):

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -258,7 +258,7 @@ class EmmaaTest(object):
 class StatementCheckingTest(EmmaaTest):
     """Represent an EMMAA test condition that checks a PySB-assembled model
     against an INDRA Statement."""
-    def __init__(self, stmt, configs):
+    def __init__(self, stmt, configs=None):
         self.stmt = stmt
         self.configs = {} if not configs else configs
         # TODO


### PR DESCRIPTION
This PR adds a new `test` key to config.json that allows setting parameters for various kinds of model tests, for now handling `statement_checking`.