### PR TITLE
Fix query result delta bug

### DIFF
--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -208,7 +208,7 @@ class ModelManager(object):
             for (sentence, link) in response:
                 sentences.append(sentence)
             response_str = ' '.join(sentences)
-            response_hash = fnv1a_32(response_str.encode('utf-8'))
+            response_hash = str(fnv1a_32(response_str.encode('utf-8')))
             response_dict[response_hash] = response
         return response_dict
 


### PR DESCRIPTION
This PR fixes the bug of delta reporting in logs. The delta is found by comparing the hashes of new result and previous result. The issue here was that hashes are generated as integers and are automatically converted to string when saved to db. As a result, integers (hash of new result before saving to db) were compared to string (hash of previous result from db) and we got false positive delta. The PR makes hashes to always be strings and avoid type difference.