### PR TITLE
Push to Dockerhub when building image

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ pip install git+https://github.com/indralab/indra_db.git
 pip install -e .
 ```
 
-Finally, a Dockerized version of EMMAA is available at
-https://hub.docker.com/r/labsyspharm/emmaa.
+A Dockerized version of EMMAA is available at
+https://hub.docker.com/r/labsyspharm/emmaa, which can be obtained as
+```
+docker pull labsyspharm/emmaa
+```
 
 ## Funding
 The development of EMMAA is funded under the DARPA Automating Scientific

--- a/README.md
+++ b/README.md
@@ -32,9 +32,21 @@ however, it can be applied to other domains that the INDRA system and the
 reading systems integrated with INDRA can handle.
 
 ## Installation
-The primary dependency of EMMAA is INDRA which can be installed using pip.
-Depending on the application, third-party dependencies of INDRA may need
-to be installed and configured separately.
+Users primarily interact with EMMAA via the
+[Dashboard](http://emmaa.indra.bio), for which no dependencies need to be
+installed.
+
+To set up programmatic access to EMMAA's features locally, do the following:
+```
+git clone https://github.com/indralab/emmaa.git
+cd emmaa
+pip install git+https://github.com/sorgerlab/indra.git
+pip install git+https://github.com/indralab/indra_db.git
+pip install -e .
+```
+
+Finally, a Dockerized version of EMMAA is available at
+https://hub.docker.com/r/labsyspharm/emmaa.
 
 ## Funding
 The development of EMMAA is funded under the DARPA Automating Scientific

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,3 +16,7 @@ phases:
       - echo Build completed on `date`
       - echo Pushing the Docker image...
       - docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
+      - echo Pushing the Docker image to Dockerhub...
+      - docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PWD}"
+      - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG labsyspharm/$IMAGE_REPO_NAME:$IMAGE_TAG
+      - docker push labsyspharm/$IMAGE_REPO_NAME:$IMAGE_TAG


### PR DESCRIPTION
This PR improves the installation instructions in the README and adds a push to Dockerhub in buildspec.yml.