### PR TITLE
Sleep between Elsevier requests

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -186,6 +186,7 @@ class EmmaaModel(object):
                 term.search_term, loaded_after=start_date)[:5]
             logger.info(f'{len(piis)} PIIs found for {term.search_term}')
             terms_to_piis[term] = piis
+            time.sleep(1)
         return terms_to_piis
 
     def get_new_readings(self, date_limit=10):


### PR DESCRIPTION
This PR adds a waiting period between calls to Elsevier API to avoid getting status code 429.