### PR TITLE
Query Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ venv.bak/
 
 *.zip
 .DS_Store
+
+# Outputs of tests
+emmaa/tests/test_query_delta.txt
+emmaa/tests/test_query_delta.html

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -21,10 +21,17 @@ class QueryManager(object):
             self, user_email, query_dict, model_names, subscribe):
         query = Query._from_json(query_dict)
         query_dict = query.to_json()
+<<<<<<< Updated upstream
         self.db.put_queries(user_email, query_dict, model_names, subscribe)
         # Check if the query has already been answered for any of given models
         # and retrieve the results from database.
         saved_results = self.db.get_results_from_query(query_dict, model_names)
+=======
+        db.put_queries(user_email, query_dict, model_names, subscribe)
+        # Check if the query has already been answered for any of given models
+        # and retrieve the results from database.
+        saved_results = db.get_results_from_query(query_dict, model_names)
+>>>>>>> Stashed changes
         checked_models = {res[0] for res in saved_results}
         if checked_models == set(model_names):
             return format_results(saved_results)

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -13,10 +13,9 @@ model_manager_cache = {}
 
 
 class QueryManager(object):
-    def __init__(self, db_name='primary'):
+    def __init__(self, db_name='primary', model_managers=None):
         self.db = get_db(db_name)
-        self.queries = []
-        self.model_managers = []
+        self.model_managers = model_managers if model_managers else []
 
     def answer_immediate_query(self, user_email, query_dict, model_names, subscribe):
         query = Query._from_json(query_dict)

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -12,44 +12,51 @@ logger = logging.getLogger(__name__)
 model_manager_cache = {}
 
 
-def answer_immediate_query(user_email, query_dict, model_names, subscribe,
-                           db_name='primary'):
-    """Save an immediate query in a database and answer it for each model."""
-    db = get_db(db_name)
-    query = Query._from_json(query_dict)
-    query_dict = query.to_json()
-    db.put_queries(user_email, query_dict, model_names, subscribe)
-    # Check if the query has already been answered for any of given models and
-    # retrieve the results from database.
-    saved_results = db.get_results_from_query(query_dict, model_names)
-    checked_models = {res[0] for res in saved_results}
-    if checked_models == set(model_names):
-        return format_results(saved_results)
-    # Run answer queries mechanism for models for which result was not found.
-    new_results = []
-    new_date = datetime.now()
-    for model_name in model_names:
-        if model_name not in checked_models:
-            mm = load_model_manager_from_s3(model_name)
-            response = mm.answer_query(query)
-            new_results.append((model_name, query_dict, response, new_date))
-            if subscribe:
-                db.put_results(model_name, [(query_dict, response)])
-    all_results = saved_results + new_results
-    return format_results(all_results)
+class QueryManager(object):
+    def __init__(self, db_name='primary'):
+        self.db = get_db(db_name)
+        self.queries = []
+        self.model_managers = []
 
+    def answer_immediate_query(self, user_email, query_dict, model_names, subscribe):
+        query = Query._from_json(query_dict)
+        query_dict = query.to_json()
+        db.put_queries(user_email, query_dict, model_names, subscribe)
+        # Check if the query has already been answered for any of given models and
+        # retrieve the results from database.
+        saved_results = db.get_results_from_query(query_dict, model_names)
+        checked_models = {res[0] for res in saved_results}
+        if checked_models == set(model_names):
+            return format_results(saved_results)
+        # Run answer queries mechanism for models for which result was not found.
+        new_results = []
+        new_date = datetime.now()
+        for model_name in model_names:
+            if model_name not in checked_models:
+                mm = get_model_manager(model_name)
+                response = mm.answer_query(query)
+                new_results.append((model_name, query_dict, response, new_date))
+                if subscribe:
+                    db.put_results(model_name, [(query_dict, response)])
+        all_results = saved_results + new_results
+        return format_results(all_results)
+    
+    def get_model_manager(self, model_name):
+        # Try get model manager from class attributes or load from s3.
+        for mm in self.model_managers:
+            if mm.model.name == model_name:
+                return mm
+        return load_model_manager_from_s3(model_name)
 
-def answer_registered_queries(model_name, model_manager=None, db_name='primary'):
-    """Retrieve queries registered on database for a given model, answer them,
-    and put results to a database.
-    """
-    if not model_manager:
-        model_manager = load_model_manager_from_s3(model_name)
-    db = get_db(db_name)
-    query_dicts = db.get_queries(model_name)
-    queries = [Query._from_json(json) for json in query_dicts]
-    results = model_manager.answer_queries(queries)
-    db.put_results(model_name, results)
+    def answer_registered_queries(self, model_name):
+        """Retrieve queries registered on database for a given model, answer them,
+        and put results to a database.
+        """
+        model_manager = self.get_model_manager(model_name)
+        query_dicts = db.get_queries(model_name)
+        queries = [Query._from_json(json) for json in query_dicts]
+        results = model_manager.answer_queries(queries)
+        db.put_results(model_name, results)
 
 
 def get_registered_queries(user_email, db_name='primary'):

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -70,11 +70,30 @@ class QueryManager(object):
         self.db.create_tables()
 
 
+def is_diff(new_result_json, old_result_json):
+    old_result_hashes = [k for k in old_result_json.keys()]
+    new_result_hashes = [k for k in new_result_json.keys()]
+    return not set(new_result_hashes) == set(previous_result_hashes)
+
+
 def get_registered_queries(user_email, db_name='primary'):
     """Get formatted results to queries registered by user."""
     db = get_db(db_name)
     results = db.get_results(user_email)
     return format_results(results)
+
+
+def make_report(query_json, new_result_json, old_result_json, new_stmts=None):
+    # TODO construct a report in either html/email format or txt file
+    pass
+
+
+def notify_user(user_email, query_json, new_result_json, old_result_json,
+                new_stmts=None):
+    report = make_report(
+        query_json, new_result_json, old_result_json, new_stmts)
+    # TODO send an email to user
+    pass
 
 
 def format_results(results):

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -195,7 +195,7 @@ class QueryManager(object):
     def _make_html_one_query_inner(
             self, model_name, query, new_result_json, old_result_json=None):
         # Create an html part for one query to be used in producing html report
-            if _is_diff(new_result_json, old_result_json):
+            if is_query_result_diff(new_result_json, old_result_json):
                 if not old_result_json:
                     msg = f'<p>This is the first result to query {query} in ' \
                           f'{model_name}. The result is:<br>'
@@ -279,7 +279,8 @@ def load_model_manager_from_s3(model_name):
     logger.info(f'Loading latest model manager for {model_name} model from '
                 f'S3.')
     obj = client.get_object(Bucket='emmaa', Key=key)
-    model_manager = pickle.loads(obj['Body'].read())
+    body = obj['Body'].read()
+    model_manager = pickle.loads(body)
     model_manager_cache[model_name] = model_manager
     return model_manager
 

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -1,12 +1,6 @@
 import logging
 import pickle
 from datetime import datetime
-from indra.statements.statements import get_statement_by_name
-from indra.statements.agent import Agent
-from indra.databases.hgnc_client import get_hgnc_id
-from indra.databases.chebi_client import get_chebi_id_from_name
-from indra.databases.mesh_client import get_mesh_id_name
-from indra.preassembler.grounding_mapper import gm
 from emmaa.util import get_s3_client, make_date_str
 from emmaa.db import get_db
 from emmaa.queries import Query

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -104,6 +104,24 @@ class QueryManager(object):
             filename = filename + '.html'
             self.make_html_report_per_user(user_email, filename=filename)
 
+    def get_report_per_query(self, model_name, query):
+        try:
+            new_results = self.db.get_results_from_query(
+                            query, [model_name], latest_order=1)
+            new_result_json = new_results[0][2]
+        except IndexError:
+            logger.info('No latest result was found.')
+            new_result_json = None
+        try:
+            old_results = self.db.get_results_from_query(
+                            query, [model_name], latest_order=2)
+            old_result_json = old_results[0][2]
+        except IndexError:
+            logger.info('No previous result was found.')
+            old_result_json = None
+        return self.make_str_report_one_query(
+            model_name, query, new_result_json, old_result_json)
+
     def make_str_report_per_user(self, user_email, filename='query_delta.txt'):
         """Produce a report for all query results per user in a text file."""
         results = self.db.get_results(user_email, latest_order=1)
@@ -121,7 +139,7 @@ class QueryManager(object):
                     old_result_json = None
                 f.write(self.make_str_report_one_query(model_name, query,
                         new_result_json, old_result_json))
-
+    
     def make_html_report_per_user(self, user_email, filename='query_delta.html'):
         """Produce a report for all query results per user in an html file."""
         results = self.db.get_results(user_email, latest_order=1)

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -156,9 +156,8 @@ class EmmaaDatabaseManager(object):
         ----------
         user_email : str
             (currently unused) the email of the user that entered the queries.
-        query_json : json
-            The json dictionary containing the data needed to specify the
-            query.
+        query : emmaa.queries.Query
+            A query object containing all necessary information.
         model_ids : list[str]
             A list of the short, standard model IDs to which the user wishes
             to apply these queries.
