### PR TITLE
Refresh hash

### DIFF
--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -110,7 +110,8 @@ class TestRound(object):
         """Return a dictionary mapping a statement and its English description."""
         stmts_by_hash = {}
         for stmt in self.statements:
-            stmts_by_hash[str(stmt.get_hash(refresh=True))] = self.get_english_statement(stmt)
+            stmts_by_hash[str(stmt.get_hash(refresh=True))] = (
+                self.get_english_statement(stmt))
         return stmts_by_hash
 
     def get_english_statement(self, stmt):

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -74,7 +74,7 @@ class TestRound(object):
 
     def get_stmt_hashes(self):
         """Return a list of hashes for all statements in a model."""
-        return [str(stmt.get_hash()) for stmt in self.statements]
+        return [str(stmt.get_hash(refresh=True)) for stmt in self.statements]
 
     def get_statement_types(self):
         """Return a sorted list of tuples containing a statement type and a
@@ -102,7 +102,7 @@ class TestRound(object):
         number of times this statement occured in a model."""
         stmts_evidence = {}
         for stmt in self.statements:
-            stmts_evidence[str(stmt.get_hash())] = len(stmt.evidence)
+            stmts_evidence[str(stmt.get_hash(refresh=True))] = len(stmt.evidence)
         logger.info('Sorting statements by evidence count.')
         return sorted(stmts_evidence.items(), key=lambda x: x[1], reverse=True)
 
@@ -110,7 +110,7 @@ class TestRound(object):
         """Return a dictionary mapping a statement and its English description."""
         stmts_by_hash = {}
         for stmt in self.statements:
-            stmts_by_hash[str(stmt.get_hash())] = self.get_english_statement(stmt)
+            stmts_by_hash[str(stmt.get_hash(refresh=True))] = self.get_english_statement(stmt)
         return stmts_by_hash
 
     def get_english_statement(self, stmt):
@@ -165,7 +165,7 @@ class TestRound(object):
                 return 'Fail'
 
         for ix, test in enumerate(self.tests):
-            test_hash = str(test.get_hash())
+            test_hash = str(test.get_hash(refresh=True))
             result = self.test_results[ix]
             tests_by_hash[test_hash] = [
                 self.get_english_statement(test),
@@ -190,7 +190,7 @@ class TestRound(object):
                         link_str = f'<a href="{link}">{sentence}</a>'
                         links.append(link_str)
                     paths.append(links)
-                    english_paths[str(self.tests[ix].get_hash())] = paths
+                    english_paths[str(self.tests[ix].get_hash(refresh=True))] = paths
         return english_paths
 
     def get_english_codes(self):
@@ -200,7 +200,7 @@ class TestRound(object):
         english_codes = {}
         for ix, result in enumerate(self.test_results):
             (sentence, link) = self.json_results[ix+1]['english_code'][0][0]
-            english_codes[str(self.tests[ix].get_hash())] = (
+            english_codes[str(self.tests[ix].get_hash(refresh=True))] = (
                 [[f'<a href="{link}">{sentence}</a>']])
         return english_codes
 

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -125,16 +125,16 @@ class EmmaaModel(object):
 
     def extend_unique(self, estmts):
         """Extend model statements only if it is not already there."""
-        source_hashes = {est.stmt.get_hash(shallow=False)
+        source_hashes = {est.stmt.get_hash(shallow=False, refresh=True)
                          for est in self.stmts}
         for estmt in estmts:
-            if estmt.stmt.get_hash(shallow=False) not in source_hashes:
+            if estmt.stmt.get_hash(shallow=False, refresh=True) not in source_hashes:
                 self.stmts.append(estmt)
 
     def eliminate_copies(self):
         """Filter out exact copies of the same Statement."""
         logger.info('Starting with %d raw EmmaaStatements' % len(self.stmts))
-        self.stmts = list({estmt.stmt.get_hash(shallow=False): estmt
+        self.stmts = list({estmt.stmt.get_hash(shallow=False, refresh=True): estmt
                            for estmt in self.stmts}.values())
         logger.info(('Continuing with %d raw EmmaaStatements'
                      ' that are not exact copies') % len(self.stmts))

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -128,14 +128,15 @@ class EmmaaModel(object):
         source_hashes = {est.stmt.get_hash(shallow=False, refresh=True)
                          for est in self.stmts}
         for estmt in estmts:
-            if estmt.stmt.get_hash(shallow=False, refresh=True) not in source_hashes:
+            if estmt.stmt.get_hash(shallow=False, refresh=True) not in \
+                    source_hashes:
                 self.stmts.append(estmt)
 
     def eliminate_copies(self):
         """Filter out exact copies of the same Statement."""
         logger.info('Starting with %d raw EmmaaStatements' % len(self.stmts))
-        self.stmts = list({estmt.stmt.get_hash(shallow=False, refresh=True): estmt
-                           for estmt in self.stmts}.values())
+        self.stmts = list({estmt.stmt.get_hash(shallow=False, refresh=True):
+                           estmt for estmt in self.stmts}.values())
         logger.info(('Continuing with %d raw EmmaaStatements'
                      ' that are not exact copies') % len(self.stmts))
 


### PR DESCRIPTION
Recalculate hashes every time we need them to avoid False positive in new statements/tests (that would happen if we use old and new hashes together).