### PR TITLE
Fix KeyError

### DIFF
--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -122,7 +122,7 @@ class TestRound(object):
         """Return a list of hashes for passed tests."""
         passed_tests = []
         for ix, result in enumerate(self.test_results):
-            if result.path_found:
+            if result.paths:
                 passed_tests.append(str(self.tests[ix].get_hash()))
         return passed_tests
 


### PR DESCRIPTION
This PR fixes an occasional KeyError in model tests stats generating process. The error occurred in cases when the path was found, but its length exceeded the maximum allowed length. 