### PR TITLE
Model update jobs

### DIFF
--- a/emmaa/aws_lambda_functions/update_pipeline.py
+++ b/emmaa/aws_lambda_functions/update_pipeline.py
@@ -48,7 +48,7 @@ def lambda_handler(event, context):
     lam = boto3.client('lambda')
     objs = s3.list_objects_v2(Bucket='emmaa', Prefix='models/', Delimiter='/')
     prefixes = objs['CommonPrefixes']
-    for prefix_dict in in prefixes:
+    for prefix_dict in prefixes:
         prefix = prefix_dict['Prefix']
         config_key = f'{prefix}config.json'
         obj = client.get_object(Bucket='emmaa', Key=config_key)
@@ -59,5 +59,5 @@ def lambda_handler(event, context):
             resp = lam.invoke(FunctionName='emmaa-model-update',
                               InvocationType='RequestResponse',
                               Payload=json.dumps(payload))
-            print(resp)
-    return resp
+            print(resp['Payload'].read())
+    return {'statusCode': 200, 'result': 'SUCCESS'}

--- a/emmaa/aws_lambda_functions/update_pipeline.py
+++ b/emmaa/aws_lambda_functions/update_pipeline.py
@@ -1,0 +1,63 @@
+"""The AWS Lambda emmaa-update-pipeline definition.
+
+This file contains the function that starts model update cycle. It must be
+placed on AWS Lambda, which can either be done manually (not recommended) or by
+running:
+
+$ python update_lambda.py update_pipeline.py emmaa-update-pipeline
+
+in this directory.
+"""
+
+import boto3
+import json
+
+
+def lambda_handler(event, context):
+    """Invoke individual model update functions.
+
+    This function iterates through all models contained on S3 bucket and calls
+    a different Lambda function to run model update for the models configured
+    to be updated daily. It is expected that models have 'run_model_update'
+    parameter in their config.json files.
+
+    This function is designed to be placed on AWS Lambda, taking the event and
+    context arguments that are passed. Note that this function must always have
+    the same parameters, even if any or all of them are unused, because we do
+    not have control over what Lambda sends as parameters. Parameters are
+    unused in this function.
+
+    Lambda is configured to automatically run this script every day.
+
+    See the top of the page for the Lambda update procedure.
+
+    Parameters
+    ----------
+    event : dict
+        A dictionary containing metadata regarding the triggering event.
+    context : object
+        This is an object containing potentially useful context provided by
+        Lambda. See the documentation cited above for details.
+
+    Returns
+    -------
+    ret : dict
+        A response returned by the latest call to emmaa-model-update function.
+    """
+    s3 = boto3.client('s3')
+    lam = boto3.client('lambda')
+    objs = s3.list_objects_v2(Bucket='emmaa', Prefix='models/', Delimiter='/')
+    prefixes = objs['CommonPrefixes']
+    for prefix_dict in in prefixes:
+        prefix = prefix_dict['Prefix']
+        config_key = f'{prefix}config.json'
+        obj = client.get_object(Bucket='emmaa', Key=config_key)
+        config = json.loads(obj['Body'].read().decode('utf8'))
+        if config.get('run_daily_update', False):
+            model_name = prefix[7:-1]
+            payload = {"model": model_name}
+            resp = lam.invoke(FunctionName='emmaa-model-update',
+                              InvocationType='RequestResponse',
+                              Payload=json.dumps(payload))
+            print(resp)
+    return resp

--- a/scripts/run_model_update.py
+++ b/scripts/run_model_update.py
@@ -1,12 +1,14 @@
+import argparse
 from emmaa.model import EmmaaModel
 
 
 if __name__ == '__main__':
-    cancer_types = ('paad', 'skcm', 'aml', 'luad', 'prad', 'food_insecurity',
-                    'rasmachine', 'brca')
+    parser = argparse.ArgumentParser(
+        description='Script to update a model saved on S3.')
+    parser.add_argument('-m', '--model', help='Model name', required=True)
+    args = parser.parse_args()
 
-    for ctype in cancer_types:
-        em = EmmaaModel.load_from_s3(ctype)
-        em.get_new_readings()
-        em.save_to_s3()
-        em.update_to_ndex()
+    em = EmmaaModel.load_from_s3(args.model)
+    em.get_new_readings()
+    em.save_to_s3()
+    em.update_to_ndex()


### PR DESCRIPTION
This PR changes the model update pipeline. Instead of having one Batch job to update all models, each model will have its own job and instead of hardcoding the list of models for daily update, this option is provided in config files for each model. The process involves 2 Lambda functions:
- `emmaa-update-pipeline` gets a list of all existing models from S3 and checks their config files for run_daily_update parameter. If it's set to 'True', the function calls a different Lambda function to update this model.
- `emmaa-model-update` gets a model name inside the 'event' parameter and starts a batch job with a script `run_model_update` which is now parameterized to take model name as a parameter and only update one model. It will be also possible to trigger this function directly for one model at a time by creating a test event in Lambda console. The test event should have a format {"model": model_name}.
After merging this PR we need to run the command to update the functions on AWS. Config files are already updated with the new parameter. I tested the simplified version of two functions interactions on AWS (that doesn't involve actual model update, but involves getting a list of models and calling a different function for each model) and it seems to work fine.