### PR TITLE
Add assembly option to filter by relevance

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -147,7 +147,8 @@ class EmmaaModel(object):
         stmts = ac.map_grounding(stmts)
         if self.assembly_config.get('filter_ungrounded'):
             stmts = ac.filter_grounded_only(stmts)
-        stmts = self.filter_relevance(stmts)
+        if self.assembly_config.get('filter_relevance'):
+            stmts = self.filter_relevance(stmts)
         stmts = ac.filter_human_only(stmts)
         stmts = ac.map_sequence(stmts)
         stmts = ac.run_preassembly(stmts, return_toplevel=False)
@@ -177,12 +178,14 @@ class EmmaaModel(object):
 
     def filter_relevance(self, stmts):
         """Filter a list of Statements to ones matching a search term."""
+        logger.info('Filtering %d statements for relevance...' % len(stmts))
         stmts_out = []
         stnames = {s.name for s in self.search_terms}
         for stmt in stmts:
             agnames = {a.name for a in stmt.agent_list() if a is not None}
             if agnames & stnames:
                 stmts_out.append(stmt)
+        logger.info('%d statements after filter...' % len(stmts_out))
         return stmts_out
 
     def update_to_ndex(self):

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -188,6 +188,8 @@ class EmmaaModel(object):
                 stmts_out.append(stmt)
             elif policy == 'prior_all' and agnames.issubset(stnames):
                 stmts_out.append(stmt)
+            elif policy is None:
+                stmts_out.append(stmt)
         logger.info('%d statements after filter...' % len(stmts_out))
         return stmts_out
 

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -147,6 +147,7 @@ class EmmaaModel(object):
         stmts = ac.map_grounding(stmts)
         if self.assembly_config.get('filter_ungrounded'):
             stmts = ac.filter_grounded_only(stmts)
+        stmts = self.filter_relevance(stmts)
         stmts = ac.filter_human_only(stmts)
         stmts = ac.map_sequence(stmts)
         stmts = ac.run_preassembly(stmts, return_toplevel=False)
@@ -173,6 +174,16 @@ class EmmaaModel(object):
             stmts = ml.statements
 
         self.assembled_stmts = stmts
+
+    def filter_relevance(self, stmts):
+        """Filter a list of Statements to ones matching a search term."""
+        stmts_out = []
+        stnames = {s.name for s in self.search_terms}
+        for stmt in stmts:
+            agnames = {a.name for a in stmt.agent_list() if a is not None}
+            if agnames & stnames:
+                stmts_out.append(stmt)
+        return stmts_out
 
     def update_to_ndex(self):
         """Update assembled model as CX on NDEx, updates existing network."""

--- a/emmaa/tests/test_model.py
+++ b/emmaa/tests/test_model.py
@@ -79,9 +79,7 @@ def test_filter_relevance():
                    'search_terms': [{'db_refs': {'HGNC': '20974'},
                                      'name': 'MAPK1',
                                      'search_term': 'MAPK1',
-                                     'type': 'gene'}],
-                   'assembly': {'filter_relevance': True}}
-    emmaa_model = EmmaaModel('test', config_dict)
+                                     'type': 'gene'}]}
     indra_stmts = \
         [Activation(Agent('BRAF', db_refs={'HGNC': '20974'}),
                     Agent('MAP2K1'),
@@ -97,7 +95,24 @@ def test_filter_relevance():
     st = SearchTerm('gene', 'MAP2K1', db_refs={}, search_term='MAP2K1')
     emmaa_stmts = [EmmaaStatement(stmt, datetime.datetime.now(), [st])
                    for stmt in indra_stmts]
+
+    # Try no filter first
+    emmaa_model = EmmaaModel('test', config_dict)
+    emmaa_model.extend_unique(emmaa_stmts)
+    emmaa_model.run_assembly()
+    assert len(emmaa_model.assembled_stmts) == 2, emmaa_model.assembled_stmts
+
+    # Next do a prior_one filter
+    config_dict['assembly'] = {'filter_relevance': 'prior_one'}
+    emmaa_model = EmmaaModel('test', config_dict)
     emmaa_model.extend_unique(emmaa_stmts)
     emmaa_model.run_assembly()
     assert len(emmaa_model.assembled_stmts) == 1, emmaa_model.assembled_stmts
     assert emmaa_model.assembled_stmts[0].obj.name == 'MAPK1'
+
+    # Next do a prior_all filter
+    config_dict['assembly'] = {'filter_relevance': 'prior_all'}
+    emmaa_model = EmmaaModel('test', config_dict)
+    emmaa_model.extend_unique(emmaa_stmts)
+    emmaa_model.run_assembly()
+    assert len(emmaa_model.assembled_stmts) == 0

--- a/emmaa/tests/test_model.py
+++ b/emmaa/tests/test_model.py
@@ -72,3 +72,32 @@ def test_model_json():
     # Need hashes to be strings so that javascript can read them
     assert isinstance(emmaa_model_json['stmts'][0]['stmt']['evidence'][0][
                           'source_hash'], str)
+
+
+def test_filter_relevance():
+    config_dict = {'ndex': {'network': 'a08479d1-24ce-11e9-bb6a-0ac135e8bacf'},
+                   'search_terms': [{'db_refs': {'HGNC': '20974'},
+                                     'name': 'MAPK1',
+                                     'search_term': 'MAPK1',
+                                     'type': 'gene'}],
+                   'assembly': {'filter_relevance': True}}
+    emmaa_model = EmmaaModel('test', config_dict)
+    indra_stmts = \
+        [Activation(Agent('BRAF', db_refs={'HGNC': '20974'}),
+                    Agent('MAP2K1'),
+                    evidence=[Evidence(text='BRAF activates MAP2K1.',
+                                       source_api='assertion')]),
+         Activation(Agent('MAP2K1',
+                          activity=ActivityCondition('activity', True)),
+                    Agent('MAPK1'),
+                    evidence=[Evidence(text='Active MAP2K1 activates '
+                                            'MAPK1.',
+                                       source_api='assertion')])
+         ]
+    st = SearchTerm('gene', 'MAP2K1', db_refs={}, search_term='MAP2K1')
+    emmaa_stmts = [EmmaaStatement(stmt, datetime.datetime.now(), [st])
+                   for stmt in indra_stmts]
+    emmaa_model.extend_unique(emmaa_stmts)
+    emmaa_model.run_assembly()
+    assert len(emmaa_model.assembled_stmts) == 1, emmaa_model.assembled_stmts
+    assert emmaa_model.assembled_stmts[0].obj.name == 'MAPK1'


### PR DESCRIPTION
This PR adds a new assembly option that allows controlling how the new information collected at each update is handled upon assembly: the two options are prior_one and prior_all (or no filtering).