### PR TITLE
WM model

### DIFF
--- a/emmaa/aws_lambda_functions/analyze_changes_on_s3.py
+++ b/emmaa/aws_lambda_functions/analyze_changes_on_s3.py
@@ -70,7 +70,7 @@ def lambda_handler(event, context):
         if BRANCH is not None:
             core_command += f' --branch {BRANCH}'
         core_command += (' python scripts/run_model_tests_from_s3.py'
-                         f' --model {model_name} --test large_corpus_tests.pkl')
+                         f' --model {model_name}')
         print(core_command)
         cont_overrides = {
             'command': ['python', '-m', 'indra.util.aws', 'run_in_batch',

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -184,8 +184,10 @@ class EmmaaModel(object):
         """Run INDRA's assembly pipeline on the Statements."""
         self.eliminate_copies()
         stmts = self.get_indra_stmts()
+        model_type = self.assembly_config.get('type', 'bio')
         stmts = ac.filter_no_hypothesis(stmts)
-        stmts = ac.map_grounding(stmts)
+        if model_type == 'bio':
+            stmts = ac.map_grounding(stmts)
         # TODO: standardize names based on UN ontology in a way that matches
         #  the name entries of search terms
         if self.assembly_config.get('standardize_names'):
@@ -208,8 +210,7 @@ class EmmaaModel(object):
         stmts = ac.filter_human_only(stmts)
         stmts = ac.map_sequence(stmts)
         # TODO: configure preassembly to WM ontology and belief scorer
-        preassembly_type = self.assembly_config.get('type', 'bio')
-        if preassembly_type == 'wm':
+        if model_type == 'wm':
             hierarchies = get_wm_hierarchies()
             belief_scorer = get_eidos_scorer()
             stmts = ac.run_preassembly(

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -2,6 +2,7 @@ import json
 import time
 import pickle
 import logging
+import datetime
 from indra.databases import ndex_client
 import indra.tools.assemble_corpus as ac
 from indra.literature import pubmed_client, elsevier_client
@@ -133,12 +134,13 @@ class EmmaaModel(object):
 
     @staticmethod
     def search_elsevier(search_terms, date_limit):
-        # TODO: see if get_piis_for_date can be made more specific to only
-        #  search for the given date limit
+        start_date = (
+            datetime.datetime.utcnow() - datetime.timedelta(days=date_limit))
+        start_date = start_date.isoformat(timespec='seconds') + 'Z'
         terms_to_piis = {}
         for term in search_terms:
-            piis = elsevier_client.get_piis_for_date(term.search_term,
-                                                     date='2019')
+            piis = elsevier_client.get_piis_for_date(
+                term.search_term, loaded_after=start_date)
             logger.info(f'{len(piis)} PIIs found for {term.search_term}')
             terms_to_piis[term] = piis
         return terms_to_piis

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -181,6 +181,9 @@ class EmmaaModel(object):
         stmts = self.get_indra_stmts()
         stmts = ac.filter_no_hypothesis(stmts)
         stmts = ac.map_grounding(stmts)
+        # TODO: standardize names based on UN ontology in a way that matches
+        #  the name entries of search terms
+        # TODO: add configuration for scored grounding filter
         if self.assembly_config.get('filter_ungrounded'):
             stmts = ac.filter_grounded_only(stmts)
         relevance_policy = self.assembly_config.get('filter_relevance')
@@ -188,6 +191,7 @@ class EmmaaModel(object):
             stmts = self.filter_relevance(stmts, relevance_policy)
         stmts = ac.filter_human_only(stmts)
         stmts = ac.map_sequence(stmts)
+        # TODO: configure preassembly to WM ontology and belief scorer
         stmts = ac.run_preassembly(stmts, return_toplevel=False)
         belief_cutoff = self.assembly_config.get('belief_cutoff')
         if belief_cutoff is not None:
@@ -233,6 +237,7 @@ class EmmaaModel(object):
         """Update assembled model as CX on NDEx, updates existing network."""
         if not self.assembled_stmts:
             self.run_assembly()
+        # TODO: does CX assembler handle Influences?
         cxa = CxAssembler(self.assembled_stmts, network_name=self.name)
         cxa.make_model()
         cx_str = cxa.print_cx()

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -128,6 +128,21 @@ class EmmaaModel(object):
 
     @staticmethod
     def search_pubmed(search_terms, date_limit):
+        """Search PubMed for given search terms.
+
+        Parameters
+        ----------
+        search_terms : list[emmaa.priors.SearchTerm]
+            A list of SearchTerm objects to search PubMed for.
+        date_limit : int
+            The number of days to search back from today.
+        
+        Returns
+        -------
+        terms_to_pmids : dict
+            A dict representing given search terms as keys and PMIDs returned
+            by searches as values.
+        """
         terms_to_pmids = {}
         for term in search_terms:
             pmids = pubmed_client.get_ids(term.search_term, reldate=date_limit)
@@ -138,6 +153,21 @@ class EmmaaModel(object):
 
     @staticmethod
     def search_elsevier(search_terms, date_limit):
+        """Search Elsevier for given search terms.
+
+        Parameters
+        ----------
+        search_terms : list[emmaa.priors.SearchTerm]
+            A list of SearchTerm objects to search PubMed for.
+        date_limit : int
+            The number of days to search back from today.
+        
+        Returns
+        -------
+        terms_to_piis : dict
+            A dict representing given search terms as keys and PIIs returned
+            by searches as values.
+        """
         start_date = (
             datetime.datetime.utcnow() - datetime.timedelta(days=date_limit))
         start_date = start_date.isoformat(timespec='seconds') + 'Z'
@@ -241,6 +271,7 @@ class EmmaaModel(object):
         self.assembled_stmts = stmts
 
     def filter_associations(self, stmts):
+        """Filter a list of Statements to exclude Associations."""
         logger.info('Filtering Associations')
         stmts = [stmt for stmt in stmts if not isinstance(stmt, Association)]
         logger.info('%d statements after filter...' % len(stmts))

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -12,6 +12,7 @@ from indra.mechlinker import MechLinker
 from indra.preassembler.hierarchy_manager import get_wm_hierarchies
 from indra.preassembler import Preassembler
 from indra.belief.wm_scorer import get_eidos_scorer
+from indra.statements import Association
 from emmaa.priors import SearchTerm
 from emmaa.readers.aws_reader import read_pmid_search_terms
 from emmaa.readers.db_client_reader import read_db_pmid_search_terms
@@ -184,6 +185,7 @@ class EmmaaModel(object):
         """Run INDRA's assembly pipeline on the Statements."""
         self.eliminate_copies()
         stmts = self.get_indra_stmts()
+        stmts = self.filter_associations(stmts)
         stmts = ac.filter_no_hypothesis(stmts)
         if not self.assembly_config.get('skip_map_grounding'):
             stmts = ac.map_grounding(stmts)
@@ -237,6 +239,12 @@ class EmmaaModel(object):
             stmts = ml.statements
 
         self.assembled_stmts = stmts
+
+    def filter_associations(self, stmts):
+        logger.info('Filtering Associations')
+        stmts = [stmt for stmt in stmts if not isinstance(stmt, Association)]
+        logger.info('%d statements after filter...' % len(stmts))
+        return stmts
 
     def filter_relevance(self, stmts, policy=None):
         """Filter a list of Statements to ones matching a search term."""

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -297,7 +297,6 @@ class EmmaaModel(object):
         """Update assembled model as CX on NDEx, updates existing network."""
         if not self.assembled_stmts:
             self.run_assembly()
-        # TODO: does CX assembler handle Influences?
         cxa = CxAssembler(self.assembled_stmts, network_name=self.name)
         cxa.make_model()
         cx_str = cxa.print_cx()

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -398,8 +398,6 @@ def run_model_tests_from_s3(model_name, upload_mm=True,
     ----------
     model_name : str
         Name of EmmaaModel to load from S3.
-    test_name : str
-        Name of test file to load from S3.
     upload_mm : Optional[bool]
         Whether to upload a model manager instance to S3 as a pickle file.
         Default: True

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -385,7 +385,7 @@ def save_model_manager_to_s3(model_name, model_manager):
                       Key=f'results/{model_name}/latest_model_manager.pkl')
 
 
-def run_model_tests_from_s3(model_name, test_name, upload_mm=True,
+def run_model_tests_from_s3(model_name, upload_mm=True,
                             upload_results=True, upload_stats=True,
                             registered_queries=True, db=None):
     """Run a given set of tests on a given model, both loaded from S3.
@@ -424,7 +424,8 @@ def run_model_tests_from_s3(model_name, test_name, upload_mm=True,
         Instance of StatsGenerator containing statistics about model and test.
     """
     model = EmmaaModel.load_from_s3(model_name)
-    tests = load_tests_from_s3(test_name)
+    test_corpus = model.test_config.get('test_corpus', 'large_corpus_tests.pkl')
+    tests = load_tests_from_s3(test_corpus)
     mm = ModelManager(model)
     if upload_mm:
         save_model_manager_to_s3(model_name, mm)

--- a/emmaa/priors/world_modelers_prior.py
+++ b/emmaa/priors/world_modelers_prior.py
@@ -33,8 +33,8 @@ def make_config(search_terms, human_readable_name, description,
     config['search_terms'] = [st.to_json() for st in search_terms]
     config['test'] = {'statement_checking': {
                       'max_path_length': 5,
-                      'max_paths': 1}}
-    config['test_corpus'] = 'world_modelers_tests.pkl'
+                      'max_paths': 1},
+                      'test_corpus': 'world_modelers_tests.pkl'}
     config['assembly'] = {'skip_map_grounding': True,
                           'skip_filter_human': True,
                           'skip_map_sequence': True,

--- a/emmaa/priors/world_modelers_prior.py
+++ b/emmaa/priors/world_modelers_prior.py
@@ -3,6 +3,21 @@ from emmaa.model import save_config_to_s3
 
 
 def make_search_terms(terms, ontology_file):
+    """Make SearchTerm objects standardized to a given ontology from terms.
+
+    Parameters
+    ----------
+    terms : list[str]
+        A list of terms corresponding to suffixes of entries in the ontology.
+    ontology_file : str
+        A path to a file containing ontology.
+
+    Returns
+    -------
+    search_terms : set
+        A set of SearchTerm objects constructed from given terms and ontology
+        having standardized names.
+    """
     search_terms = set()
     with open(ontology_file, 'r') as f:
         lines = f.readlines()
@@ -26,6 +41,7 @@ def make_search_terms(terms, ontology_file):
 
 def make_config(search_terms, human_readable_name, description,
                 short_name, ndex_network=None, save_to_s3=False):
+    """Make a config file for WorldModelers models and optionally save to S3."""
     config = {}
     config['ndex'] = {'network': ndex_network if ndex_network else ''}
     config['human_readable_name'] = human_readable_name

--- a/emmaa/priors/world_modelers_prior.py
+++ b/emmaa/priors/world_modelers_prior.py
@@ -27,8 +27,7 @@ def make_search_terms(terms, ontology_file):
 def make_config(search_terms, human_readable_name, description,
                 short_name, ndex_network=None, save_to_s3=False):
     config = {}
-    if ndex_network:
-        config['ndex'] = {'network': ndex_network}
+    config['ndex'] = {'network': ndex_network if ndex_network else ''}
     config['human_readable_name'] = human_readable_name
     config['search_terms'] = [st.to_json() for st in search_terms]
     config['test'] = {'statement_checking': {

--- a/emmaa/priors/world_modelers_prior.py
+++ b/emmaa/priors/world_modelers_prior.py
@@ -1,0 +1,51 @@
+from emmaa.priors import SearchTerm
+from emmaa.model import save_config_to_s3
+
+
+def make_search_terms(terms, ontology_file):
+    search_terms = set()
+    with open(ontology_file, 'r') as f:
+        lines = f.readlines()
+    ontologies = []
+    for line in lines:
+        links = line.split('> <')
+        link = links[0]
+        ont_start = link.find('UN')
+        ont = link[ont_start:]
+        ontologies.append(ont)
+    for ont in ontologies:
+        for term in terms:
+            if ont.endswith(term):
+                search_term = term.replace('_', ' ')
+                name = search_term.capitalize()
+                st = SearchTerm(type='concept', name=name, db_refs={'UN': ont},
+                                search_term='\"%s\"' % search_term)
+                search_terms.add(st)
+    return search_terms
+
+
+def make_config(search_terms, human_readable_name, description,
+                short_name, ndex_network=None, save_to_s3=False):
+    config = {}
+    if ndex_network:
+        config['ndex'] = {'network': ndex_network}
+    config['human_readable_name'] = human_readable_name
+    config['search_terms'] = [st.to_json() for st in search_terms]
+    config['test'] = {'statement_checking': {
+                      'max_path_length': 5,
+                      'max_paths': 1}}
+    config['test_corpus'] = 'world_modelers_tests.pkl'
+    config['assembly'] = {'skip_map_grounding': True,
+                          'skip_filter_human': True,
+                          'skip_map_sequence': True,
+                          'belief_cutoff': 0.8,
+                          'filter_ungrounded': True,
+                          'score_threshold': 0.7,
+                          'filter_relevance': 'prior_one',
+                          'standardize_names': True,
+                          'preassembly_mode': 'wm'}
+    config['reading'] = {'literature_source': 'elsevier',
+                         'reader': 'elsevier_eidos'}
+    if save_to_s3:
+        save_config_to_s3(model_name, config)
+    return config

--- a/emmaa/readers/elsevier_eidos_reader.py
+++ b/emmaa/readers/elsevier_eidos_reader.py
@@ -25,14 +25,23 @@ def read_elsevier_eidos_search_terms(ids_to_terms):
 def read_piis(piis):
     texts = {}
     for pii in piis:
-        xml = elsevier_client.download_article(pii, id_type='pii')
-        if not xml:
-            logger.info('Could not get article content for %s' % pii)
+        try:
+            xml = elsevier_client.download_article(pii, id_type='pii')
+            if not xml:
+                logger.info('Could not get article content for %s' % pii)
+                continue
+        except Exception as e:
+            logger.info('Could not get article content for %s because of %s'
+                        % (pii, e))
             continue
-        txt = elsevier_client.extract_text(xml)
-        if not txt:
-            logger.info('Could not extract article text for %s' % pii)
-            continue
+        try:
+            txt = elsevier_client.extract_text(xml)
+            if not txt:
+                logger.info('Could not extract article text for %s' % pii)
+                continue
+        except Exception as e:
+            logger.info('Could not extract article text for %s because of %s'
+                        % (pii, e))
         texts[pii] = txt
     logger.info('Got text back for %d articles.' % len(texts))
     return texts

--- a/emmaa/readers/elsevier_eidos_reader.py
+++ b/emmaa/readers/elsevier_eidos_reader.py
@@ -9,36 +9,65 @@ from emmaa.statements import EmmaaStatement
 logger = logging.getLogger(__name__)
 
 
-def read_elsevier_eidos_search_terms(ids_to_terms):
-    piis = list(ids_to_terms.keys())
+def read_elsevier_eidos_search_terms(piis_to_terms):
+    """Return extracted EmmaaStatements given a dict of PIIS to SearchTerms.
+
+    Parameters
+    ----------
+    piis_to_terms : dict
+        A dict representing a set of PIIs pointing to search terms that
+        produced them.
+
+    Returns
+    -------
+    list[:py:class:`emmaa.model.EmmaaStatement`]
+        A list of EmmaaStatements extracted from the given PMIDs.
+    """
+    piis = list(piis_to_terms.keys())
     date = datetime.datetime.utcnow()
     texts = read_piis(piis)
     pii_stmts = process_texts(texts)
     estmts = []
     for pii, stmts in pii_stmts.items():
         for stmt in stmts:
-            es = EmmaaStatement(stmt, date, ids_to_terms[pii])
+            es = EmmaaStatement(stmt, date, piis_to_terms[pii])
             estmts.append(es)
     return estmts
 
 
 def read_piis(piis):
+    """Return texts extracted from articles with given PIIs.
+
+    Parameters
+    ----------
+    piis : list[str]
+        A list of PIIs to extract texts from.
+
+    Returns
+    -------
+    texts : dict
+        A dictionary representing PIIs as keys and extracted texts as values.
+    """
     texts = {}
     for pii in piis:
         try:
             xml = elsevier_client.download_article(pii, id_type='pii')
+            # If we got an empty xml or bad response
             if not xml:
                 logger.info('Could not get article content for %s' % pii)
                 continue
+        # Handle Connection and other errors
         except Exception as e:
             logger.info('Could not get article content for %s because of %s'
                         % (pii, e))
             continue
         try:
             txt = elsevier_client.extract_text(xml)
+            # If we could find relevant xml parts
             if not txt:
                 logger.info('Could not extract article text for %s' % pii)
                 continue
+        # Handle Connection and other errors
         except Exception as e:
             logger.info('Could not extract article text for %s because of %s'
                         % (pii, e))
@@ -48,6 +77,18 @@ def read_piis(piis):
 
 
 def process_texts(texts):
+    """Process article texts with Eidos and extract INDRA Statements.
+
+    Parameters
+    ----------
+    texts : dict
+        A dictionary mapping PIIs to texts to process.
+
+    Returns
+    -------
+    pii_stmts : dict
+        A dictionary mapping PIIs as keys and extracted INDRA statements.
+    """
     eidos_url = os.environ.get('EIDOS_URL')
     logger.info('Reading with Eidos URL: %s' % eidos_url)
     pii_stmts = {}
@@ -57,6 +98,7 @@ def process_texts(texts):
             ep = eidos.process_text(txt, webservice=eidos_url)
             if ep:
                 pii_stmts[pii] = ep.statements
+        # Handle Connection and other errors
         except Exception as e:
             logger.info('Could not read the text because of %s' % str(e))
             continue

--- a/emmaa/readers/elsevier_eidos_reader.py
+++ b/emmaa/readers/elsevier_eidos_reader.py
@@ -12,7 +12,8 @@ logger = logging.getLogger(__name__)
 def read_elsevier_eidos_search_terms(ids_to_terms):
     piis = list(ids_to_terms.keys())
     date = datetime.datetime.utcnow()
-    pii_stmts = read_piis(piis)
+    texts = read_piis(piis)
+    pii_stmts = process_texts(texts)
     estmts = []
     for pii, stmts in pii_stmts.items():
         for stmt in stmts:
@@ -22,17 +23,32 @@ def read_elsevier_eidos_search_terms(ids_to_terms):
 
 
 def read_piis(piis):
-    eidos_url = os.environ.get('EIDOS_URL')
-    logger.info('Reading with Eidos URL: %s' % eidos_url)
-    pii_stmts = {}
+    texts = {}
     for pii in piis:
-        pii_stmts[pii] = []
         xml = elsevier_client.download_article(pii, id_type='pii')
         if not xml:
             logger.info('Could not get article content for %s' % pii)
             continue
         txt = elsevier_client.extract_text(xml)
-        ep = eidos.process_text(txt, webservice=eidos_url)
-        if ep:
-            pii_stmts[pii] = ep.statements
+        if not txt:
+            logger.info('Could not extract article text for %s' % pii)
+            continue
+        texts[pii] = txt
+    logger.info('Got text back for %d articles.' % len(texts))
+    return texts
+
+
+def process_texts(texts):
+    eidos_url = os.environ.get('EIDOS_URL')
+    logger.info('Reading with Eidos URL: %s' % eidos_url)
+    pii_stmts = {}
+    for pii, txt in texts.items():
+        logger.info('Reading the article with %s pii.' % pii)
+        try:
+            ep = eidos.process_text(txt, webservice=eidos_url)
+            if ep:
+                pii_stmts[pii] = ep.statements
+        except Exception as e:
+            logger.info('Could not read the text because of %s' % str(e))
+            continue
     return pii_stmts

--- a/emmaa/readers/elsevier_eidos_reader.py
+++ b/emmaa/readers/elsevier_eidos_reader.py
@@ -1,0 +1,6 @@
+from indra.sources import eidos
+from indra.literature import elsevier_client
+
+
+def read_elsevier_eidos_search_terms(ids_to_terms):
+    return []

--- a/emmaa/readers/elsevier_eidos_reader.py
+++ b/emmaa/readers/elsevier_eidos_reader.py
@@ -1,6 +1,38 @@
+import os
+import logging
+import datetime
 from indra.sources import eidos
 from indra.literature import elsevier_client
+from emmaa.statements import EmmaaStatement
+
+
+logger = logging.getLogger(__name__)
 
 
 def read_elsevier_eidos_search_terms(ids_to_terms):
-    return []
+    piis = list(ids_to_terms.keys())
+    date = datetime.datetime.utcnow()
+    pii_stmts = read_piis(piis)
+    estmts = []
+    for pii, stmts in pii_stmts.items():
+        for stmt in stmts:
+            es = EmmaaStatement(stmt, date, ids_to_terms[pii])
+            estmts.append(es)
+    return estmts
+
+
+def read_piis(piis):
+    eidos_url = os.environ.get('EIDOS_URL')
+    logger.info('Reading with Eidos URL: %s' % eidos_url)
+    pii_stmts = {}
+    for pii in piis:
+        pii_stmts[pii] = []
+        xml = elsevier_client.download_article(pii, id_type='pii')
+        if not xml:
+            logger.info('Could not get article content for %s' % pii)
+            continue
+        txt = elsevier_client.extract_text(xml)
+        ep = eidos.process_text(txt, webservice=eidos_url)
+        if ep:
+            pii_stmts[pii] = ep.statements
+    return pii_stmts

--- a/emmaa/tests/test_model_tests.py
+++ b/emmaa/tests/test_model_tests.py
@@ -28,9 +28,8 @@ def test_load_tests_from_s3():
 def test_run_tests_from_s3():
     db = _get_test_db()
     (mm, sg) = run_model_tests_from_s3(
-        'test', 'simple_model_test.pkl', upload_mm=False,
-        upload_results=False, upload_stats=False, registered_queries=False,
-        db=db)
+        'test', upload_mm=False, upload_results=False, upload_stats=False,
+        registered_queries=False, db=db)
     assert isinstance(mm, ModelManager)
     assert isinstance(mm.model, EmmaaModel)
     assert isinstance(mm.model_checker, ModelChecker)

--- a/scripts/run_model_tests_from_s3.py
+++ b/scripts/run_model_tests_from_s3.py
@@ -7,11 +7,7 @@ if __name__ == '__main__':
             description='Script to run tests against models, both stored on '
                         'Amazon S3.')
     parser.add_argument('-m', '--model', help='Model name', required=True)
-    parser.add_argument('-t', '--test', required=True,
-                        help='Test file name (optional). If not specified, '
-                             'runs all available tests against the model.')
     args = parser.parse_args()
 
     run_model_tests_from_s3(
-        args.model, args.test, upload_results=True, upload_stats=True)
-
+        args.model, upload_results=True, upload_stats=True)

--- a/scripts/run_model_update.py
+++ b/scripts/run_model_update.py
@@ -2,7 +2,7 @@ from emmaa.model import EmmaaModel
 
 
 if __name__ == '__main__':
-    cancer_types = ('paad', 'skcm', 'aml', 'luad', 'prad',
+    cancer_types = ('paad', 'skcm', 'aml', 'luad', 'prad', 'food_insecurity',
                     'rasmachine', 'brca')
 
     for ctype in cancer_types:


### PR DESCRIPTION
This PR integrates a WorldModelers model into EMMAA framework. Main differences from biology models: Elsevier is used as a literature source, Eidos reader is used to process text, different assembly steps are used, choice of test corpus is parameterized. All these parameters are configured in the config file. Merging this PR also requires uploading new files to S3, updating lambda function (by running `emmaa.aws_lambda_functions.update_lambda.py`), merging PR #925 in INDRA, rebuilding INDRA and EMMAA dockers, and restarting EMMAA webservice.