@@ -206,8 +205,8 @@ class EmmaaDatabaseManager(object):
 
         Returns
         -------
-        queries : list[json]
-            A list of query json's retrieved from the database.
+        queries : list[emmaa.queries.Query]
+            A list of queries retrieved from the database.
         """
         # TODO: check whether a query is registered or not.
         with self.get_session() as sess:
@@ -223,8 +222,8 @@ class EmmaaDatabaseManager(object):
         model_id : str
             The short, standard model ID.
         query_results : list of tuples
-            A list of tuples of the form (query_json, result_json), where
-            the query_json is the standard query json run against the model,
+            A list of tuples of the form (query, result_json), where
+            the query is the query object run against the model,
             and the result_json is the json containing corresponding result.
         """
         results = []
@@ -264,7 +263,7 @@ class EmmaaDatabaseManager(object):
         Returns
         -------
         results : list[tuple]
-            A list of tuples, each of the form: (model_id, query_json,
+            A list of tuples, each of the form: (model_id, query,
             result_json, date) representing the result of a query run on a
             model on a given date.
         """

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -295,6 +295,8 @@ def sorted_json_string(json_thing):
     elif isinstance(json_thing, dict):
         return '{%s}' % (','.join(sorted(k + sorted_json_string(v)
                                          for k, v in json_thing.items())))
+    elif isinstance(json_thing, float):
+        return str(json_thing)
     else:
         raise TypeError(f"Invalid type: {type(json_thing)}")
 

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -10,7 +10,7 @@ import logging
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from .schema import EmmaaTable, User, Query, Base, Result
+from .schema import EmmaaTable, User, Query, Base, Result, UserQuery
 
 logger = logging.getLogger(__name__)
 
@@ -274,6 +274,14 @@ class EmmaaDatabaseManager(object):
             results = _weed_results(q.all())
         logger.info(f"Found {len(results)} results.")
         return results
+
+    def get_users(self, query_json):
+        logger.info(f"Got request for users for {query_json}")
+        with self.get_session() as sess:
+            q = (sess.query(User.email).filter(User.id == UserQuery.user_id,
+                                               Query.json == query_json))
+            users = [q for q, in q.all()]
+        return users
 
 
 def _weed_results(result_iter):

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -87,6 +87,8 @@ class ModelManager(object):
         self.model_checker.statements = []
         self.model_checker.add_statements([test.stmt])
         self.get_im()
+        if not test.configs:
+            test.configs = self.model.test_config.get('statement_checking')
         return test.check(self.model_checker, self.pysb_model)
 
     def run_tests(self):

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -173,7 +173,7 @@ class ModelManager(object):
                 applicable_stmts.append(query.path_stmt)
             else:
                 responses.append(
-                    (query.to_json(), self.hash_response_list(
+                    (query, self.hash_response_list(
                         [[(RESULT_CODES['QUERY_NOT_APPLICABLE'],
                           result_codes_link)]])))
         self.model_checker.statements = []
@@ -182,7 +182,7 @@ class ModelManager(object):
         results = self.model_checker.check_model()
         for ix, (_, result) in enumerate(results):
             responses.append(
-                (applicable_queries[ix].to_json(),
+                (applicable_queries[ix],
                  self.process_response(result)))
         return responses
 

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -88,7 +88,7 @@ class ModelManager(object):
         self.model_checker.add_statements([test.stmt])
         self.get_im()
         if not test.configs:
-            test.configs = self.model.test_config.get('statement_checking')
+            test.configs = self.model.test_config.get('statement_checking', {})
         return test.check(self.model_checker, self.pysb_model)
 
     def run_tests(self):

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -15,7 +15,7 @@ from indra.sources.indra_db_rest.api import get_statement_queries
 from emmaa.model import EmmaaModel
 from emmaa.util import make_date_str, get_s3_client
 from emmaa.analyze_tests_results import TestRound, StatsGenerator
-from emmaa.answer_queries import answer_registered_queries
+from emmaa.answer_queries import QueryManager
 
 
 logger = logging.getLogger(__name__)
@@ -388,7 +388,7 @@ def save_model_manager_to_s3(model_name, model_manager):
 
 def run_model_tests_from_s3(model_name, test_name, upload_mm=True,
                             upload_results=True, upload_stats=True,
-                            registered_queries=True):
+                            registered_queries=True, db_name='primary'):
     """Run a given set of tests on a given model, both loaded from S3.
 
     After loading both the model and the set of tests, model/test overlap
@@ -448,5 +448,6 @@ def run_model_tests_from_s3(model_name, test_name, upload_mm=True,
     if upload_stats:
         sg.save_to_s3()
     if registered_queries:
-        answer_registered_queries(model_name, model_manager=mm)
+        qm = QueryManager(db_name=db_name, model_managers=[mm])
+        qm.answer_registered_queries(model_name)
     return (mm, sg)

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -167,7 +167,8 @@ class ModelManager(object):
         applicable_stmts = []
         for query in queries:
             test = StatementCheckingTest(
-                query.path_stmt, self.model.test_config.get('statement_checking'))
+                query.path_stmt,
+                self.model.test_config.get('statement_checking'))
             if ScopeTestConnector.applicable(self, test):
                 applicable_queries.append(query)
                 applicable_stmts.append(query.path_stmt)

--- a/emmaa/queries.py
+++ b/emmaa/queries.py
@@ -1,0 +1,93 @@
+from inflection import camelize, underscore
+from collections import OrderedDict as _o
+from indra.statements.statements import Statement, Agent, get_all_descendants
+
+
+class Query(object):
+    """The parent class of all query types."""
+    @classmethod
+    def _from_json(cls, json_dict):
+        query_type = json_dict.get('type')
+        query_cls = query_cls_from_type(query_type)
+        query = query_cls._from_json(json_dict)
+        return query
+
+
+class StructuralProperty(Query):
+    pass
+
+
+class PathProperty(Query):
+    """This type of query requires finding a mechanistic causally consistent
+    path that satisfies query statement.
+
+    Parameters:
+    ----------
+    path_stmt : indra.statements.Statement
+        A path to look for in the model represented as INDRA statement.
+    entity_constraints : dict(list(indra.statements.Agent))
+        A dictionary containing lists of Agents to be included in or excluded
+        from the path.
+    relationship_constraints : dict(list(str))
+        A dictionary containing lists of Statement types to include in or
+        exclude from the path.
+    """
+    def __init__(self, path_stmt, entity_constraints=None,
+                 relationship_constraints=None):
+        self.path_stmt = path_stmt
+        self.include_entities = entity_constraints.get('include')
+        self.exclude_entities = entity_constraints.get('exclude')
+        self.include_rels = relationship_constraints.get('include')
+        self.exclude_rels = relationship_constraints.get('exclude')
+
+    def to_json(self):
+        query_type = underscore(type(self).__name__)
+        json_dict = _o(type=query_type)
+        json_dict['path'] = self.path_stmt.to_json()
+        json_dict['entity_constraints'] = {}
+        json_dict['entity_constraints']['include'] = [ec.to_json() for ec in
+                                                      self.include_entities]
+        json_dict['entity_constraints']['exclude'] = [ec.to_json() for ec in
+                                                      self.exclude_entities]
+        json_dict['relationship_constraints'] = {}
+        json_dict['relationship_constraints']['include'] = [
+            {'type': rel} for rel in self.include_rels]
+        json_dict['relationship_constraints']['exclude'] = [
+            {'type': rel} for rel in self.exclude_rels]
+        return json_dict
+
+    @classmethod
+    def _from_json(cls, json_dict):
+        path_stmt_json = json_dict.get('path')
+        path_stmt = Statement._from_json(path_stmt_json)
+        ent_constr_json = json_dict.get('entity_constraints')
+        entity_constraints = {}
+        for key, value in ent_constr_json.items():
+            entity_constraints[key] = [Agent._from_json(ec) for ec in value]
+        rel_constr_json = json_dict.get('relationship_constraints')
+        relationship_constraints = {}
+        for key, value in rel_constr_json.items():
+            relationship_constraints[key] = [
+                rel_type['type'] for rel_type in value]
+        query = cls(path_stmt, entity_constraints, relationship_constraints)
+        return query
+
+
+class SimpleInterventionProperty(Query):
+    pass
+
+
+class ComparativeInterventionProperty(Query):
+    pass
+
+
+def query_cls_from_type(query_type):
+    query_classes = get_all_descendants(Query)
+    for query_class in query_classes:
+        if query_class.__name__.lower() == camelize(query_type).lower():
+            return query_class
+    raise NotAQueryType(f'{query_type} is not recognized as a query type!')
+
+
+class NotAQueryType(Exception):
+    pass

--- a/emmaa/queries.py
+++ b/emmaa/queries.py
@@ -39,6 +39,7 @@ class PathProperty(Query):
     def __init__(self, path_stmt, entity_constraints=None,
                  relationship_constraints=None):
         self.path_stmt = path_stmt
+        self.entities = self._get_entities()
         if entity_constraints:
             self.include_entities = entity_constraints.get('include')
             self.exclude_entities = entity_constraints.get('exclude')
@@ -94,6 +95,15 @@ class PathProperty(Query):
                     rel_type['type'] for rel_type in value]
         query = cls(path_stmt, entity_constraints, relationship_constraints)
         return query
