### PR TITLE
Change over to using a travis db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,7 @@ install:
   - pip install .[test]
 before_script:
   # Create a test database.
-  - psql -c 'create database travis_db_test;' -U postgres
-  - psql -c 'CREATE extension tablefunc;' -U postgres
-  - export INDRADBTEST="postgresql://postgres:@localhost/emmaadb_test"
+  - psql -c 'create database emmaadb_test;' -U postgres
 script:
   - export AWS_DEFAULT_REGION='us-east-1'
   - export NOSEATTR="!notravis";

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,22 @@ cache:
     - $HOME/.cache/pip
 python:
   - "3.6"
+services:
+  - postgresql
+addons:
+  postgresql: "9.6"
+  apt:
+    packages:
+      - libssl1.0.0
 install:
   - pip install git+https://github.com/sorgerlab/indra.git
   - pip install git+https://github.com/indralab/indra_db.git
   - pip install .[test]
+before_script:
+  # Create a test database.
+  - psql -c 'create database travis_db_test;' -U postgres
+  - psql -c 'CREATE extension tablefunc;' -U postgres
+  - export INDRADBTEST="postgresql://postgres:@localhost/emmaadb_test"
 script:
   - export AWS_DEFAULT_REGION='us-east-1'
   - export NOSEATTR="!notravis";

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -3,8 +3,6 @@ import pickle
 from datetime import datetime
 from emmaa.util import get_s3_client, make_date_str
 from emmaa.db import get_db
-from emmaa.queries import Query
-from indra.statements.statements import Statement
 
 
 logger = logging.getLogger(__name__)

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -24,8 +24,10 @@ class QueryManager(object):
         Optional list of ModelManagers to use for running queries. If not
         given, the methods will load ModelManager from S3 when needed.
     """
-    def __init__(self, db_name='primary', model_managers=None):
-        self.db = get_db(db_name)
+    def __init__(self, db=None, model_managers=None):
+        self.db = db
+        if db is None:
+            self.db = get_db('primary')
         self.model_managers = model_managers if model_managers else []
 
     def answer_immediate_query(

--- a/emmaa/db/constructors.py
+++ b/emmaa/db/constructors.py
@@ -1,4 +1,3 @@
-import os
 import re
 import logging
 
@@ -10,11 +9,8 @@ logger = logging.getLogger(__name__)
 
 def get_db(name):
     """Get a db instance based on its name in the config or env."""
-    if name == 'test' and 'EMMAADBTEST' in os.environ:
-        db_name = os.environ['EMMAADBTEST']
-    else:
-        defaults = get_databases()
-        db_name = defaults[name]
+    defaults = get_databases()
+    db_name = defaults[name]
     m = re.match('(\w+)://.*?/([\w.]+)', db_name)
     if m is None:
         logger.error("Poorly formed db name: %s" % db_name)

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -385,7 +385,7 @@ def save_model_manager_to_s3(model_name, model_manager):
 
 def run_model_tests_from_s3(model_name, test_name, upload_mm=True,
                             upload_results=True, upload_stats=True,
-                            registered_queries=True, db_name='primary'):
+                            registered_queries=True, db=None):
     """Run a given set of tests on a given model, both loaded from S3.
 
     After loading both the model and the set of tests, model/test overlap
