### PR TITLE
Move JS functionality to Python back end

### DIFF
--- a/emmaa/tests/test_api_functions.py
+++ b/emmaa/tests/test_api_functions.py
@@ -1,0 +1,17 @@
+import re
+
+from emmaa.util import RE_DATEFORMAT
+from emmaa_service.api import get_model_stats, model_last_updated
+
+MODEL = 'aml'
+
+
+def test_last_updated():
+    key_str = model_last_updated(MODEL)
+    assert key_str
+    assert re.search(RE_DATEFORMAT, key_str).group()
+
+
+def test_get_model_statistics():
+    model_json = get_model_stats(MODEL)
+    assert isinstance(model_json, dict)

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -1,4 +1,5 @@
 import os
+import re
 import boto3
 import logging
 from datetime import datetime
@@ -9,7 +10,17 @@ from indra.statements import get_all_descendants
 
 
 FORMAT = '%Y-%m-%d-%H-%M-%S'
+RE_DATEFORMAT = r'\d{4}\-\d{2}\-\d{2}\-\d{2}\-\d{2}\-\d{2}'
 logger = logging.getLogger(__name__)
+
+
+def strip_out_date(keystring):
+    """Strips out datestring of format FORMAT from a keystring"""
+    try:
+        return re.search(RE_DATEFORMAT, keystring).group()
+    except AttributeError:
+        logger.warning(f'Can\'t parse string {keystring} for date')
+        return None
 
 
 def get_date_from_str(date_str):

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -77,7 +77,8 @@ def find_latest_s3_file(bucket, prefix, extension=None):
 
 
 def find_second_latest_s3_file(bucket, prefix, extension=None):
-    """Return the key of the file with second latest date string on an S3 path"""
+    """Return the key of the file with second latest date string on an S3 path
+    """
     files = sort_s3_files_by_date(bucket, prefix, extension)
     try:
         latest = files[1]['Key']

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -9,7 +9,7 @@ from indra.statements import get_all_descendants, IncreaseAmount, \
     DecreaseAmount, Activation, Inhibition, AddModification, \
     RemoveModification, get_statement_by_name
 
-from emmaa.util import find_latest_s3_file, strip_out_date
+from emmaa.util import find_latest_s3_file, strip_out_date, get_s3_client
 from emmaa.model import load_config_from_s3
 from emmaa.answer_queries import QueryManager, load_model_manager_from_s3
 from emmaa.queries import PathProperty, get_agent_from_text, GroundingError
@@ -71,7 +71,7 @@ def get_model_stats(model, extension='.json'):
     model_data : json
         The json formatted data containing the statistics for the model
     """
-    s3 = boto3.client('s3')
+    s3 = get_s3_client()
 
     # Need jsons for model meta data and test statistics. File name examples:
     # stats/skcm/stats_2019-08-20-17-34-40.json

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -5,7 +5,6 @@ import logging
 from botocore.exceptions import ClientError
 from flask import abort, Flask, request, Response, render_template
 
-from indra.util.aws import get_s3_file_tree
 from indra.statements import get_all_descendants, IncreaseAmount, \
     DecreaseAmount, Activation, Inhibition, AddModification, \
     RemoveModification, get_statement_by_name

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -205,7 +205,7 @@ def process_query():
     # Extract info.
     expected_query_keys = {f'{pos}Selection'
                            for pos in ['subject', 'object', 'type']}
-    expceted_models = {mid for mid, _ in _get_model_meta_data()}
+    expected_models = {mid for mid, _ in _get_model_meta_data()}
     try:
         user_email = request.json['user']['email']
         subscribe = request.json['register']
@@ -214,8 +214,8 @@ def process_query():
             (f'Did not get expected query keys: got {set(query_json.keys())} '
              f'not {expected_query_keys}')
         models = set(request.json.get('models'))
-        assert models < expceted_models, \
-            f'Got unexpected models: {models - expceted_models}'
+        assert models < expected_models, \
+            f'Got unexpected models: {models - expected_models}'
     except (KeyError, AssertionError) as e:
         logger.exception(e)
         logger.error("Invalid query!")

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -159,12 +159,23 @@ def get_home():
 
 @app.route('/dashboard/<model>')
 def get_model_dashboard(model):
-    model_data = _get_models()
+    model_meta_data = _get_model_meta_data()
     mod_link_list = [('.' + t[0], t[1]) for t in link_list]
+    last_update = model_last_updated(model=model)
+    ndex_id = 'None available'
+    for mid, mmd in model_meta_data:
+        if mid == model:
+            ndex_id = mmd['ndex']['network']
+    if ndex_id == 'None available':
+        logger.warning(f'No ndex ID found for {model}')
+    model_stats = get_model_stats(model)
     return render_template('model_template.html',
                            model=model,
-                           model_data=model_data,
-                           link_list=mod_link_list)
+                           model_data=model_meta_data,
+                           model_stats_json=model_stats,
+                           link_list=mod_link_list,
+                           model_last_updated=last_update,
+                           ndexID=ndex_id)
 
 
 @app.route('/query')

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -59,6 +59,19 @@ def get_model_config(model):
 
 
 def get_model_stats(model, extension='.json'):
+    """Gets the latest statistics for the given model
+
+    Parameters
+    ----------
+    model : str
+        Model name to look for
+    extension : str
+
+    Returns
+    -------
+    model_data : json
+        The json formatted data containing the statistics for the model
+    """
     s3 = boto3.client('s3')
 
     # Need jsons for model meta data and test statistics. File name examples:
@@ -71,7 +84,7 @@ def get_model_stats(model, extension='.json'):
     return json.loads(model_data_object['Body'].read().decode('utf8'))
 
 
-def model_last_updated(model, extenstsion='.pkl'):
+def model_last_updated(model, extension='.pkl'):
     """Find the most recent pickle file of model and return its creation date
 
     Example file name:
@@ -80,7 +93,9 @@ def model_last_updated(model, extenstsion='.pkl'):
     Parameters
     ----------
     model : str
-        model name
+        Model name to look for
+    extension : str
+        The extension the model file needs to have. Default is '.pkl'
 
     Returns
     -------
