### PR TITLE
Include global optional cache load.

### DIFF
--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -52,16 +52,6 @@ def _get_models():
     return model_data
 
 
-GLOBAL_PRELOAD = False
-model_cache = {}
-if GLOBAL_PRELOAD:
-    # Load all the model configs
-    models = _get_models()
-    # Load all the model managers for queries
-    for model, _ in models:
-        load_model_manager_from_s3(model)
-
-
 def get_model_config(model):
     if model in model_cache:
         return model_cache[model]
@@ -75,6 +65,16 @@ def get_model_config(model):
         logger.warning(f"Model {model} has no readable name. Skipping...")
         model_cache[model] = None
     return model_cache[model]
+
+
+GLOBAL_PRELOAD = False
+model_cache = {}
+if GLOBAL_PRELOAD:
+    # Load all the model configs
+    models = _get_models()
+    # Load all the model managers for queries
+    for model, _ in models:
+        load_model_manager_from_s3(model)
 
 
 def get_queryable_stmt_types():

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -39,9 +39,6 @@ MODEL = _load_template('model.html')
 QUERIES = _load_template('query.html')
 
 
-model_cache = {}
-
-
 def _get_models():
     s3 = boto3.client('s3')
     resp = s3.list_objects(Bucket='emmaa', Prefix='models/', Delimiter='/')
@@ -53,6 +50,16 @@ def _get_models():
             continue
         model_data.append((model, config_json))
     return model_data
+
+
+GLOBAL_PRELOAD = False
+model_cache = {}
+if GLOBAL_PRELOAD:
+    # Load all the model configs
+    models = _get_models()
+    # Load all the model managers for queries
+    for model, _ in models:
+        load_model_manager_from_s3(model)
 
 
 def get_model_config(model):
@@ -170,7 +177,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # TODO: make pre-loading available when running service via Gunicorn
-    if args.preload:
+    if args.preload and not GLOBAL_PRELOAD:
         # Load all the model configs
         models = _get_models()
         # Load all the model mamangers for queries


### PR DESCRIPTION
When using gunicorn, set `GLOBAL_PRELOAD` to `True`, and the caches will be filled whenever the file is loaded.