### PR TITLE
Add a cache of previously-searched pmids.

### DIFF
--- a/emmaa/readers/db_client_reader.py
+++ b/emmaa/readers/db_client_reader.py
@@ -1,7 +1,15 @@
+import logging
 import datetime
+
 from indra_db.client.statements import get_statements_by_paper
 from indra_db.util import get_primary_db
+
 from emmaa.statements import EmmaaStatement
+
+
+logger = logging.getLogger(__name__)
+
+PMID_CACHE = {}
 
 
 def read_db_pmid_search_terms(pmid_search_terms):
@@ -19,11 +27,17 @@ def read_db_pmid_search_terms(pmid_search_terms):
     list[:py:class:`emmaa.model.EmmaaStatement`]
         A list of EmmaaStatements extracted from the given PMIDs.
     """
-    pmids = list(pmid_search_terms.keys())
+    pmids = set(pmid_search_terms.keys())
     date = datetime.datetime.utcnow()
     db = get_primary_db()
-    pmid_stmts = get_statements_by_paper(pmids, id_type='pmid', db=db,
-                                         preassembled=False)
+    cached_pmids = pmids & set(PMID_CACHE.keys())
+    logger.info(f"Found {len(cached_pmids)} in the cache.")
+    pmid_stmts = {pmid: PMID_CACHE[pmid][:] for pmid in cached_pmids}
+
+    new_pmids = pmids - cached_pmids
+    logger.info(f"Searching for {len(new_pmids)} new pmids.")
+    pmid_stmts.update(get_statements_by_paper(new_pmids, id_type='pmid', db=db,
+                                              preassembled=False))
     estmts = []
     for pmid, stmts in pmid_stmts.items():
         for stmt in stmts:


### PR DESCRIPTION
This should dramatically reduce the amount of calls to the database, especially when the scopes of the models share a great deal of overlap.