@@ -91,17 +106,8 @@ def model_last_updated(model, extenstsion='.pkl'):
     return strip_out_date(find_latest_s3_file(
         bucket=EMMAA_BUCKET_NAME,
         prefix=prefix,
-        extension=extenstsion
+        extension=extension
     ))
-
-
-def _file_tree_list(prefix):
-    """This function assumes the prefix is specific enough that the top level
-    dict keys of the returned structure are the filenames of the sought after
-    files, i.e. that the top level keys are 'file.txt' as explained in the
-    docstring of 'get_s3_file_tree'."""
-    s3 = boto3.client('s3')
-    return sorted(get_s3_file_tree(s3=s3, bucket='emmaa', prefix=prefix))
 
 
 GLOBAL_PRELOAD = False

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -107,6 +107,10 @@ def model_last_updated(model):
 
 
 def _file_tree_list(prefix):
+    """This function assumes the prefix is specific enough that the top level
+    dict keys of the returned structure are the filenames of the sought after
+    files, i.e. that the top level keys are 'file.txt' as explained in the
+    docstring of 'get_s3_file_tree'."""
     s3 = boto3.client('s3')
     return sorted(get_s3_file_tree(s3=s3, bucket='emmaa', prefix=prefix))
 

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -35,7 +35,6 @@ function setModel(ddSelect, model) {
 }
 
 function selectModel(modelInfoTableBody, listTestResultsTableBody, testResultTableBody, ddSelect) {
-  // console.log('function selectModel(modelInfoTableBody, listTestResultsTableBody, testResultTableBody, ddSelect)')
   // Get selected option
   var model = '';
   for (child of ddSelect.children) {
@@ -61,7 +60,6 @@ function selectModel(modelInfoTableBody, listTestResultsTableBody, testResultTab
 }
 
 function loadModelMetaData(modelInfoTable, bucket, model, maxKeys, endsWith) {
-  console.log('function loadModelMetaData(modelInfoTable, bucket, model, maxKeys, prefix, endsWith)')
   // wrapper function that can be called selectModel or from pageload of models.html
 
   // Prefix needs to be precise enough that fewer than 1000 objects are returned
@@ -69,8 +67,6 @@ function loadModelMetaData(modelInfoTable, bucket, model, maxKeys, endsWith) {
   let today = new Date();
   let currentYearMonth = today.toISOString().slice(0,7);
   let s3Prefix = `models/${model}/model_${currentYearMonth}`;
-  console.log('s3Prefix: ');
-  console.log(s3Prefix);
   // mode, tableBody, testResultTableBody, s3Interface, bucket, model, prefix, maxKeys, endsWith
   // listObjectsInBucketUnAuthenticated('listModelInfo', modelInfoTable, null, new AWS.S3(), bucket, model, s3Prefix, maxKeys, endsWith)
 }
@@ -120,7 +116,6 @@ function generatePassFail(rowEl, col) {
 }
 
 function linkifyFromArray(tag, linkArray) {
-  // console.log('function linkifyFromArray(tag, linkArray)')
   if (Object.prototype.toString.call(linkArray) == '[object String]') {
     return linkifyFromString(tag, linkArray);
   }
@@ -133,7 +128,6 @@ function linkifyFromArray(tag, linkArray) {
 }
 
 function linkifyFromString(tag, htmlText) {
-  // console.log('function linkifyFromString(tag, htmlText)')
   tag.innerHTML = null;
   tag.innerHTML = htmlText;
   let anchors = tag.getElementsByTagName('a')
@@ -143,7 +137,6 @@ function linkifyFromString(tag, htmlText) {
       a.target = "_blank"
     }
   }
-  // console.log(tag)
   return tag;
 }
 
@@ -156,15 +149,12 @@ function addLineBreaks(rowEl, col) {
 }
 
 function populateModelsTable(metaTableBody, json) {
-  // console.log('function populateModelsTable(metaTableBody, json)')
-  // console.log(json)
   clearTable(metaTableBody);
 
   // Get english statements from evidence text
   // Link out to restAPI html page with all statements
   let maxOutput = Math.min(json.length, 25)
   for (let i = 0; i < maxOutput; i++) {
-    // console.log('Loop ' + i)
     let plainEnglish = json[i].stmt.evidence[0].text;
     let sourceHash = json[i].stmt.evidence[0].source_hash;
     link = document.createElement('a')
@@ -185,7 +175,6 @@ function populateModelsTable(metaTableBody, json) {
 }
 
 function getTestResultJsonToTable(testResultTableBody, jsonKey) {
-  // console.log('function getTestResultJsonToTable(testResultTableBody, jsonKey)');
   let jsonPromise = getPublicJson(EMMMAA_BUCKET, jsonKey);
   jsonPromise.then(function(json){
     populateTestResultTable(testResultTableBody, json);
@@ -194,10 +183,6 @@ function getTestResultJsonToTable(testResultTableBody, jsonKey) {
 
 // Populate test results json to modelTestResultBody
 function populateTestResultTable(tableBody, json) {
-  console.log('function populateTestResultTable(tableBody, json)');
-  // console.log(tableBody)
-  console.log('test results json');
-  console.log(json);
 
   // IDs
   let stmtTypDistId = '#modelTestResultBody'
@@ -221,8 +206,6 @@ function populateTestResultTable(tableBody, json) {
     stmt_freq_array.push(pair[1])
   }
   // See example at: https://c3js.org/samples/axes_x_tick_format.html
-  // console.log('stmt_type_array: ' + stmt_type_array)
-  // console.log('stmt_freq_array: ' + stmt_freq_array)
   stmtTypeDataParams = {
     // x: 'x',
     columns: [
@@ -282,7 +265,6 @@ function populateTestResultTable(tableBody, json) {
   let newStTable = document.getElementById('addedStmts')
   clearTable(newStTable)
   var new_stmts = json.model_delta.statements_delta.added
-  // console.log(new_stmts)
   for (stmt of new_stmts) {
     // Has columns: statements
     let rowEl = addToRow([stmt])
@@ -296,7 +278,6 @@ function populateTestResultTable(tableBody, json) {
   passedRatio = passedRatio.map(function(element) {
     return (element*100).toFixed(2);
   })
-  // console.log('ratio %' + passedRatio)
   passedRatio.unshift('Passed Ratio')
 
   lineDataParams = {
@@ -408,11 +389,7 @@ function modelsLastUpdated(keyMapArray, endsWith) {
   //    sort list descending, alphabetical, order
   //    get first (i.e. latest) item
   //    item.split('/')[2].split('_')[1].split('.')[0] gives datetime string
-  // console.log('Objects in bucket: ')
-  // console.log(keyMapArray)
   let modelsMapArray = getModels(null, keyMapArray, endsWith)
-  // console.log('Following objects mapped to models, filtered for object keys ending in ' + endsWith)
-  // console.log(modelsMapArray)
 
   let modelUpdateTagsArray = document.getElementsByClassName('modelUpdateInfo')
   for (tag of modelUpdateTagsArray) {
@@ -425,7 +402,6 @@ function modelsLastUpdated(keyMapArray, endsWith) {
 }
 
 function getModels(findModel, keyMapArray, endsWith) {
-  // console.log('function getModels(findModel, keyMapArray, endsWith)')
   var models = {}
   for (m of MODELS_ARRAY) {
     models[m] = []
@@ -450,8 +426,7 @@ function getModels(findModel, keyMapArray, endsWith) {
 }
 
 function listModelTests(tableBody, testResultTableBody, keyMapArray, model, endsWith) {
-  // console.log('function listModelTests(tableBody, testResultTableBody, keyMapArray, model, endsWith)')
-  
+
   // get array of filtered object keys
   let testJsonsArray = getArrayOfModelTests(model, keyMapArray, endsWith);
   let sortedTestJsonsArray = testJsonsArray.sort();
@@ -483,7 +458,6 @@ function listModelTests(tableBody, testResultTableBody, keyMapArray, model, ends
 }
 
 function getArrayOfModelTests(model, keyMapArray, endsWith) {
-  // console.log('function getArrayOfModelTests(model, keyMapArray, endsWith)');
   //  for each object ket
   //    if key.endswith(endsWith) & correct prefix
   //      save to list
@@ -494,7 +468,6 @@ function getArrayOfModelTests(model, keyMapArray, endsWith) {
     }
   }
   // if (tests.length > 0) {
-  //   console.log('Non-zero array of test jsons resolved')
   //   console.log(tests)
   // }
   return tests;
@@ -518,9 +491,6 @@ https://c3js.org/
 */
 
 function generateBar(chartDivId, dataParams, ticksLabels, chartTitle) {
-  // console.log('function generateBar(chartDivId, dataParams)')
-  // console.log(chartDivId)
-  // console.log(dataParams)
   var barChart = c3.generate({
     bindto: chartDivId,
     data: dataParams,
@@ -544,9 +514,6 @@ function generateBar(chartDivId, dataParams, ticksLabels, chartTitle) {
 }
 
 function generateLineArea(chartDivId, dataParams, chartTitle) {
-  // console.log('function generateLine(chartId, dataparams)')
-  // console.log(chartDivId)
-  // console.log(dataParams)
   var lineChart = c3.generate({
     bindto: chartDivId,
     data: dataParams,

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -55,7 +55,7 @@ function generatePassFail(rowEl, col) {
     rowEl.children[col].innerHTML = null;
     rowEl.children[col].appendChild(itag);
   } else {
-    console.log('pass/fail not in column' + col)
+    console.log(`pass/fail not in column ${col}`)
   }
   return rowEl;
 }
@@ -66,7 +66,7 @@ function linkifyFromArray(tag, linkArray) {
   }
   let linkText = '';
   for (link of linkArray) {
-    linkText = linkText + link + '<br>'; // Append link
+    linkText = `${linkText}${link}<br>`; // Append link
   }
 
   return linkifyFromString(tag, linkText.substr(0, linkText.length-4)); // Remove last <br>
@@ -272,7 +272,7 @@ function listModelInfo(modelInfoTableBody, lastUpdated, ndexID) {
   // Create link to ndex
   let link = document.createElement('a');
   link.textContent = ndexID;
-  link.href = 'http://www.ndexbio.org/#/network/' + ndexID;
+  link.href = `http://www.ndexbio.org/#/network/${ndexID}`;
   link.target = '_blank';
 
   let tableRow = addToRow(['Network on NDEX', '']);

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -55,7 +55,6 @@ function selectModel(modelInfoTableBody, listTestResultsTableBody, testResultTab
   let s3Interface = new AWS.S3();
 
   // List model info
-  loadModelMetaData(modelInfoTableBody, EMMMAA_BUCKET, model, maxKeys, '.pkl')
 
   // Pass tables, model and mode to function that lists the latest tests
   listObjectsInBucketUnAuthenticated('listModelTests', listTestResultsTableBody, testResultTableBody, s3Interface, EMMMAA_BUCKET, model, resultsPrefix, maxKeys, endsWith)
@@ -73,7 +72,7 @@ function loadModelMetaData(modelInfoTable, bucket, model, maxKeys, endsWith) {
   console.log('s3Prefix: ');
   console.log(s3Prefix);
   // mode, tableBody, testResultTableBody, s3Interface, bucket, model, prefix, maxKeys, endsWith
-  listObjectsInBucketUnAuthenticated('listModelInfo', modelInfoTable, null, new AWS.S3(), bucket, model, s3Prefix, maxKeys, endsWith)
+  // listObjectsInBucketUnAuthenticated('listModelInfo', modelInfoTable, null, new AWS.S3(), bucket, model, s3Prefix, maxKeys, endsWith)
 }
 
 function clearTables(arrayOfTableBodys) {
@@ -383,44 +382,24 @@ function populateTestResultTable(tableBody, json) {
   });
 }
 
-function listModelInfo(modelInfoTableBody, keyMapArray, bucket, model, endsWith) {
-  // console.log('listModelInfo(modelInfoTableBody, keyMapArray, bucket, model, endsWith)')
+function listModelInfo(modelInfoTableBody, lastUpdated, ndexID) {
   // 1. Last updated: get from listing models using already created function
   // 2. NDEX link-out: read from config
   // 3. Possibly listing nodes and edges info (Q: from where? A: From the json files that don't exist yet)
 
-  // Get an array of the models for model
-  modelsMapArray = getModels(model, keyMapArray, endsWith);
-  clearTable(modelInfoTableBody);
-  var lastUpdated = '';
-  if (modelsMapArray[model].sort()[modelsMapArray[model].length - 1].includes('_')) {
-    lastUpdated = modelsMapArray[model].sort()[modelsMapArray[model].length - 1].split('.')[0].split('_')[1]
-  } else {
-    lastUpdated = modelsMapArray[model].sort()[modelsMapArray[model].length - 1].split('.')[0]
-  }
+  // Add when model was last updated
   modelInfoTableBody.appendChild(addToRow(['Last updated', lastUpdated]))
+  // Create link to ndex
+  let link = document.createElement('a');
+  link.textContent = ndexID;
+  link.href = 'http://www.ndexbio.org/#/network/' + ndexID;
+  link.target = '_blank';
 
-  var configURL = 'https://s3.amazonaws.com/' + bucket + '/models/' + model + '/config.json';
-  // console.log('Loading model json from ' + configURL)
-  var configPromise = $.ajax({
-    url: configURL,
-    dataType: "json",
-    success: function(json) {
-      console.log('success! Here is your model json ndex id: ')
-      console.log(json.ndex.network)
-      let ndexID = json.ndex.network;
-      let link = document.createElement('a');
-      link.textContent = ndexID;
-      link.href = 'http://www.ndexbio.org/#/network/' + ndexID;
-      link.target = '_blank';
+  tableRow = addToRow(['Network on NDEX', '']);
+  tableRow.children[1].innerHTML = null;
+  tableRow.children[1].appendChild(link);
 
-      tableRow = addToRow(['Network on NDEX', '']);
-      tableRow.children[1].innerHTML = null;
-      tableRow.children[1].appendChild(link);
-
-      modelInfoTableBody.appendChild(tableRow);
-      }
-  });
+  modelInfoTableBody.appendChild(tableRow);
 }
 
 function modelsLastUpdated(keyMapArray, endsWith) {

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -17,7 +17,7 @@ var MODELS_ARRAY = ['aml',      // Acute myeloid leukemia
                     'rasmodel', // RasModel
                     'rasmachine', // Ras Machine
                     'skcm',     // Skin cutaneous melanoma
-                    'test']     // TestModel (only three nodes/two edges)
+                    'test'];    // TestModel (only three nodes/two edges)
 
 function grabPlainText (url, callback) {
   return $.ajax({url: url, dataType: "text"});
@@ -75,8 +75,8 @@ function loadModelMetaData(modelInfoTable, bucket, model, maxKeys, endsWith) {
   // listObjectsInBucketUnAuthenticated('listModelInfo', modelInfoTable, null, new AWS.S3(), bucket, model, s3Prefix, maxKeys, endsWith)
 }
 
-function clearTables(arrayOfTableBodys) {
-  for (tableBody of arrayOfTableBodys) {
+function clearTables(arrayOfTableBodies) {
+  for (tableBody of arrayOfTableBodies) {
     clearTable(tableBody)
   }
 }
@@ -194,10 +194,10 @@ function getTestResultJsonToTable(testResultTableBody, jsonKey) {
 
 // Populate test results json to modelTestResultBody
 function populateTestResultTable(tableBody, json) {
-  console.log('function populateTestResultTable(tableBody, json)')
+  console.log('function populateTestResultTable(tableBody, json)');
   // console.log(tableBody)
-  console.log('test results json')
-  console.log(json)
+  console.log('test results json');
+  console.log(json);
 
   // IDs
   let stmtTypDistId = '#modelTestResultBody'
@@ -453,7 +453,7 @@ function listModelTests(tableBody, testResultTableBody, keyMapArray, model, ends
   // console.log('function listModelTests(tableBody, testResultTableBody, keyMapArray, model, endsWith)')
   
   // get array of filtered object keys
-  let testJsonsArray = getArrayOfModelTests(model, keyMapArray, endsWith)
+  let testJsonsArray = getArrayOfModelTests(model, keyMapArray, endsWith);
   let sortedTestJsonsArray = testJsonsArray.sort();
 
   getTestResultJsonToTable(testResultTableBody, sortedTestJsonsArray[sortedTestJsonsArray.length-1]);

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -5,12 +5,11 @@ the client side work of exposing cancer network models for the end users
 
 */
 
-// CONSTANTS AND IDs
 function setModel(ddSelect, model) {
   // Sets the selected option
   // let ddSelect = document.getElementById('modelSelectDD');
   for (child of ddSelect.children) {
-    if (model == child.value) {
+    if (model === child.value) {
       child.selected = 'selected';
       break;
     }
@@ -18,7 +17,7 @@ function setModel(ddSelect, model) {
 }
 
 function clearTables(arrayOfTableBodies) {
-  for (tableBody of arrayOfTableBodies) {
+  for (let tableBody of arrayOfTableBodies) {
     clearTable(tableBody)
   }
 }
@@ -31,8 +30,8 @@ function clearTable(tableBody) {
 function addToRow(col_values) {
   let tableRow = document.createElement('tr');
 
-  for (col of col_values) {
-    column = document.createElement('td');
+  for (let col of col_values) {
+    let column = document.createElement('td');
     column.textContent = col;
     tableRow.appendChild(column);
   }
@@ -47,11 +46,11 @@ function generatePassFail(rowEl, col) {
   // Fail: <i class="fas fa-times"></i>
   let string = rowEl.children[col].textContent;
   let itag = document.createElement('i');
-  if (string.toLowerCase() == 'pass') {
+  if (string.toLowerCase() === 'pass') {
     itag.className = 'fas fa-check';
     rowEl.children[col].innerHTML = null;
     rowEl.children[col].appendChild(itag);
-  } else if (string.toLowerCase() == 'fail') {
+  } else if (string.toLowerCase() === 'fail') {
     itag.className = 'fas fa-times';
     rowEl.children[col].innerHTML = null;
     rowEl.children[col].appendChild(itag);
@@ -62,10 +61,10 @@ function generatePassFail(rowEl, col) {
 }
 
 function linkifyFromArray(tag, linkArray) {
-  if (Object.prototype.toString.call(linkArray) == '[object String]') {
+  if (Object.prototype.toString.call(linkArray) === '[object String]') {
     return linkifyFromString(tag, linkArray);
   }
-  var linkText = '';
+  let linkText = '';
   for (link of linkArray) {
     linkText = linkText + link + '<br>'; // Append link
   }
@@ -76,10 +75,10 @@ function linkifyFromArray(tag, linkArray) {
 function linkifyFromString(tag, htmlText) {
   tag.innerHTML = null;
   tag.innerHTML = htmlText;
-  let anchors = tag.getElementsByTagName('a')
+  let anchors = tag.getElementsByTagName('a');
   if (anchors.length > 0) {
     for (let a of anchors) {
-      a.className = 'stmt-dblink'
+      a.className = 'stmt-dblink';
       a.target = "_blank"
     }
   }
@@ -90,24 +89,24 @@ function linkifyFromString(tag, htmlText) {
 function populateTestResultTable(tableBody, json) {
 
   // IDs
-  let stmtTypDistId = '#modelTestResultBody'
-  let pasRatId = '#passedRatio'
-  let pasAppId = '#passedApplied'
-  let agDist = '#agentDistr'
-  let stmtTime = '#stmtsOverTime'
+  let stmtTypDistId = '#modelTestResultBody';
+  let pasRatId = '#passedRatio';
+  let pasAppId = '#passedApplied';
+  let agDist = '#agentDistr';
+  let stmtTime = '#stmtsOverTime';
 
   // Dates
-  dates = json.changes_over_time.dates
-  dates.unshift('x')
+  dates = json.changes_over_time.dates;
+  dates.unshift('x');
 
   //  Model Tab
 
   // Stmt type distribution bar graph 
-  var stmt_type_array = []
-  var stmt_freq_array = ['count']
+  let stmt_type_array = [];
+  let stmt_freq_array = ['count'];
 
-  for (pair of json.model_summary.stmts_type_distr) {
-    stmt_type_array.push(pair[0])
+  for (let pair of json.model_summary.stmts_type_distr) {
+    stmt_type_array.push(pair[0]);
     stmt_freq_array.push(pair[1])
   }
   // See example at: https://c3js.org/samples/axes_x_tick_format.html
@@ -117,73 +116,73 @@ function populateTestResultTable(tableBody, json) {
       stmt_freq_array
     ],
     type: 'bar'
-  }
+  };
 
-  var stmtTypeChart = generateBar(stmtTypDistId, stmtTypeDataParams, stmt_type_array, '')
+  let stmtTypeChart = generateBar(stmtTypDistId, stmtTypeDataParams, stmt_type_array, '');
 
   // Top agents bar graph
-  var top_agents_array = []
-  var agent_freq_array = ['count']
+  let top_agents_array = [];
+  let agent_freq_array = ['count'];
 
-  for (pair of json.model_summary.agent_distr.slice(0, 10)) {
-    top_agents_array.push(pair[0])
+  for (let pair of json.model_summary.agent_distr.slice(0, 10)) {
+    top_agents_array.push(pair[0]);
     agent_freq_array.push(pair[1])
   }
 
-  agentDataParams = {
+  let agentDataParams = {
     columns: [
       agent_freq_array
     ],
     type: 'bar'
-  }
+  };
 
-  var agentChart = generateBar(agDist, agentDataParams, top_agents_array, '')
+  let agentChart = generateBar(agDist, agentDataParams, top_agents_array, '');
 
   // Statements by Evidence Table
-  let stEvTable = document.getElementById('stmtEvidence')
-  clearTable(stEvTable)
-  var english_stmts = json.model_summary.english_stmts
-  var stmtByEv = json.model_summary.stmts_by_evidence
+  let stEvTable = document.getElementById('stmtEvidence');
+  clearTable(stEvTable);
+  let english_stmts = json.model_summary.english_stmts;
+  let stmtByEv = json.model_summary.stmts_by_evidence;
 
-  for (pair of stmtByEv.slice(0,10)) {
-    let rowEl = addToRow(['', pair[1]])
+  for (let pair of stmtByEv.slice(0,10)) {
+    let rowEl = addToRow(['', pair[1]]);
     rowEl.children[0] = linkifyFromString(rowEl.children[0], english_stmts[pair[0]]);
     stEvTable.appendChild(rowEl)
   }
 
   // Statements over Time line graph
-  stmtsOverTime = json.changes_over_time.number_of_statements
-  stmtsOverTime.unshift('Statements')
+  let stmtsOverTime = json.changes_over_time.number_of_statements;
+  stmtsOverTime.unshift('Statements');
 
-  stmtsCountDataParams = {
+  let stmtsCountDataParams = {
     x: 'x',
     xFormat: '%Y-%m-%d-%H-%M-%S',
     columns: [
       dates,
       stmtsOverTime
     ]
-  }
+  };
 
-  var stmtsCountChart = generateLineArea(stmtTime, stmtsCountDataParams, '')
+  let stmtsCountChart = generateLineArea(stmtTime, stmtsCountDataParams, '');
 
   // Model Delta - New statements
-  let newStTable = document.getElementById('addedStmts')
-  clearTable(newStTable)
-  var new_stmts = json.model_delta.statements_delta.added
-  for (stmt of new_stmts) {
+  let newStTable = document.getElementById('addedStmts');
+  clearTable(newStTable);
+  let new_stmts = json.model_delta.statements_delta.added;
+  for (let stmt of new_stmts) {
     // Has columns: statements
-    let rowEl = addToRow([stmt])
-    rowEl.children[0] = linkifyFromString(rowEl.children[0], stmt)
+    let rowEl = addToRow([stmt]);
+    rowEl.children[0] = linkifyFromString(rowEl.children[0], stmt);
     newStTable.appendChild(rowEl)
   }
   // Tests Tab
 
   // Passed ratio line graph
-  passedRatio = json.changes_over_time.passed_ratio
+  let passedRatio = json.changes_over_time.passed_ratio;
   passedRatio = passedRatio.map(function(element) {
     return (element*100).toFixed(2);
-  })
-  passedRatio.unshift('Passed Ratio')
+  });
+  passedRatio.unshift('Passed Ratio');
 
   lineDataParams = {
     x: 'x',
@@ -192,17 +191,17 @@ function populateTestResultTable(tableBody, json) {
       dates,
       passedRatio
     ]
-  }
+  };
 
-  var lineChart = generateLineArea(pasRatId, lineDataParams, '');
+  let lineChart = generateLineArea(pasRatId, lineDataParams, '');
 
   // Applied/passed area graph
-  appliedTests = json.changes_over_time.number_applied_tests
-  appliedTests.unshift('Applied Tests')
-  passedTests = json.changes_over_time.number_passed_tests
-  passedTests.unshift('Passed Tests')
+  let appliedTests = json.changes_over_time.number_applied_tests;
+  appliedTests.unshift('Applied Tests');
+  let passedTests = json.changes_over_time.number_passed_tests;
+  passedTests.unshift('Passed Tests');
 
-  passedAppliedParams = {
+  let passedAppliedParams = {
     x: 'x',
     xFormat: '%Y-%m-%d-%H-%M-%S',
     columns: [
@@ -211,49 +210,48 @@ function populateTestResultTable(tableBody, json) {
       appliedTests
     ],
     type: 'area'
-  }
+  };
 
-  var areaChart = generateLineArea(pasAppId, passedAppliedParams, '');
+  let areaChart = generateLineArea(pasAppId, passedAppliedParams, '');
 
   // Tests Delta - New Applied Tests
-  let newAppliedTable = document.getElementById('newAppliedTests')
-  clearTable(newAppliedTable)
-  var newAppTests = json.tests_delta.applied_tests_delta.added
+  let newAppliedTable = document.getElementById('newAppliedTests');
+  clearTable(newAppliedTable);
+  let newAppTests = json.tests_delta.applied_tests_delta.added;
 
-  for (pair of newAppTests) {
+  for (let pair of newAppTests) {
     // Has columns: Test; Status;
-    let rowEl = addToRow(pair)
-    rowEl = generatePassFail(rowEl, 1)
-    rowEl.children[0] = linkifyFromString(rowEl.children[0], pair[0])
+    let rowEl = addToRow(pair);
+    rowEl = generatePassFail(rowEl, 1);
+    rowEl.children[0] = linkifyFromString(rowEl.children[0], pair[0]);
     newAppliedTable.appendChild(rowEl)
   }
   // Tests Delta - New Passed Tests
-  let newPassedTable = document.getElementById('newPassedTests')
-  clearTable(newPassedTable)
-  var newPasTests = json.tests_delta.pass_fail_delta.added
-  var newPaths = json.tests_delta.new_paths.added
+  let newPassedTable = document.getElementById('newPassedTests');
+  clearTable(newPassedTable);
+  let newPasTests = json.tests_delta.pass_fail_delta.added;
+  let newPaths = json.tests_delta.new_paths.added;
 
-  for (i = 0; i < newPasTests.length; i++) {
+  for (let i = 0; i < newPasTests.length; i++) {
     // Has columns: test; Path Found
-    // let rowEl = addToRow([newPasTests[i], newPaths[i]])
-    let rowEl = addToRow(['', ''])
-    rowEl.children[0] = linkifyFromString(rowEl.children[0], newPasTests[i])
-    rowEl.children[1] = linkifyFromArray(rowEl.children[1], newPaths[i][0])
+    let rowEl = addToRow(['', '']);
+    rowEl.children[0] = linkifyFromString(rowEl.children[0], newPasTests[i]);
+    rowEl.children[1] = linkifyFromArray(rowEl.children[1], newPaths[i][0]);
     newPassedTable.appendChild(rowEl)
   }
 
   // All Tests Results
-  let allTestsTable = document.getElementById('allTestResults')
+  let allTestsTable = document.getElementById('allTestResults');
   clearTable(allTestsTable)
-  var testResults = json.test_round_summary.tests_by_hash
-  var resultValues = Object.values(testResults)
+  let testResults = json.test_round_summary.tests_by_hash;
+  let resultValues = Object.values(testResults);
   resultValues.sort(function(a,b){return (a[1] < b[1]) ? 1 : (a[1] > b[1]) ? -1 : 0;});
 
   for (val of resultValues) {
     // Has columns: test; Status; Path Found;
-    let rowEl = addToRow(val)
-    rowEl.children[0] = linkifyFromString(rowEl.children[0], val[0])
-    rowEl.children[2] = linkifyFromArray(rowEl.children[2], val[2][0])
+    let rowEl = addToRow(val);
+    rowEl.children[0] = linkifyFromString(rowEl.children[0], val[0]);
+    rowEl.children[2] = linkifyFromArray(rowEl.children[2], val[2][0]);
     allTestsTable.appendChild(generatePassFail(rowEl, 1))
   }
 
@@ -270,14 +268,14 @@ function populateTestResultTable(tableBody, json) {
 
 function listModelInfo(modelInfoTableBody, lastUpdated, ndexID) {
   // Add when model was last updated
-  modelInfoTableBody.appendChild(addToRow(['Last updated', lastUpdated]))
+  modelInfoTableBody.appendChild(addToRow(['Last updated', lastUpdated]));
   // Create link to ndex
   let link = document.createElement('a');
   link.textContent = ndexID;
   link.href = 'http://www.ndexbio.org/#/network/' + ndexID;
   link.target = '_blank';
 
-  tableRow = addToRow(['Network on NDEX', '']);
+  let tableRow = addToRow(['Network on NDEX', '']);
   tableRow.children[1].innerHTML = null;
   tableRow.children[1].appendChild(link);
 
@@ -291,7 +289,7 @@ https://c3js.org/
 */
 
 function generateBar(chartDivId, dataParams, ticksLabels, chartTitle) {
-  var barChart = c3.generate({
+  return c3.generate({
     bindto: chartDivId,
     data: dataParams,
     bar:  {
@@ -310,11 +308,10 @@ function generateBar(chartDivId, dataParams, ticksLabels, chartTitle) {
       text: chartTitle
     }
   });
-  return barChart;
 }
 
 function generateLineArea(chartDivId, dataParams, chartTitle) {
-  var lineChart = c3.generate({
+  return c3.generate({
     bindto: chartDivId,
     data: dataParams,
     axis: {
@@ -333,5 +330,4 @@ function generateLineArea(chartDivId, dataParams, chartTitle) {
       enabled: true
     }
   });
-  return lineChart;
 }

--- a/emmaa_service/static/queryFunctions.js
+++ b/emmaa_service/static/queryFunctions.js
@@ -113,8 +113,8 @@ function submitQuery(queryDict, test) {
           queryNotify('Query failed: Internal Server Error (500)');
           break;
         default:
-          console.log('Unhandled server response: ' + xhr.status);
-          queryNotify('Query failed: ' + xhr.status)
+          console.log(`Unhandled server response: ${xhr.status}`);
+          queryNotify(`Query failed: ${xhr.status}`)
       }
     }
   });

--- a/emmaa_service/static/queryFunctions.js
+++ b/emmaa_service/static/queryFunctions.js
@@ -10,14 +10,15 @@ function postQuery(queryContainer) {
   console.log('function postQuery(queryContainer)')
 
   // Get user info
+  // ToDo: Tie up with login capabilities
   userInfo = {
     name: 'joshua',
     slack_id: '123456abcdef',
     email: 'joshua@emmaa.com'
-  }
+  };
 
   // Collect model query
-  let querySel = collectQuery(queryContainer)
+  let querySel = collectQuery(queryContainer);
   if (querySel.length < 2) {
     queryNotify('Did not send query');
     return;

--- a/emmaa_service/static/queryFunctions.js
+++ b/emmaa_service/static/queryFunctions.js
@@ -1,9 +1,9 @@
 // EMMAA rest API
-var EMMAA_API = './query/submit'
-var QUERY_STATUS_ID = 'query-status'
+let EMMAA_API = './query/submit';
+let QUERY_STATUS_ID = 'query-status';
 
 function postQuery(queryContainer) {
-  console.log('function postQuery(queryContainer)')
+  console.log('function postQuery(queryContainer)');
 
   // Get user info
   // ToDo: Tie up with login capabilities
@@ -21,42 +21,42 @@ function postQuery(queryContainer) {
   }
 
   // Check if user wants to register query
-  let reg = document.getElementById('register-query').checked
+  let reg = document.getElementById('register-query').checked;
 
   let ajax_response = submitQuery({
     user: userInfo,
     models: querySel[0],
     query: querySel[1],
     register: reg
-  }, null)
+  }, null);
 
   console.log("ajax response from submission: ");
   console.log(ajax_response);
 }
 
 function collectQuery(queryContainer) {
-  console.log('function collectQuery(queryContainer)')
-  let dropdownSelections = queryContainer.getElementsByClassName('custom-select')
+  console.log('function collectQuery(queryContainer)');
+  let dropdownSelections = queryContainer.getElementsByClassName('custom-select');
 
-  result = []
-  query = {};
-  models = []
+  let result = [];
+  let query = {};
+  let models = [];
 
   // Get checked models
   for (op of document.getElementById('model-select').children) {
-    console.log(op.value)
+    console.log(op.value);
     models.push(op.value)
   }
-  if (models.length == 0) {
+  if (models.length === 0) {
     // Handle no boxes ticked
-    alert('Must select at least one model!')
+    alert('Must select at least one model!');
     return;
-  };
+  }
   result.push(models);
 
   //  Collect dropdown selections
-  for (selection of dropdownSelections) {
-    selId = selection.id;
+  for (let selection of dropdownSelections) {
+    let selId = selection.id;
     // Use the IDs of the select tags as keys in the query json
     query[selId] = selection.options[selection.selectedIndex].value;
   }
@@ -70,65 +70,64 @@ function collectQuery(queryContainer) {
 }
 
 function submitQuery(queryDict, test) {
-  console.log('function submitQuery(queryDict)')
-  console.log('Submitting data to query DB')
-  console.log(queryDict)
+  console.log('function submitQuery(queryDict)');
+  console.log('Submitting data to query DB');
+  console.log(queryDict);
 
   if (test) queryDict['test'] = true;
 
   // submit POST to emmaa user db
   queryNotify('Waiting for server response');
   $('#query-status-gif').show();
-  let response = $.ajax({
+  return $.ajax({
     url: EMMAA_API,
     type: 'POST',
     dataType: 'json',
     contentType: 'application/json',
     data: JSON.stringify(queryDict),
     complete: function(xhr, statusText) {
-      console.log('responseJSON')
-      console.log(xhr.responseJSON)
-      console.log(statusText)
+      console.log('responseJSON');
+      console.log(xhr.responseJSON);
+      console.log(statusText);
       $('#query-status-gif').hide();
       switch (xhr.status) {
         case 200:
-          console.log('200 response')
-          queryNotify('Query resolved')
-          populateQueryResults(xhr.responseJSON)
+          console.log('200 response');
+          queryNotify('Query resolved');
+          populateQueryResults(xhr.responseJSON);
           break;
         case 400:
-          console.log('400 response')
-          queryNotify('Query failed: Bad Request (400)')
+          console.log('400 response');
+          queryNotify('Query failed: Bad Request (400)');
           break;
         case 401:
-          console.log('401 response')
-          queryNotify('Query failed: Unauthorized (401). Try to sign in again.')
+          console.log('401 response');
+          queryNotify('Query failed: Unauthorized (401). Try to sign in again.');
           break;
         case 404:
-          console.log('404 response')
-          queryNotify('Query failed: Not Found (404)')
+          console.log('404 response');
+          queryNotify('Query failed: Not Found (404)');
           break;
         case 500:
-          console.log('500 response')
-          queryNotify('Query failed: Internal Server Error (500)')
+          console.log('500 response');
+          queryNotify('Query failed: Internal Server Error (500)');
           break;
         default:
-          console.log('Unhandled server response: ' + xhr.status)
+          console.log('Unhandled server response: ' + xhr.status);
           queryNotify('Query failed: ' + xhr.status)
       }
     }
-  })
-  return response;
+  });
 }
 
 function populateQueryResults(json) {
-  console.log('function populateQueryResults(json)')
-  console.log(json)
+  console.log('function populateQueryResults(json)');
+  console.log(json);
   let qrTable = document.getElementById('queryResults');
-  clearTable(qrTable)
-  for (res of json.result) {
+  clearTable(qrTable);
+  for (let res of json.result) {
     let rowEl = addToRow([res['model'], res['mc_type'], res['response']])
-    rowEl.children[1] = linkifyFromString(rowEl.children[2], rowEl.children[2].textContent)
+    rowEl.children[1] = linkifyFromString(rowEl.children[2], rowEl.children[2].textContent);
     qrTable.appendChild(rowEl);
   }
 }

--- a/emmaa_service/static/queryFunctions.js
+++ b/emmaa_service/static/queryFunctions.js
@@ -2,10 +2,6 @@
 var EMMAA_API = './query/submit'
 var QUERY_STATUS_ID = 'query-status'
 
-$(document).ready(function() {
-  fillNamespaceOptions()
-})
-
 function postQuery(queryContainer) {
   console.log('function postQuery(queryContainer)')
 
@@ -134,19 +130,6 @@ function populateQueryResults(json) {
     let rowEl = addToRow([res['model'], res['mc_type'], res['response']])
     rowEl.children[1] = linkifyFromString(rowEl.children[2], rowEl.children[2].textContent)
     qrTable.appendChild(rowEl);
-  }
-}
-
-function fillNamespaceOptions() {
-  for (nsDD of document.getElementsByClassName('namespace-dropdown')) {
-    console.log(nsDD)
-    for (n_v of NAMESPACE_OPTIONS) {
-      let optionTag = document.createElement('option');
-      optionTag.value = n_v[1];
-      optionTag.textContent = n_v[0];
-      console.log(optionTag.textContent)
-      nsDD.appendChild(optionTag);
-    }
   }
 }
 

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -37,12 +37,6 @@
   <script src="https://s3.amazonaws.com/emmaa-test/awsServices.js"></script>
   <script src="{{ url_for('static', filename='emmaaFunctions.js') }}"></script>
 
-  <script>
-    $(document).ready(function() {
-      let modelSelect = new Choices('#model-select');
-    })
-  </script>
-
   {% block additional_scripts %}
   {% endblock %}
 

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -23,9 +23,6 @@
   <!-- bootstrap 4.1.3 -->
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
 
-  <!-- AWS SDK -->
-  <script src="https://sdk.amazonaws.com/js/aws-sdk-2.283.1.min.js"></script>
-
   <!-- D3 -->
   <script src="https://d3js.org/d3.v5.min.js"></script>
 
@@ -33,8 +30,6 @@
   <script src="{{ url_for('static', filename='c3.min.js') }}"></script>
 
   <!-- Script Files -->
-  <!-- <script src="https://indralab.github.io/aws/js/awsServices.js"></script> -->
-  <script src="https://s3.amazonaws.com/emmaa-test/awsServices.js"></script>
   <script src="{{ url_for('static', filename='emmaaFunctions.js') }}"></script>
 
   {% block additional_scripts %}

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -2,28 +2,21 @@
 
 {% block additional_scripts %}
 <script>
-  var model = '{{ model }}'
+  let model = '{{ model }}';
+  let ndexID = '{{ ndexID }}';
 
-  // Check if user signed in immediately after page load
   $(document).ready(function(){
-    clearTables(document.getElementsByClassName('table-body'))
-    console.log('document ready')
-    var return_url = window.location.href;
-    let dict_split = getDictFromUrl(return_url);
-
-    // Check sign-in
-    // checkSignIn()
-
-    var ddSelectTag = document.getElementById('modelSelectDD');
+    clearTables(document.getElementsByClassName('table-body'));
+    console.log('document ready');
+    let ddSelectTag = document.getElementById('modelSelectDD');
     setModel(ddSelectTag, model);
 
-    var infoTableBody = document.getElementById('modelInfoTableBody');
-    var listTestResultsTableBody = document.getElementById('modelTestsTableBody');
-    var testResultsTableBody = document.getElementById('modelTestResultBody');
+    let infoTableBody = document.getElementById('modelInfoTableBody');
+    let testResultsTableBody = document.getElementById('modelTestResultBody');
 
-    // args: modelInfoTableBody, listTestResultsTableBody, testResultTableBody, ddSelect
-    selectModel(infoTableBody, listTestResultsTableBody, testResultsTableBody, ddSelectTag)
-    });
+    listModelInfo(infoTableBody, '{{ model_last_updated }}', '{{ ndexID }}');
+    populateTestResultTable(testResultsTableBody, {{ model_stats_json|safe }});
+  });
 
   function modelRedirect(ddSelect) {
 

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -30,9 +30,9 @@
     }
 
     // redirect url:
-    let redirect = window.location.href.replace(model, newModel)
-    console.log(redirect)
-    window.location.replace(redirect)
+    let redirect = window.location.href.replace(model, newModel);
+    console.log(redirect);
+    window.location.replace(redirect);
   }
 </script>
 <style>

--- a/emmaa_service/templates/query_template.html
+++ b/emmaa_service/templates/query_template.html
@@ -1,14 +1,15 @@
 {% extends "emmaa_page_template.html" %}
 
 {% block additional_scripts %}
-<script src="{{ url_for('static', filename='queryFunctions.js') }}"></script>
+  <script src="{{ url_for('static', filename='queryFunctions.js') }}"></script>
+  <script>
+    $(document).ready(function() {
+      let modelSelect = new Choices('#model-select');
+    })
+  </script>
 {% endblock %}
 
 {% block body %}
-<script type="text/javascript">
-  setEnv('emmaa') // Set environment for AWS functionalities
-  // checkSignIn() // Check sign-in
-</script>
 <div class="container" id="query-container">
 
   <div class="card">


### PR DESCRIPTION
This PR moves a lot of the JavaScript functionality to the Python back end, thanks to jinja2 templates.

There is still a need for JavaScript to carry out certain functions, namely:

- Taking care of POSTing to endpoint
- Displaying graphics of the data

The JavaScript code handling this remains in the affected files.