### PR TITLE
Increase sleep time for Pubmed client

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -156,7 +156,7 @@ class EmmaaModel(object):
             pmids = pubmed_client.get_ids(term.search_term, reldate=date_limit)
             logger.info(f'{len(pmids)} PMIDs found for {term.search_term}')
             terms_to_pmids[term] = pmids
-            time.sleep(0.5)
+            time.sleep(1)
         return terms_to_pmids
 
     @staticmethod


### PR DESCRIPTION
This small PR increases sleep time between Pubmed client requests from 0.5 to 1 analogously to Elsevier client calls. Reviewing some Batch job logs showed that 0.5 is not enough.

![Screen Shot 2019-09-10 at 2 39 54 PM](https://user-images.githubusercontent.com/35860871/64641690-b7b5ff80-d3da-11e9-97bb-b6043a57cfb1.png)