+
+    def _get_entities(self):
+        """Return entities of the query.
+
+        Note: Right now we only return entities of the path statement her, but
+        in future we can also incorporate checking entity constraints at this
+        level.
+        """
+        return path_stmt.agent_list()
 
 
 class SimpleInterventionProperty(Query):

--- a/emmaa/queries.py
+++ b/emmaa/queries.py
@@ -77,17 +77,14 @@ class PathProperty(Query):
         path_stmt_json = json_dict.get('path')
         path_stmt = Statement._from_json(path_stmt_json)
         for ag in path_stmt.agent_list():
-            grounding = get_grounding_from_name(ag.name)
-            if not grounding:
-                grounding = get_grounding_from_name(ag.name.upper())
-                ag.name = ag.name.upper()
-            ag.db_refs = {grounding[0]: grounding[1]}
+            ag = add_db_refs(ag)
         ent_constr_json = json_dict.get('entity_constraints')
         entity_constraints = None
         if ent_constr_json:
             entity_constraints = {}
             for key, value in ent_constr_json.items():
-                entity_constraints[key] = [Agent._from_json(ec) for ec in value]
+                entity_constraints[key] = [
+                    add_db_refs(Agent._from_json(ec)) for ec in value]
         rel_constr_json = json_dict.get('relationship_constraints')
         relationship_constraints = None
         if rel_constr_json:
@@ -113,6 +110,16 @@ def query_cls_from_type(query_type):
         if query_class.__name__.lower() == camelize(query_type).lower():
             return query_class
     raise NotAQueryType(f'{query_type} is not recognized as a query type!')
+
+
+def add_db_refs(agent):
+    """Add db_refs to an Agent object and update a name if needed."""
+    grounding = get_grounding_from_name(agent.name)
+    if not grounding:
+        grounding = get_grounding_from_name(agent.name.upper())
+        ag.name = agent.name.upper()
+    agent.db_refs = {grounding[0]: grounding[1]}
+    return agent
 
 
 def get_grounding_from_name(name):

--- a/emmaa/queries.py
+++ b/emmaa/queries.py
@@ -197,7 +197,7 @@ def get_grounding_from_name(name):
 
     chebi_id = get_chebi_id_from_name(name)
     if chebi_id:
-        return ('CHEBI', f'CHEBI: {chebi_id}')
+        return ('CHEBI', f'CHEBI:{chebi_id}')
 
     mesh_id, _ = get_mesh_id_name(name)
     if mesh_id:

--- a/emmaa/queries.py
+++ b/emmaa/queries.py
@@ -45,15 +45,19 @@ class PathProperty(Query):
         json_dict = _o(type=query_type)
         json_dict['path'] = self.path_stmt.to_json()
         json_dict['entity_constraints'] = {}
-        json_dict['entity_constraints']['include'] = [ec.to_json() for ec in
-                                                      self.include_entities]
-        json_dict['entity_constraints']['exclude'] = [ec.to_json() for ec in
-                                                      self.exclude_entities]
+        if self.include_entities:
+            json_dict['entity_constraints']['include'] = [
+                ec.to_json() for ec in self.include_entities]
+        if self.exclude_entities:
+            json_dict['entity_constraints']['exclude'] = [
+                ec.to_json() for ec in self.exclude_entities]
         json_dict['relationship_constraints'] = {}
-        json_dict['relationship_constraints']['include'] = [
-            {'type': rel} for rel in self.include_rels]
-        json_dict['relationship_constraints']['exclude'] = [
-            {'type': rel} for rel in self.exclude_rels]
+        if self.include_rels:
+            json_dict['relationship_constraints']['include'] = [
+                {'type': rel} for rel in self.include_rels]
+        if self.exclude_rels:
+            json_dict['relationship_constraints']['exclude'] = [
+                {'type': rel} for rel in self.exclude_rels]
         return json_dict
 
     @classmethod

--- a/emmaa/queries.py
+++ b/emmaa/queries.py
@@ -1,6 +1,7 @@
 from inflection import camelize, underscore
 from collections import OrderedDict as _o
-from indra.statements.statements import Statement, Agent, get_all_descendants
+from indra.statements.statements import Statement, Agent, get_all_descendants,\
+    mk_str, make_hash
 from indra.databases.hgnc_client import get_hgnc_id
 from indra.databases.chebi_client import get_chebi_id_from_name
 from indra.databases.mesh_client import get_mesh_id_name
@@ -15,6 +16,12 @@ class Query(object):
         query_cls = query_cls_from_type(query_type)
         query = query_cls._from_json(json_dict)
         return query
+
+    def matches(self, other):
+        return self.matches_key() == other.matches_key()
+
+    def get_hash(self):
+        return make_hash(self.matches_key(), 14)
 
 
 class StructuralProperty(Query):
@@ -99,11 +106,36 @@ class PathProperty(Query):
     def _get_entities(self):
         """Return entities of the query.
 
-        Note: Right now we only return entities of the path statement her, but
+        NOTE: Right now we only return entities of the path statement her, but
         in future we can also incorporate checking entity constraints at this
         level.
         """
         return self.path_stmt.agent_list()
+
+    def matches_key(self):
+        key = (self.path_stmt.matches_key(), tuple(ent.matches_key() for ent
+               in sorted(self.include_entities, key=lambda x: x.matches_key())),
+               tuple(ent.matches_key() for ent in
+               sorted(self.exclude_entities, key=lambda x: x.matches_key())),
+               tuple(rel for rel in sorted(self.include_rels)),
+               tuple(rel for rel in sorted(self.exclude_rels)))
+        return mk_str(key)
+
+    def __str__(self):
+        parts = [f'PathPropertyQuery(stmt={str(self.path_stmt)}.']
+        if self.include_entities:
+            inents = ', '.join([str(e) for e in self.include_entities])
+            parts.append(f' Include entities: {inents}.')
+        if self.exclude_entities:
+            exents = ', '.join([str(e) for e in self.exclude_entities])
+            parts.append(f' Exclude entities: {exents}.')
+        if self.include_rels:
+            inrels = ', '.join(self.include_rels)
+            parts.append(f' Include relations: {inrels}.')
+        if self.exclude_rels:
+            exrels = ', '.join(self.exclude_rels)
+            parts.append(f' Exclude relations: {exrels}.')
+        return ''.join(parts)
 
 
 class SimpleInterventionProperty(Query):

--- a/emmaa/queries.py
+++ b/emmaa/queries.py
@@ -1,3 +1,4 @@
+import requests
 from inflection import camelize, underscore
 from collections import OrderedDict as _o
 from indra.statements.statements import Statement, Agent, get_all_descendants,\
@@ -8,7 +9,7 @@ from indra.databases.mesh_client import get_mesh_id_name
 from indra.preassembler.grounding_mapper import gm
 
 
-GROUNDING_URL = 'http://localhost:8001'
+GROUNDING_URL = 'http://localhost:8001/ground'
 
 
 class Query(object):
@@ -219,7 +220,7 @@ def get_agent_from_grounding_service(ag_name, url):
     rj = res.json()
     if not rj:
         raise GroundingError(f"Could not find grounding for {ag_name}.")
