### PR TITLE
Fix query registration

### DIFF
--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -33,7 +33,8 @@ def answer_immediate_query(user_email, query_dict, model_names, subscribe):
             mm = load_model_manager_from_s3(model_name)
             response = mm.answer_query(stmt)
             new_results.append((model_name, query_dict, response, new_date))
-            db.put_results(model_name, [(query_dict, response)])
+            if subscribe:
+                db.put_results(model_name, [(query_dict, response)])
     all_results = saved_results + new_results
     return format_results(all_results)
 

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -30,10 +30,10 @@ def answer_immediate_query(user_email, query_dict, model_names, subscribe):
     new_date = make_date_str(datetime.now())
     for model_name in model_names:
         if model_name not in checked_models:
-            result = {}
             mm = load_model_manager_from_s3(model_name)
             response = mm.answer_query(stmt)
             new_results.append((model_name, query_dict, response, new_date))
+            db.put_results(model_name, [(query_dict, response)])
     all_results = saved_results + new_results
     return format_results(all_results)
 

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -253,6 +253,7 @@ class EmmaaDatabaseManager(object):
                             Result.string, Result.date)
                  .filter(Query.hash == Result.query_hash))
             results = [tuple(res) for res in q.all()]
+        logger.info(f"Found {len(results)} results.")
         return results
 
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -127,8 +127,7 @@ def process_query():
     expceted_models = {mid for mid, _ in _get_models()}
     try:
         user_email = request.json['user']['email']
-        subscribe = request.json.get('register') == 'true' if \
-            request.args.get('register') else False
+        subscribe = request.json['register']
         query_json = request.json['query']
         assert set(query_json.keys()) == expected_query_keys, \
             (f'Did not get expected query keys: got {set(query_json.keys())} '

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -115,11 +115,11 @@ def get_query_page():
 def process_query():
     # Print inputs.
     logger.info('Got model query')
-    print("Args -----------")
-    print(request.args)
-    print("Json -----------")
-    print(str(request.json))
-    print("------------------")
+    logger.info("Args -----------")
+    logger.info(request.args)
+    logger.info("Json -----------")
+    logger.info(str(request.json))
+    logger.info("------------------")
 
     # Extract info.
     expected_query_keys = {f'{pos}Selection'


### PR DESCRIPTION
Fix queries and query registration. Queries can now be registered, and registered queries are now displayed when the query page is loaded. This PR also adds some logging messages to the db manager and the api.