@@ -410,6 +410,8 @@ def run_model_tests_from_s3(model_name, test_name, upload_mm=True,
     registered_queries : Optional[bool]
         If True, registered queries are fetched from the database and
         executed, the results are then saved to the database. Default: True
+    db : Optional[emmaa.db.manager.EmmaaDatabaseManager]
+        If given over-rides the default primary database.
 
     Returns
     -------
@@ -445,6 +447,6 @@ def run_model_tests_from_s3(model_name, test_name, upload_mm=True,
     if upload_stats:
         sg.save_to_s3()
     if registered_queries:
-        qm = QueryManager(db_name=db_name, model_managers=[mm])
+        qm = QueryManager(db=db, model_managers=[mm])
         qm.answer_registered_queries(model_name)
     return (mm, sg)

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -442,7 +442,7 @@ def run_model_tests_from_s3(model_name, test_name, upload_mm=True,
     tr = TestRound(results_json_dict)
     sg = StatsGenerator(model_name, latest_round=tr)
     sg.make_stats()
-    stats_json_dict = sg.json_stats
+
     # Optionally upload statistics to S3
     if upload_stats:
         sg.save_to_s3()

--- a/emmaa/resources/default_db_config.ini
+++ b/emmaa/resources/default_db_config.ini
@@ -4,19 +4,6 @@
 # the format defined in `emmaa.db.config.DB_STR_FMT`, with a name starting with
 # EMMAADB<db_name_in_all_caps>
 
-# Tests Databases:
-# ----------------
-
-[local test]
-dialect = sqlite
-driver =
-username =
-password =
-host =
-port =
-name = emmaa_test.db
-
-
 # The Primary Database:
 # ---------------------
 # When using the low-level database access classes, it is assumed that there is

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -4,9 +4,7 @@ from emmaa.answer_queries import QueryManager, format_results, \
     load_model_manager_from_s3, is_query_result_diff
 from emmaa.queries import Query
 from emmaa.model_tests import ModelManager
-from emmaa.db import get_db
-from indra.statements.statements import Activation
-from indra.statements.agent import Agent
+from emmaa.tests.test_db import _get_test_db
 
 
 test_query = {'type': 'path_property', 'path': {'type': 'Activation',
@@ -52,7 +50,8 @@ def test_format_results():
 
 @attr('nonpublic')
 def test_answer_immediate_query():
-    qm = QueryManager(db_name='test')
+    db = _get_test_db()
+    qm = QueryManager(db=db)
     qm._recreate_db()
     results = qm.answer_immediate_query('tester@test.com', query_object,
                                         ['test'], subscribe=False)
@@ -67,7 +66,8 @@ def test_answer_immediate_query():
 
 @attr('nonpublic')
 def test_answer_get_registered_queries():
-    qm = QueryManager(db_name='test')
+    db = _get_test_db()
+    qm = QueryManager(db=db)
     qm._recreate_db()
     qm.db.put_queries('tester@test.com', query_object, ['test'],
                       subscribe=True)
@@ -89,7 +89,8 @@ def test_is_diff():
 
 @attr('nonpublic')
 def test_report_one_query():
-    qm = QueryManager(db_name='test')
+    db = _get_test_db()
+    qm = QueryManager(db=db)
     # Using results from db
     qm.db.put_queries('tester@test.com', query_object, ['test'],
                       subscribe=True)
@@ -118,7 +119,8 @@ def test_report_one_query():
 
 @attr('nonpublic')
 def test_report_files():
-    qm = QueryManager(db_name='test')
+    db = _get_test_db()
+    qm = QueryManager(db=db)
     qm._recreate_db()
     qm.db.put_queries('tester@test.com', query_object, ['test'],
                       subscribe=True)

--- a/emmaa/tests/test_db.py
+++ b/emmaa/tests/test_db.py
@@ -3,7 +3,7 @@ import random
 
 from nose.plugins.attrib import attr
 
-from emmaa.db import get_db, Query, Result
+from emmaa.db import Query, Result, EmmaaDatabaseManager
 from emmaa.queries import Query as QueryObject, PathProperty
 
 
@@ -20,7 +20,7 @@ test_queries = [QueryObject._from_json(qj) for qj in test_query_jsons]
 
 @attr('nonpublic')
 def _test_db():
-    db = get_db('test')
+    db = EmmaaDatabaseManager('postgresql://postgres:@localhost/emmaadb_test')
     db.drop_tables(force=True)
     db.create_tables()
     return db

--- a/emmaa/tests/test_db.py
+++ b/emmaa/tests/test_db.py
@@ -18,8 +18,7 @@ test_query_jsons = [{'type': 'path_property', 'path': {'type': 'Activation',
 test_queries = [QueryObject._from_json(qj) for qj in test_query_jsons]
 
 
-@attr('nonpublic')
-def _test_db():
+def _get_test_db():
     db = EmmaaDatabaseManager('postgresql://postgres:@localhost/emmaadb_test')
     db.drop_tables(force=True)
     db.create_tables()
@@ -28,14 +27,14 @@ def _test_db():
 
 @attr('nonpublic')
 def test_instantiation():
-    db = _test_db()
+    db = _get_test_db()
     assert db
     return
 
 
 @attr('nonpublic')
 def test_put_queries():
-    db = _test_db()
+    db = _get_test_db()
     db.put_queries('joshua', test_queries[0], ['aml', 'luad'])
     with db.get_session() as sess:
         queries = sess.query(Query).all()
@@ -44,7 +43,7 @@ def test_put_queries():
 
 @attr('nonpublic')
 def test_get_queries():
-    db = _test_db()
+    db = _get_test_db()
     for query in test_queries:
         db.put_queries('joshua', query, ['aml', 'luad'])
     queries = db.get_queries('aml')
@@ -58,7 +57,7 @@ def _get_random_result():
 
 @attr('nonpublic')
 def test_put_results():
-    db = _test_db()
+    db = _get_test_db()
     db.put_queries('joshua', test_queries[0], ['aml', 'luad'])
     queries = db.get_queries('aml')
     results = [(query, _get_random_result())
@@ -71,7 +70,7 @@ def test_put_results():
 
 @attr('nonpublic')
 def test_get_results():
-    db = _test_db()
+    db = _get_test_db()
     models = ['aml', 'luad']
 
     # Fill up the database.
@@ -92,7 +91,7 @@ def test_get_results():
 
 @attr('nonpublic')
 def test_get_latest_results():
-    db = _test_db()
+    db = _get_test_db()
     models = ['aml', 'luad']
 
     # Fill up the database.

--- a/emmaa/tests/test_model_tests.py
+++ b/emmaa/tests/test_model_tests.py
@@ -6,6 +6,9 @@ from emmaa.model_tests import (StatementCheckingTest, run_model_tests_from_s3,
                                load_tests_from_s3, ModelManager)
 from emmaa.analyze_tests_results import TestRound, StatsGenerator
 
+from emmaa.tests.test_db import _get_test_db
+
+
 # Tell nose to not run tests in the imported modules
 StatementCheckingTest.__test__ = False
 run_model_tests_from_s3.__test__ = False
@@ -23,10 +26,11 @@ def test_load_tests_from_s3():
 
 @attr('nonpublic')
 def test_run_tests_from_s3():
+    db = _get_test_db()
     (mm, sg) = run_model_tests_from_s3(
         'test', 'simple_model_test.pkl', upload_mm=False,
         upload_results=False, upload_stats=False, registered_queries=False,
-        db_name='test')
+        db=db)
     assert isinstance(mm, ModelManager)
     assert isinstance(mm.model, EmmaaModel)
     assert isinstance(mm.model_checker, ModelChecker)


### PR DESCRIPTION
To add extra distance between the testing and primary databases, and also to resolve issues of conflicting access to a shared resource, use the local postgres database provided by Travis to test. This will require local tests to create a local database for testing (detailed instructions could perhaps be included in a later PR).