-    agent = Agent(name=rj[0]['entry']['entry_name'], 
+    agent = Agent(name=rj[0]['entry']['entry_name'],
                   db_refs={rj[0]['entry']['db']: rj[0]['entry']['id']})
     return agent
 

--- a/emmaa/queries.py
+++ b/emmaa/queries.py
@@ -23,6 +23,10 @@ class Query(object):
     def get_hash(self):
         return make_hash(self.matches_key(), 14)
 
+    def get_hash_with_model(self, model_name):
+        key = (self.matches_key(), model_name)
+        return make_hash(mk_str(key), 14)
+
 
 class StructuralProperty(Query):
     pass
@@ -113,12 +117,21 @@ class PathProperty(Query):
         return self.path_stmt.agent_list()
 
     def matches_key(self):
-        key = (self.path_stmt.matches_key(), tuple(ent.matches_key() for ent
-               in sorted(self.include_entities, key=lambda x: x.matches_key())),
-               tuple(ent.matches_key() for ent in
-               sorted(self.exclude_entities, key=lambda x: x.matches_key())),
-               tuple(rel for rel in sorted(self.include_rels)),
-               tuple(rel for rel in sorted(self.exclude_rels)))
+        key = self.path_stmt.matches_key()
+        if self.include_entities:
+            for ent in sorted(self.include_entities,
+                              key=lambda x: x.matches_key()):
+                key += ent.matches_key()
+        if self.exclude_entities:
+            for ent in sorted(self.exclude_entities,
+                              key=lambda x: x.matches_key()):
+                key += ent.matches_key()
+        if self.include_rels:
+            for rel in sorted(self.include_rels):
+                key += rel
+        if self.exclude_rels:
+            for rel in sorted(self.exclude_rels):
+                key += rel
         return mk_str(key)
 
     def __str__(self):

--- a/emmaa/queries.py
+++ b/emmaa/queries.py
@@ -69,7 +69,7 @@ class PathProperty(Query):
         else:
             self.include_rels = []
             self.exclude_rels = []
-        self.entities = self._get_entities()
+        self.entities = self.get_entities()
 
     def to_json(self):
         query_type = underscore(type(self).__name__)
@@ -112,7 +112,7 @@ class PathProperty(Query):
         query = cls(path_stmt, entity_constraints, relationship_constraints)
         return query
 
-    def _get_entities(self):
+    def get_entities(self):
         """Return entities from the path statement and the inclusion list."""
         path_entities = self.path_stmt.agent_list()
         return path_entities + self.include_entities

--- a/emmaa/queries.py
+++ b/emmaa/queries.py
@@ -103,7 +103,7 @@ class PathProperty(Query):
         in future we can also incorporate checking entity constraints at this
         level.
         """
-        return path_stmt.agent_list()
+        return self.path_stmt.agent_list()
 
 
 class SimpleInterventionProperty(Query):

--- a/emmaa/tests/path_property_query.json
+++ b/emmaa/tests/path_property_query.json
@@ -3,18 +3,22 @@
        "type": "Phosphorylation",
        "enz": {
            "type": "Agent",
-           "name": "EGFR"
+           "name": "EGFR",
+           "db_refs": {"HGNC": "3236"}
            },
        "sub": {
            "type": "Agent",
-           "name": "ERK"
+           "name": "ERK",
+           "db_refs": {"FPLX": "ERK"}
            }
        },
      "entity_constraints": {
        "exclude": [
            {"type": "Agent",
-            "name": "PI3K"}
-           ]
+            "name": "PI3K",
+            "db_refs": {"FPLX": "ERK"}
+           }
+        ]
        },
      "relationship_constraints": {
        "exclude": [

--- a/emmaa/tests/path_property_query.json
+++ b/emmaa/tests/path_property_query.json
@@ -13,6 +13,12 @@
            }
        },
      "entity_constraints": {
+       "include": [
+         {"type": "Agent",
+          "name": "MAPK1",
+          "db_refs": {"HGNC": "6871"}
+          }
+       ],
        "exclude": [
            {"type": "Agent",
             "name": "PI3K",
@@ -21,6 +27,9 @@
         ]
        },
      "relationship_constraints": {
+       "include": [
+         {"type": "Inhibition"}
+       ],
        "exclude": [
            {"type": "IncreaseAmount"},
            {"type": "DecreaseAmount"}

--- a/emmaa/tests/path_property_query.json
+++ b/emmaa/tests/path_property_query.json
@@ -1,0 +1,25 @@
+{"type": "path_property",
+    "path": {
+       "type": "Phosphorylation",
+       "enz": {
+           "type": "Agent",
+           "name": "EGFR"
+           },
+       "sub": {
+           "type": "Agent",
+           "name": "ERK"
+           }
+       },
+     "entity_constraints": {
+       "exclude": [
+           {"type": "Agent",
+            "name": "PI3K"}
+           ]
+       },
+     "relationship_constraints": {
+       "exclude": [
+           {"type": "IncreaseAmount"},
+           {"type": "DecreaseAmount"}
+           ]
+       }
+    }

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -9,18 +9,6 @@ from indra.statements.statements import Activation
 from indra.statements.agent import Agent
 
 
-# Tell nose to not run tests in the imported modules
-format_results.__test__ = False
-load_model_manager_from_s3.__test__ = False
-ModelManager.__test__ = False
-Activation.__test__ = False
-Agent.__test__ = False
-get_db.__test__ = False
-Query.__test__ = False
-QueryManager.__test__ = False
-is_query_result_diff.__test__ = False
-
-
 test_query = {'type': 'path_property', 'path': {'type': 'Activation',
               'subj': {'type': 'Agent', 'name': 'BRAF',
                        'db_refs': {'HGNC': '1097'}},

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -135,7 +135,8 @@ def test_report_files():
     qm.db.put_queries('tester@test.com', query_object, ['test'],
                       subscribe=True)
     qm.db.put_results('test', [(query_object, query_not_appl)])
-    qm.make_str_report_per_user('tester@test.com',
+    results = qm.db.get_results('tester@test.com', latest_order=1)
+    qm.make_str_report_per_user(results,
                                 filename='test_query_delta.txt')
     with open('test_query_delta.txt', 'r') as f:
         msg = f.read()
@@ -143,7 +144,8 @@ def test_report_files():
     assert 'This is the first result to query' in msg, msg
     assert 'Query is not applicable for this model' in msg
     qm.db.put_results('test', [(query_object, test_response)])
-    qm.make_str_report_per_user('tester@test.com',
+    results = qm.db.get_results('tester@test.com', latest_order=1)
+    qm.make_str_report_per_user(results,
                                 filename='test_query_delta.txt')
     with open('test_query_delta.txt', 'r') as f:
         msg = f.read()

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -22,9 +22,12 @@ _is_diff.__test__ = False
 
 
 test_query = {'type': 'path_property', 'path': {
-    'type': 'Activation', 'subj': {'type': 'Agent', 'name': 'BRAF'},
-    'obj': {'type': 'Agent', 'name': 'MAPK1'}}}
-processed_query = Query._from_json(test_query)
+              'type': 'Activation', 'subj': {'type': 'Agent', 'name': 'BRAF'},
+              'obj': {'type': 'Agent', 'name': 'MAPK1'}}}
+simple_query = {'typeSelection': 'Activation',
+                'subjectSelection': 'BRAF',
+                'objectSelection': 'MAPK1'}
+query_object = Query._from_json(test_query)
 test_response = {3801854542: [
     ('BRAF activates MAP2K1.',
      'https://db.indra.bio/statements/from_agents?subject=1097@HGNC&object=6840@HGNC&type=Activation&format=html'),
@@ -42,11 +45,11 @@ def test_load_model_manager_from_s3():
 
 
 def test_format_results():
-    results = [('test', test_query, test_response, datetime.now())]
+    results = [('test', query_object, test_response, datetime.now())]
     formatted_results = format_results(results)
     assert len(formatted_results) == 1
     assert formatted_results[0]['model'] == 'test'
-    assert formatted_results[0]['query'] == test_query
+    assert formatted_results[0]['query'] == simple_query
     assert isinstance(formatted_results[0]['response'], str)
     assert isinstance(formatted_results[0]['date'], str)
 
@@ -55,11 +58,11 @@ def test_format_results():
 def test_answer_immediate_query():
     qm = QueryManager(db_name='test')
     qm._recreate_db()
-    results = qm.answer_immediate_query('tester@test.com', processed_query,
+    results = qm.answer_immediate_query('tester@test.com', query_object,
                                         ['test'], subscribe=False)
     assert len(results) == 1
     assert results[0]['model'] == 'test'
-    assert results[0]['query'] == processed_query, (results[0]['query'], processed_query)
+    assert results[0]['query'] == simple_query
     assert isinstance(results[0]['response'], str)
     assert 'BRAF activates MAP2K1.' in results[0]['response'], results[0]['response']
     assert isinstance(results[0]['date'], str)
@@ -69,12 +72,12 @@ def test_answer_immediate_query():
 def test_answer_get_registered_queries():
     qm = QueryManager(db_name='test')
     qm._recreate_db()
-    qm.db.put_queries('tester@test.com', processed_query, ['test'], subscribe=True)
+    qm.db.put_queries('tester@test.com', query_object, ['test'], subscribe=True)
     qm.answer_registered_queries('test')
     results = qm.get_registered_queries('tester@test.com')
     assert len(results) == 1
     assert results[0]['model'] == 'test'
-    assert results[0]['query'] == processed_query
+    assert results[0]['query'] == simple_query
     assert isinstance(results[0]['response'], str)
     assert 'BRAF activates MAP2K1.' in results[0]['response'], results[0]['response']
     assert isinstance(results[0]['date'], str)
@@ -89,13 +92,13 @@ def test_is_diff():
 def test_report_one_query():
     qm = QueryManager(db_name='test')
     str_msg = qm.make_str_report_one_query(
-        'test', processed_query, test_response, query_not_appl)
+        'test', query_object, test_response, query_not_appl)
     assert str_msg
     assert 'A new result to query' in str_msg
     assert 'Query is not applicable for this model' in str_msg
     assert 'BRAF activates MAP2K1.' in str_msg
     html_msg = qm.make_html_one_query_report(
-        'test', processed_query, test_response, query_not_appl)
+        'test', query_object, test_response, query_not_appl)
     assert html_msg
     assert 'A new result to query' in html_msg
     assert 'Query is not applicable for this model' in html_msg
@@ -106,15 +109,15 @@ def test_report_one_query():
 def test_report_files():
     qm = QueryManager(db_name='test')
     qm._recreate_db()
-    qm.db.put_queries('tester@test.com', processed_query, ['test'], subscribe=True)
-    qm.db.put_results('test', [(processed_query, query_not_appl)])
+    qm.db.put_queries('tester@test.com', query_object, ['test'], subscribe=True)
+    qm.db.put_results('test', [(query_object, query_not_appl)])
     qm.make_str_report_per_user('tester@test.com', filename='test_query_delta.txt')
     with open('test_query_delta.txt', 'r') as f:
         msg = f.read()
     assert msg
     assert 'This is the first result to query' in msg, msg
     assert 'Query is not applicable for this model' in msg
-    qm.db.put_results('test', [(processed_query, test_response)])
+    qm.db.put_results('test', [(query_object, test_response)])
     qm.make_str_report_per_user('tester@test.com', filename='test_query_delta.txt')
     with open('test_query_delta.txt', 'r') as f:
         msg = f.read()

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -24,7 +24,7 @@ _is_diff.__test__ = False
 test_query = {'type': 'path_property', 'path': {
     'type': 'Activation', 'subj': {'type': 'Agent', 'name': 'BRAF'},
     'obj': {'type': 'Agent', 'name': 'MAPK1'}}}
-processed_query = Query._from_json(test_query).to_json()
+processed_query = Query._from_json(test_query)
 test_response = {3801854542: [
     ('BRAF activates MAP2K1.',
      'https://db.indra.bio/statements/from_agents?subject=1097@HGNC&object=6840@HGNC&type=Activation&format=html'),

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from nose.plugins.attrib import attr
-from emmaa.answer_queries import QueryManager, get_registered_queries, \
-    format_results, load_model_manager_from_s3
+from emmaa.answer_queries import QueryManager, format_results, \
+    load_model_manager_from_s3, _is_diff
 from emmaa.queries import Query
 from emmaa.model_tests import ModelManager
 from emmaa.db import get_db
@@ -10,7 +10,6 @@ from indra.statements.agent import Agent
 
 
 # Tell nose to not run tests in the imported modules
-get_registered_queries.__test__ = False
 format_results.__test__ = False
 load_model_manager_from_s3.__test__ = False
 ModelManager.__test__ = False
@@ -19,6 +18,7 @@ Agent.__test__ = False
 get_db.__test__ = False
 Query.__test__ = False
 QueryManager.__test__ = False
+_is_diff.__test__ = False
 
 
 test_query = {'type': 'path_property', 'path': {
@@ -30,6 +30,10 @@ test_response = {3801854542: [
      'https://db.indra.bio/statements/from_agents?subject=1097@HGNC&object=6840@HGNC&type=Activation&format=html'),
     ('Active MAP2K1 activates MAPK1.',
      'https://db.indra.bio/statements/from_agents?subject=6840@HGNC&object=6871@HGNC&type=Activation&format=html')]}
+processed_link = '<a href="https://db.indra.bio/statements/from_agents?subject=1097@HGNC&object=6840@HGNC&type=Activation&format=html" target="_blank" class="status-link">BRAF activates MAP2K1.</a>'
+query_not_appl = {2413475507: [
+    ('Query is not applicable for this model',
+     'https://emmaa.readthedocs.io/en/latest/dashboard/response_codes.html')]}
 
 
 def test_load_model_manager_from_s3():
@@ -67,10 +71,53 @@ def test_answer_get_registered_queries():
     qm._recreate_db()
     qm.db.put_queries('tester@test.com', processed_query, ['test'], subscribe=True)
     qm.answer_registered_queries('test')
-    results = get_registered_queries('tester@test.com', db_name='test')
+    results = qm.get_registered_queries('tester@test.com')
     assert len(results) == 1
     assert results[0]['model'] == 'test'
     assert results[0]['query'] == processed_query
     assert isinstance(results[0]['response'], str)
     assert 'BRAF activates MAP2K1.' in results[0]['response'], results[0]['response']
     assert isinstance(results[0]['date'], str)
+
+
+def test_is_diff():
+    assert not _is_diff(query_not_appl, query_not_appl)
+    assert _is_diff(test_response, query_not_appl)
+
+
+@attr('nonpublic')
+def test_report_one_query():
+    qm = QueryManager(db_name='test')
+    str_msg = qm.make_str_report_one_query(
+        'test', processed_query, test_response, query_not_appl)
+    assert str_msg
+    assert 'A new result to query' in str_msg
+    assert 'Query is not applicable for this model' in str_msg
+    assert 'BRAF activates MAP2K1.' in str_msg
+    html_msg = qm.make_html_one_query_report(
+        'test', processed_query, test_response, query_not_appl)
+    assert html_msg
+    assert 'A new result to query' in html_msg
+    assert 'Query is not applicable for this model' in html_msg
+    assert processed_link in html_msg
+
+
+@attr('nonpublic')
+def test_report_files():
+    qm = QueryManager(db_name='test')
+    qm._recreate_db()
+    qm.db.put_queries('tester@test.com', processed_query, ['test'], subscribe=True)
+    qm.db.put_results('test', [(processed_query, query_not_appl)])
+    qm.make_str_report_per_user('tester@test.com', filename='test_query_delta.txt')
+    with open('test_query_delta.txt', 'r') as f:
+        msg = f.read()
+    assert msg
+    assert 'This is the first result to query' in msg, msg
+    assert 'Query is not applicable for this model' in msg
+    qm.db.put_results('test', [(processed_query, test_response)])
+    qm.make_str_report_per_user('tester@test.com', filename='test_query_delta.txt')
+    with open('test_query_delta.txt', 'r') as f:
+        msg = f.read()
+    assert msg
+    assert 'A new result to query' in msg
+    assert 'BRAF activates MAP2K1.' in msg

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -94,12 +94,23 @@ def test_is_diff():
 @attr('nonpublic')
 def test_report_one_query():
     qm = QueryManager(db_name='test')
+    # Using results from db
+    qm.db.put_queries('tester@test.com', query_object, ['test'], subscribe=True)
+    qm.db.put_results('test', [(query_object, test_response),
+                               (query_object, query_not_appl)])
+    str_msg = qm.get_report_per_query('test', query_object)
+    assert str_msg
+    assert 'A new result to query' in str_msg
+    assert 'Query is not applicable for this model' in str_msg
+    assert 'BRAF activates MAP2K1.' in str_msg
+    # String report given two responses explicitly
     str_msg = qm.make_str_report_one_query(
         'test', query_object, test_response, query_not_appl)
     assert str_msg
     assert 'A new result to query' in str_msg
     assert 'Query is not applicable for this model' in str_msg
     assert 'BRAF activates MAP2K1.' in str_msg
+    # Html report given two responses explicitly
     html_msg = qm.make_html_one_query_report(
         'test', query_object, test_response, query_not_appl)
     assert html_msg

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from nose.plugins.attrib import attr
 from emmaa.answer_queries import QueryManager, format_results, \
-    load_model_manager_from_s3, _is_diff
+    load_model_manager_from_s3, is_query_result_diff
 from emmaa.queries import Query
 from emmaa.model_tests import ModelManager
 from emmaa.db import get_db
@@ -18,7 +18,7 @@ Agent.__test__ = False
 get_db.__test__ = False
 Query.__test__ = False
 QueryManager.__test__ = False
-_is_diff.__test__ = False
+is_query_result_diff.__test__ = False
 
 
 test_query = {'type': 'path_property', 'path': {'type': 'Activation',
@@ -33,10 +33,15 @@ query_object = Query._from_json(test_query)
 
 test_response = {3801854542: [
     ('BRAF activates MAP2K1.',
-     'https://db.indra.bio/statements/from_agents?subject=1097@HGNC&object=6840@HGNC&type=Activation&format=html'),
+     'https://db.indra.bio/statements/from_agents?subject=1097@HGNC&object='
+     '6840@HGNC&type=Activation&format=html'),
     ('Active MAP2K1 activates MAPK1.',
-     'https://db.indra.bio/statements/from_agents?subject=6840@HGNC&object=6871@HGNC&type=Activation&format=html')]}
-processed_link = '<a href="https://db.indra.bio/statements/from_agents?subject=1097@HGNC&object=6840@HGNC&type=Activation&format=html" target="_blank" class="status-link">BRAF activates MAP2K1.</a>'
+     'https://db.indra.bio/statements/from_agents?subject=6840@HGNC&object='
+     '6871@HGNC&type=Activation&format=html')]}
+processed_link = '<a href="https://db.indra.bio/statements/from_agents?'\
+    'subject=1097@HGNC&object=6840@HGNC&type=Activation&format=html" '\
+                 'target="_blank" class="status-link">'\
+                 'BRAF activates MAP2K1.</a>'
 query_not_appl = {2413475507: [
     ('Query is not applicable for this model',
      'https://emmaa.readthedocs.io/en/latest/dashboard/response_codes.html')]}
@@ -67,7 +72,8 @@ def test_answer_immediate_query():
     assert results[0]['model'] == 'test'
     assert results[0]['query'] == simple_query
     assert isinstance(results[0]['response'], str)
-    assert 'BRAF activates MAP2K1.' in results[0]['response'], results[0]['response']
+    assert 'BRAF activates MAP2K1.' in results[0]['response'], \
+        results[0]['response']
     assert isinstance(results[0]['date'], str)
 
 
@@ -75,27 +81,30 @@ def test_answer_immediate_query():
 def test_answer_get_registered_queries():
     qm = QueryManager(db_name='test')
     qm._recreate_db()
-    qm.db.put_queries('tester@test.com', query_object, ['test'], subscribe=True)
+    qm.db.put_queries('tester@test.com', query_object, ['test'],
+                      subscribe=True)
     qm.answer_registered_queries('test')
     results = qm.get_registered_queries('tester@test.com')
     assert len(results) == 1
     assert results[0]['model'] == 'test'
     assert results[0]['query'] == simple_query
     assert isinstance(results[0]['response'], str)
-    assert 'BRAF activates MAP2K1.' in results[0]['response'], results[0]['response']
+    assert 'BRAF activates MAP2K1.' in results[0]['response'], \
+        results[0]['response']
     assert isinstance(results[0]['date'], str)
 
 
 def test_is_diff():
-    assert not _is_diff(query_not_appl, query_not_appl)
-    assert _is_diff(test_response, query_not_appl)
+    assert not is_query_result_diff(query_not_appl, query_not_appl)
+    assert is_query_result_diff(test_response, query_not_appl)
 
 
 @attr('nonpublic')
 def test_report_one_query():
     qm = QueryManager(db_name='test')
     # Using results from db
-    qm.db.put_queries('tester@test.com', query_object, ['test'], subscribe=True)
+    qm.db.put_queries('tester@test.com', query_object, ['test'],
+                      subscribe=True)
     qm.db.put_results('test', [(query_object, test_response),
                                (query_object, query_not_appl)])
     str_msg = qm.get_report_per_query('test', query_object)
@@ -123,16 +132,19 @@ def test_report_one_query():
 def test_report_files():
     qm = QueryManager(db_name='test')
     qm._recreate_db()
-    qm.db.put_queries('tester@test.com', query_object, ['test'], subscribe=True)
+    qm.db.put_queries('tester@test.com', query_object, ['test'],
+                      subscribe=True)
     qm.db.put_results('test', [(query_object, query_not_appl)])
-    qm.make_str_report_per_user('tester@test.com', filename='test_query_delta.txt')
+    qm.make_str_report_per_user('tester@test.com',
+                                filename='test_query_delta.txt')
     with open('test_query_delta.txt', 'r') as f:
         msg = f.read()
     assert msg
     assert 'This is the first result to query' in msg, msg
     assert 'Query is not applicable for this model' in msg
     qm.db.put_results('test', [(query_object, test_response)])
-    qm.make_str_report_per_user('tester@test.com', filename='test_query_delta.txt')
+    qm.make_str_report_per_user('tester@test.com',
+                                filename='test_query_delta.txt')
     with open('test_query_delta.txt', 'r') as f:
         msg = f.read()
     assert msg

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -21,13 +21,16 @@ QueryManager.__test__ = False
 _is_diff.__test__ = False
 
 
-test_query = {'type': 'path_property', 'path': {
-              'type': 'Activation', 'subj': {'type': 'Agent', 'name': 'BRAF'},
-              'obj': {'type': 'Agent', 'name': 'MAPK1'}}}
+test_query = {'type': 'path_property', 'path': {'type': 'Activation',
+              'subj': {'type': 'Agent', 'name': 'BRAF',
+                       'db_refs': {'HGNC': '1097'}},
+              'obj': {'type': 'Agent', 'name': 'MAPK1',
+                      'db_refs': {'HGNC': '6871'}}}}
 simple_query = {'typeSelection': 'Activation',
                 'subjectSelection': 'BRAF',
                 'objectSelection': 'MAPK1'}
 query_object = Query._from_json(test_query)
+
 test_response = {3801854542: [
     ('BRAF activates MAP2K1.',
      'https://db.indra.bio/statements/from_agents?subject=1097@HGNC&object=6840@HGNC&type=Activation&format=html'),

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -2,7 +2,8 @@ from datetime import datetime
 from nose.plugins.attrib import attr
 from emmaa.answer_queries import (
     answer_immediate_query, answer_registered_queries, get_registered_queries,
-    format_results, get_statement_by_query, load_model_manager_from_s3)
+    format_results, load_model_manager_from_s3)
+from emmaa.queries import Query
 from emmaa.model_tests import ModelManager
 from emmaa.db import get_db
 from indra.statements.statements import Activation
@@ -14,32 +15,23 @@ answer_immediate_query.__test__ = False
 answer_registered_queries.__test__ = False
 get_registered_queries.__test__ = False
 format_results.__test__ = False
-get_statement_by_query.__test__ = False
 load_model_manager_from_s3.__test__ = False
 ModelManager.__test__ = False
 Activation.__test__ = False
 Agent.__test__ = False
 get_db.__test__ = False
+Query.__test__ = False
 
 
-test_query = {'objectSelection': 'MAPK1', 'subjectSelection': 'BRAF',
-              'typeSelection': 'activation'}
+test_query = {'type': 'path_property', 'path': {
+    'type': 'Activation', 'subj': {'type': 'Agent', 'name': 'BRAF'},
+    'obj': {'type': 'Agent', 'name': 'MAPK1'}}}
+processed_query = Query._from_json(test_query).to_json()
 test_response = {3801854542: [
     ('BRAF activates MAP2K1.',
      'https://db.indra.bio/statements/from_agents?subject=1097@HGNC&object=6840@HGNC&type=Activation&format=html'),
     ('Active MAP2K1 activates MAPK1.',
      'https://db.indra.bio/statements/from_agents?subject=6840@HGNC&object=6871@HGNC&type=Activation&format=html')]}
-
-
-def test_get_statement_by_query():
-    stmt = get_statement_by_query(test_query)
-    assert isinstance(stmt, Activation)
-    assert isinstance(stmt.subj, Agent)
-    assert isinstance(stmt.obj, Agent)
-    assert stmt.subj.name == 'BRAF'
-    assert stmt.subj.db_refs == {'HGNC': '1097'}
-    assert stmt.obj.name == 'MAPK1'
-    assert stmt.obj.db_refs == {'HGNC': '6871'}
 
 
 def test_load_model_manager_from_s3():
@@ -59,12 +51,13 @@ def test_format_results():
 
 @attr('nonpublic')
 def test_answer_immediate_query():
-    results = answer_immediate_query('tester@test.com', test_query, ['test'],
+    results = answer_immediate_query('tester@test.com', processed_query, ['test'],
                                      subscribe=False, db_name='test')
     assert len(results) == 1
     assert results[0]['model'] == 'test'
-    assert results[0]['query'] == test_query
+    assert results[0]['query'] == processed_query, (results[0]['query'], processed_query)
     assert isinstance(results[0]['response'], str)
+    assert 'BRAF activates MAP2K1.' in results[0]['response'], results[0]['response']
     assert isinstance(results[0]['date'], str)
 
 
@@ -73,11 +66,12 @@ def test_answer_get_registered_queries():
     db = get_db('test')
     db.drop_tables(force=True)
     db.create_tables()
-    db.put_queries('tester@test.com', test_query, ['test'], subscribe=True)
+    db.put_queries('tester@test.com', processed_query, ['test'], subscribe=True)
     answer_registered_queries('test', db_name='test')
     results = get_registered_queries('tester@test.com', db_name='test')
     assert len(results) == 1
     assert results[0]['model'] == 'test'
-    assert results[0]['query'] == test_query
+    assert results[0]['query'] == processed_query
     assert isinstance(results[0]['response'], str)
+    assert 'BRAF activates MAP2K1.' in results[0]['response'], results[0]['response']
     assert isinstance(results[0]['date'], str)

--- a/emmaa/tests/test_model_tests.py
+++ b/emmaa/tests/test_model_tests.py
@@ -10,13 +10,7 @@ from emmaa.analyze_tests_results import TestRound, StatsGenerator
 StatementCheckingTest.__test__ = False
 run_model_tests_from_s3.__test__ = False
 load_tests_from_s3.__test__ = False
-ModelManager.__test__ = False
-PathResult.__test__ = False
-EmmaaModel.__test__ = False
-ModelChecker.__test__ = False
 TestRound.__test__ = False
-StatsGenerator.__test__ = False
-Statement.__test__ = False
 
 
 def test_load_tests_from_s3():

--- a/emmaa/tests/test_model_tests.py
+++ b/emmaa/tests/test_model_tests.py
@@ -31,7 +31,8 @@ def test_load_tests_from_s3():
 def test_run_tests_from_s3():
     (mm, sg) = run_model_tests_from_s3(
         'test', 'simple_model_test.pkl', upload_mm=False,
-        upload_results=False, upload_stats=False, registered_queries=False)
+        upload_results=False, upload_stats=False, registered_queries=False,
+        db_name='test')
     assert isinstance(mm, ModelManager)
     assert isinstance(mm.model, EmmaaModel)
     assert isinstance(mm.model_checker, ModelChecker)

--- a/emmaa/tests/test_queries.py
+++ b/emmaa/tests/test_queries.py
@@ -1,6 +1,8 @@
 import json
 from indra.statements import Phosphorylation, Agent
-from emmaa.queries import Query, PathProperty
+from emmaa.queries import (Query, PathProperty, get_agent_from_local_grounding,
+                           get_agent_from_grounding_service,
+                           get_grounding_from_name, get_agent_from_text)
 
 
 # Tell nose to not run tests in the imported modules
@@ -50,3 +52,36 @@ def test_stringify_path_property():
     query = PathProperty(stmt, entity_constraints, relationship_contraints)
     query_str = str(query)
     assert query_str == 'PathPropertyQuery(stmt=Phosphorylation(EGFR(), ERK()). Exclude entities: PI3K(). Exclude relations: IncreaseAmount, DecreaseAmount.'
+
+
+def test_grounding_from_name():
+    assert get_grounding_from_name('MAPK1')['HGNC'] == '6871'
+    assert get_grounding_from_name('BRAF')['HGNC'] == '1097'
+
+
+def test_local_grounding():
+    agent = get_agent_from_local_grounding('MAPK1')
+    assert isinstance(agent, Agent)
+    assert agent.name == 'MAPK1'
+    assert agent.db_refs == {'HGNC': '6871'}
+    # test with lower case
+    agent = get_agent_from_local_grounding('mapk1')
+    assert isinstance(agent, Agent)
+    assert agent.name == 'MAPK1'
+    assert agent.db_refs == {'HGNC': '6871'}
+    # other agent
+    agent = get_agent_from_local_grounding('BRAF')
+    assert isinstance(agent, Agent)
+    assert agent.name == 'BRAF'
+    assert agent.db_refs == {'HGNC': '1097'}
+
+
+def test_grounding_service():
+    agent = get_agent_from_grounding_service('MAPK1', GROUNDING_SERVICE_URL)
+    assert isinstance(agent, Agent)
+    assert agent.name == 'MAPK1'
+    assert agent.db_refs == {'HGNC': '6871'}
+    agent = get_agent_from_local_grounding('BRAF')
+    assert isinstance(agent, Agent)
+    assert agent.name == 'BRAF'
+    assert agent.db_refs == {'HGNC': '1097'}

--- a/emmaa/tests/test_queries.py
+++ b/emmaa/tests/test_queries.py
@@ -71,6 +71,7 @@ def test_local_grounding():
     assert agent.db_refs == {'HGNC': '1097'}
 
 
+@attr('nonpublic')
 def test_grounding_service():
     url = os.environ['GROUNDING_SERVICE_URL']
     agent = get_agent_from_grounding_service('MAPK1', url)

--- a/emmaa/tests/test_queries.py
+++ b/emmaa/tests/test_queries.py
@@ -55,8 +55,8 @@ def test_stringify_path_property():
 
 
 def test_grounding_from_name():
-    assert get_grounding_from_name('MAPK1')['HGNC'] == '6871'
-    assert get_grounding_from_name('BRAF')['HGNC'] == '1097'
+    assert get_grounding_from_name('MAPK1') == ('HGNC', '6871')
+    assert get_grounding_from_name('BRAF') == ('HGNC', '1097')
 
 
 def test_local_grounding():

--- a/emmaa/tests/test_queries.py
+++ b/emmaa/tests/test_queries.py
@@ -1,0 +1,41 @@
+import json
+from indra.statements import Phosphorylation, Agent
+from emmaa.queries import Query, PathProperty
+
+
+# Tell nose to not run tests in the imported modules
+Phosphorylation.__test__ = False
+Agent.__test__ = False
+Query.__test__ = False
+PathProperty.__test__ = False
+
+
+def test_path_property_from_json():
+    with open('path_property_query.json', 'r') as f:
+        json_dict = json.load(f)
+    query = Query._from_json(json_dict)
+    assert query
+    assert isinstance(query, PathProperty)
+    assert isinstance(query.path_stmt, Phosphorylation), query.path_stmt
+    assert query.path_stmt.enz.name == 'EGFR', query.path_stmt
+    assert query.path_stmt.sub.name == 'ERK', query.path_stmt
+    assert isinstance(query.exclude_entities[0], Agent)
+    assert query.exclude_entities[0].name == 'PI3K'
+    assert not query.include_entities, query.include_entities
+    assert set(query.exclude_rels) == set(['IncreaseAmount', 'DecreaseAmount'])
+    assert not query.include_rels, query.include_rels
+
+
+def test_path_property_to_json():
+    stmt = Phosphorylation(enz=Agent('EGFR'), sub=Agent('ERK'))
+    entity_constraints = {'exclude': [Agent('PI3K')]}
+    relationship_contraints = {'exclude': ['IncreaseAmount', 'DecreaseAmount']}
+    query = PathProperty(stmt, entity_constraints, relationship_contraints)
+    assert query
+    json = query.to_json()
+    assert json.get('type') == 'path_property'
+    path = json.get('path')
+    assert path.get('type') == 'Phosphorylation'
+    deserialize_query = Query._from_json(json)
+    json2 = deserialize_query.to_json()
+    assert json == json2

--- a/emmaa/tests/test_queries.py
+++ b/emmaa/tests/test_queries.py
@@ -40,3 +40,13 @@ def test_path_property_to_json():
     deserialize_query = Query._from_json(json)
     json2 = deserialize_query.to_json()
     assert json == json2, {'json': json, 'json2': json2}
+
+
+def test_stringify_path_property():
+    stmt = Phosphorylation(enz=Agent('EGFR', db_refs={'HGNC': '3236'}),
+                           sub=Agent('ERK', db_refs={'FPLX': 'ERK'}))
+    entity_constraints = {'exclude': [Agent('PI3K', db_refs={'FPLX': 'PI3K'})]}
+    relationship_contraints = {'exclude': ['IncreaseAmount', 'DecreaseAmount']}
+    query = PathProperty(stmt, entity_constraints, relationship_contraints)
+    query_str = str(query)
+    assert query_str == 'PathPropertyQuery(stmt=Phosphorylation(EGFR(), ERK()). Exclude entities: PI3K(). Exclude relations: IncreaseAmount, DecreaseAmount.'

--- a/emmaa/tests/test_queries.py
+++ b/emmaa/tests/test_queries.py
@@ -27,8 +27,9 @@ def test_path_property_from_json():
 
 
 def test_path_property_to_json():
-    stmt = Phosphorylation(enz=Agent('EGFR'), sub=Agent('ERK'))
-    entity_constraints = {'exclude': [Agent('PI3K')]}
+    stmt = Phosphorylation(enz=Agent('EGFR', db_refs={'HGNC': '3236'}),
+                           sub=Agent('ERK', db_refs={'FPLX': 'ERK'}))
+    entity_constraints = {'exclude': [Agent('PI3K', db_refs={'FPLX': 'PI3K'})]}
     relationship_contraints = {'exclude': ['IncreaseAmount', 'DecreaseAmount']}
     query = PathProperty(stmt, entity_constraints, relationship_contraints)
     assert query
@@ -38,4 +39,4 @@ def test_path_property_to_json():
     assert path.get('type') == 'Phosphorylation'
     deserialize_query = Query._from_json(json)
     json2 = deserialize_query.to_json()
-    assert json == json2
+    assert json == json2, {'json': json, 'json2': json2}

--- a/emmaa/tests/test_queries.py
+++ b/emmaa/tests/test_queries.py
@@ -1,4 +1,5 @@
 import json
+import os
 from indra.statements import Phosphorylation, Agent
 from emmaa.queries import (Query, PathProperty, get_agent_from_local_grounding,
                            get_agent_from_grounding_service,
@@ -77,7 +78,8 @@ def test_local_grounding():
 
 
 def test_grounding_service():
-    agent = get_agent_from_grounding_service('MAPK1', GROUNDING_SERVICE_URL)
+    url = os.environ['GROUNDING_SERVICE_URL']
+    agent = get_agent_from_grounding_service('MAPK1', url)
     assert isinstance(agent, Agent)
     assert agent.name == 'MAPK1'
     assert agent.db_refs == {'HGNC': '6871'}

--- a/emmaa/tests/test_queries.py
+++ b/emmaa/tests/test_queries.py
@@ -1,5 +1,6 @@
 import json
 import os
+from nose.plugins.attrib import attr
 from indra.statements import Phosphorylation, Agent
 from emmaa.queries import (Query, PathProperty, get_agent_from_local_grounding,
                            get_agent_from_grounding_service,

--- a/emmaa/tests/test_queries.py
+++ b/emmaa/tests/test_queries.py
@@ -6,13 +6,6 @@ from emmaa.queries import (Query, PathProperty, get_agent_from_local_grounding,
                            get_grounding_from_name, get_agent_from_text)
 
 
-# Tell nose to not run tests in the imported modules
-Phosphorylation.__test__ = False
-Agent.__test__ = False
-Query.__test__ = False
-PathProperty.__test__ = False
-
-
 def test_path_property_from_json():
     with open('path_property_query.json', 'r') as f:
         json_dict = json.load(f)

--- a/emmaa/tests/test_queries.py
+++ b/emmaa/tests/test_queries.py
@@ -24,9 +24,10 @@ def test_path_property_from_json():
     assert query.path_stmt.sub.name == 'ERK', query.path_stmt
     assert isinstance(query.exclude_entities[0], Agent)
     assert query.exclude_entities[0].name == 'PI3K'
-    assert not query.include_entities, query.include_entities
+    assert isinstance(query.include_entities[0], Agent)
+    assert query.include_entities[0].name == 'MAPK1'
     assert set(query.exclude_rels) == set(['IncreaseAmount', 'DecreaseAmount'])
-    assert not query.include_rels, query.include_rels
+    assert query.include_rels[0] == 'Inhibition'
 
 
 def test_path_property_to_json():

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -107,7 +107,7 @@ def _make_query(query_dict):
 
 
 def _get_agent_from_name(agent_name):
-    agent = Agent('agent_name')
+    agent = Agent(agent_name)
     return add_db_refs(agent)
 
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -14,7 +14,7 @@ from indra.statements import get_all_descendants, IncreaseAmount, \
 from emmaa.model import load_config_from_s3
 from emmaa.answer_queries import QueryManager, GroundingError, \
     load_model_manager_from_s3
-from emmaa.queries import PathProperty, add_db_refs
+from emmaa.queries import PathProperty, get_agent_from_name
 
 
 app = Flask(__name__)
@@ -99,16 +99,11 @@ def get_queryable_stmt_types():
 def _make_query(query_dict):
     stmt_type = query_dict['typeSelection']
     stmt_class = get_statement_by_name(stmt_type)
-    subj = _get_agent_from_name(query_dict['subjectSelection'])
-    obj = _get_agent_from_name(query_dict['objectSelection'])
+    subj = get_agent_from_name(query_dict['subjectSelection'])
+    obj = get_agent_from_name(query_dict['objectSelection'])
     stmt = stmt_class(subj, obj)
     query = PathProperty(path_stmt=stmt)
     return query
-
-
-def _get_agent_from_name(agent_name):
-    agent = Agent(agent_name)
-    return add_db_refs(agent)
 
 
 @app.route('/')

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -9,12 +9,13 @@ from flask import abort, Flask, request, Response
 
 from indra.statements import get_all_descendants, IncreaseAmount, \
     DecreaseAmount, Activation, Inhibition, AddModification, \
-    RemoveModification
+    RemoveModification, get_statement_by_name, Agent
 
-from emmaa.db import get_db
 from emmaa.model import load_config_from_s3
-from emmaa.answer_queries import answer_immediate_query, \
-    get_registered_queries, GroundingError, load_model_manager_from_s3
+from emmaa.answer_queries import QueryManager, GroundingError, \
+    load_model_manager_from_s3
+from emmaa.queries import PathProperty, add_db_refs
+
 
 app = Flask(__name__)
 logger = logging.getLogger(__name__)
@@ -23,6 +24,9 @@ logger = logging.getLogger(__name__)
 HERE = path.dirname(path.abspath(__file__))
 EMMAA = path.join(HERE, path.pardir)
 DASHBOARD = path.join(EMMAA, 'dashboard')
+
+
+qm = QueryManager('primary')
 
 
 # Create a template object from the template file, load once
@@ -92,6 +96,21 @@ def get_queryable_stmt_types():
     return stmt_types
 
 
+def _make_query(query_dict):
+    stmt_type = query_dict['typeSelection']
+    stmt_class = get_statement_by_name(stmt_type)
+    subj = _get_agent_from_name(query_dict['subjectSelection'])
+    obj = _get_agent_from_name(query_dict['objectSelection'])
+    stmt = stmt_class(subj, obj)
+    query = PathProperty(path_stmt=stmt)
+    return query
+
+
+def _get_agent_from_name(agent_name):
+    agent = Agent('agent_name')
+    return add_db_refs(agent)
+
+
 @app.route('/')
 @app.route('/home')
 def get_home():
@@ -112,7 +131,7 @@ def get_query_page():
     stmt_types = get_queryable_stmt_types()
 
     user_email = 'joshua@emmaa.com'
-    old_results = get_registered_queries(user_email)
+    old_results = qm.get_registered_queries(user_email)
 
     return QUERIES.render(model_data=model_data, stmt_types=stmt_types,
                           old_results=old_results)
@@ -139,6 +158,7 @@ def process_query():
         assert set(query_json.keys()) == expected_query_keys, \
             (f'Did not get expected query keys: got {set(query_json.keys())} '
              f'not {expected_query_keys}')
+        query = _make_query(query_json)
         models = set(request.json.get('models'))
         assert models < expceted_models, \
             f'Got unexpected models: {models - expceted_models}'
@@ -156,8 +176,8 @@ def process_query():
     else:
         logger.info('Query submitted')
         try:
-            result = answer_immediate_query(
-                user_email, query_json, models, subscribe)
+            result = qm.answer_immediate_query(
+                user_email, query, models, subscribe)
         except GroundingError as e:
             logger.exception(e)
             logger.error("Invalid grounding!")

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -12,9 +12,8 @@ from indra.statements import get_all_descendants, IncreaseAmount, \
     RemoveModification, get_statement_by_name, Agent
 
 from emmaa.model import load_config_from_s3
-from emmaa.answer_queries import QueryManager, GroundingError, \
-    load_model_manager_from_s3
-from emmaa.queries import PathProperty, get_agent_from_text
+from emmaa.answer_queries import QueryManager, load_model_manager_from_s3
+from emmaa.queries import PathProperty, get_agent_from_text, GroundingError
 
 
 app = Flask(__name__)

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -14,7 +14,7 @@ from indra.statements import get_all_descendants, IncreaseAmount, \
 from emmaa.model import load_config_from_s3
 from emmaa.answer_queries import QueryManager, GroundingError, \
     load_model_manager_from_s3
-from emmaa.queries import PathProperty, get_agent_from_name
+from emmaa.queries import PathProperty, get_agent_from_text
 
 
 app = Flask(__name__)
@@ -99,8 +99,8 @@ def get_queryable_stmt_types():
 def _make_query(query_dict):
     stmt_type = query_dict['typeSelection']
     stmt_class = get_statement_by_name(stmt_type)
-    subj = get_agent_from_name(query_dict['subjectSelection'])
-    obj = get_agent_from_name(query_dict['objectSelection'])
+    subj = get_agent_from_text(query_dict['subjectSelection'], True)
+    obj = get_agent_from_text(query_dict['objectSelection'], True)
     stmt = stmt_class(subj, obj)
     query = PathProperty(path_stmt=stmt)
     return query

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='emmaa',
         'Programming Language :: Python :: 3.7'
         ],
       packages=find_packages(),
-      install_requires=['indra', 'boto3', 'jsonpickle', 'kappy', 'pygraphviz',
-                        'fnvhash', 'sqlalchemy', 'inflection'],
+      install_requires=['indra', 'boto3', 'jsonpickle', 'kappy==4.0.0rc1',
+                        'pygraphviz', 'fnvhash', 'sqlalchemy', 'inflection'],
       extras_require={'test': ['nose', 'coverage', 'python-coveralls']}
       )

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setup(name='emmaa',
         ],
       packages=find_packages(),
       install_requires=['indra', 'boto3', 'jsonpickle', 'kappy', 'pygraphviz',
-                        'fnvhash', 'sqlalchemy'],
+                        'fnvhash', 'sqlalchemy', 'inflection'],
       extras_require={'test': ['nose', 'coverage', 'python-coveralls']}
       )


### PR DESCRIPTION
This PR makes changes to query answering process.

- New parent class Query and four child classes for different types of queries are created. For now only PathProperty class is implemented.
- API creates a Query object from a simple form ("typeSelection", "objectSelection", "subjectSelection") using Grounding service.
- A Query object can be passed to QueryManager class that can interact with the DB Manager and ModelManager, answer immediate and registered queries (using relevant methods of ModelManager), save and retrieve queries and results to a database, find delta between query results and produce reports in either string or html format.
- The easiest way to get a report for delta in query results is to use either `qm.get_user_query_delta(user_email, filename, report_format)` # currently returns deltas for all queries as we're not handling different users. report_format can be 'str' or 'html' or
`qm.get_report_per_query(model_name, query)` # needs a Query object
- Database manager takes and returns Query object instead of JSON and calls its internal `.to_json`, `._from_json` and `.get_hash_with_model` methods to get the values to store in the database and to reconstruct the object when returning.
- A database will need to be cleared after this merge because the changes are not compatible with the existing query format.