### PR TITLE
Improvements to Query Refactor #79 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ venv.bak/
 # Outputs of tests
 emmaa/tests/test_query_delta.txt
 emmaa/tests/test_query_delta.html
+emmaa/tests/new_test_query_delta.txt

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -162,12 +162,14 @@ class ModelManager(object):
                     (query, self.hash_response_list(
                         [[(RESULT_CODES['QUERY_NOT_APPLICABLE'],
                           result_codes_link)]])))
-        self.get_im(applicable_stmts)
-        results = self.model_checker.check_model()
-        for ix, (_, result) in enumerate(results):
-            responses.append(
-                (applicable_queries[ix],
-                 self.process_response(result)))
+        # Only do the following steps if there are applicable queries
+        if applicable_queries:
+            self.get_im(applicable_stmts)
+            results = self.model_checker.check_model()
+            for ix, (_, result) in enumerate(results):
+                responses.append(
+                    (applicable_queries[ix],
+                     self.process_response(result)))
         return responses
 
     def _get_test_configs(self):

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -1,3 +1,4 @@
+from os.path import abspath, dirname, join
 from datetime import datetime
 from nose.plugins.attrib import attr
 from emmaa.answer_queries import QueryManager, format_results, \
@@ -128,7 +129,8 @@ def test_report_files():
     results = qm.db.get_results('tester@test.com', latest_order=1)
     qm.make_str_report_per_user(results,
                                 filename='test_query_delta.txt')
-    with open('test_query_delta.txt', 'r') as f:
+    report_file = join(dirname(abspath(__file__)), 'test_query_delta.txt')
+    with open(report_file, 'r') as f:
         msg = f.read()
     assert msg
     assert 'This is the first result to query' in msg, msg
@@ -136,8 +138,10 @@ def test_report_files():
     qm.db.put_results('test', [(query_object, test_response)])
     results = qm.db.get_results('tester@test.com', latest_order=1)
     qm.make_str_report_per_user(results,
-                                filename='test_query_delta.txt')
-    with open('test_query_delta.txt', 'r') as f:
+                                filename='new_test_query_delta.txt')
+    new_report_file = join(dirname(abspath(__file__)),
+                           'new_test_query_delta.txt')
+    with open(new_report_file, 'r') as f:
         msg = f.read()
     assert msg
     assert 'A new result to query' in msg

--- a/emmaa/tests/test_queries.py
+++ b/emmaa/tests/test_queries.py
@@ -1,5 +1,6 @@
 import json
 import os
+from os.path import abspath, dirname, join
 from nose.plugins.attrib import attr
 from indra.statements import Phosphorylation, Agent
 from emmaa.queries import (Query, PathProperty, get_agent_from_local_grounding,
@@ -8,7 +9,8 @@ from emmaa.queries import (Query, PathProperty, get_agent_from_local_grounding,
 
 
 def test_path_property_from_json():
-    with open('path_property_query.json', 'r') as f:
+    query_file = join(dirname(abspath(__file__)), 'path_property_query.json')
+    with open(query_file, 'r') as f:
         json_dict = json.load(f)
     query = Query._from_json(json_dict)
     assert query


### PR DESCRIPTION
This PR changes how GroundingError is handled on the API side. Because of the refactoring made in #79, GroundingError will be raised earlier at the stage of creating a query in `_make_query` from a user form (it used to happen at the level of answering the query). I also parameterized using the Grounding service in this function which makes it easier to run and test locally.