### PR TITLE
Add login capabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,10 @@ addons:
 install:
   - pip install git+https://github.com/sorgerlab/indra.git
   - pip install git+https://github.com/indralab/indra_db.git
-  - pip install git+https://github.com/indralab/ui_util.git
+  - git clone https://github.com/indralab/ui_util.git
+  - cd ui_util/indralab_auth_tools
+  - pip install .
+  - cd ../..
   - pip install .[test]
 before_script:
   # Create a test database.

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
 install:
   - pip install git+https://github.com/sorgerlab/indra.git
   - pip install git+https://github.com/indralab/indra_db.git
+  - pip install git+https://github.com/indralab/ui_util.git
   - pip install .[test]
 before_script:
   # Create a test database.

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -297,8 +297,7 @@ def format_results(results):
         formatted_result['model'] = result[0]
         query = result[1]
         formatted_result['query'] = _make_query_simple_dict(query)
-        mc_type = result[2]
-        formatted_result['mc_type'] = ' '.join(mc_type.split('_')).capitalize()
+        formatted_result['mc_type'] = result[2]
         response_json = result[3]
         response = _process_result_to_html(response_json)
         formatted_result['response'] = response

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -396,3 +396,23 @@ def hash_query(query_json, model_id):
     """Create an FNV-1a 32-bit hash from the query json and model_id."""
     unique_string = model_id + ':' + sorted_json_string(query_json)
     return fnv1a_32(unique_string.encode('utf-8'))
+
+
+def update_subscription(user_query, new_sub_status):
+    """Update a UserQuery object's subscription status
+
+    user_query : `emmaa.db.schema.UserQuery`
+        The UserQuery object to be updated
+    new_sub_status : Bool
+        The subscription status to change to
+
+    Returns
+    -------
+    user_query : UserQuery(object)
+        The updated UserQuery object
+    """
+    if new_sub_status is not user_query.subscription:
+        user_query.subscription = new_sub_status
+        logger.info(f'Updated subscription status to '
+                    f'{new_sub_status} for query {user_query.query_hash}')
+    return user_query

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -218,7 +218,9 @@ class EmmaaDatabaseManager(object):
                 logger.info(f'Updating existing query for {user_email} '
                             f'on {model_id} ({qh})')
                 # Update subscription
-                self.update_subscription(user_id, qh, subscribe)
+                # Here: set subscribe to True, handle un-subscribe elsewhere
+                if subscribe:
+                    self.update_subscription(user_id, qh, subscribe)
 
                 # Update query count
                 with self.get_session() as sess:

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -194,8 +194,8 @@ class EmmaaDatabaseManager(object):
             # Check if logged in user is in the emmaa user table
             if user_email and user_id:
                 res = \
-                    sess.query(User.id).filter(User.id == user_id).all()
-                if res.all():
+                    sess.query(User.id).filter(User.id == user_id).first()
+                if res:
                     logger.info(f'User {user_email} is registered in the '
                                 f'user table.')
                 else:
@@ -229,7 +229,7 @@ class EmmaaDatabaseManager(object):
                     user_query = sess.query(UserQuery).filter(
                         UserQuery.user_id == user_id,
                         UserQuery.query_hash == qh
-                    ).all()[0]
+                    ).first()
                     logger.info(f'Updating existing query for {user_email} '
                                 f'on {model_id} ({qh})')
                     # Update subscription

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -49,7 +49,7 @@ def test_format_results():
     assert len(formatted_results) == 1
     assert formatted_results[0]['model'] == 'test'
     assert formatted_results[0]['query'] == simple_query
-    assert formatted_results[0]['mc_type'] == 'Pysb'
+    assert formatted_results[0]['mc_type'] == 'pysb'
     assert isinstance(formatted_results[0]['response'], str)
     assert isinstance(formatted_results[0]['date'], str)
 

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -58,7 +58,7 @@ def test_format_results():
 def test_answer_immediate_query():
     db = _get_test_db()
     qm = QueryManager(db=db, model_managers=[test_mm])
-    results = qm.answer_immediate_query('tester@test.com', query_object,
+    results = qm.answer_immediate_query('tester@test.com', 1, query_object,
                                         ['test'], subscribe=False)
     assert len(results) == 1
     assert results[0]['model'] == 'test'
@@ -73,7 +73,7 @@ def test_answer_immediate_query():
 def test_answer_get_registered_queries():
     db = _get_test_db()
     qm = QueryManager(db=db, model_managers=[test_mm])
-    qm.db.put_queries('tester@test.com', query_object, ['test'],
+    qm.db.put_queries('tester@test.com', 1, query_object, ['test'],
                       subscribe=True)
     qm.answer_registered_queries('test')
     results = qm.get_registered_queries('tester@test.com')
@@ -96,7 +96,7 @@ def test_report_one_query():
     db = _get_test_db()
     qm = QueryManager(db=db, model_managers=[test_mm])
     # Using results from db
-    qm.db.put_queries('tester@test.com', query_object, ['test'],
+    qm.db.put_queries('tester@test.com', 1, query_object, ['test'],
                       subscribe=True)
     qm.db.put_results('test', [(query_object, 'pysb', test_response),
                                (query_object, 'pysb', query_not_appl)])
@@ -125,7 +125,7 @@ def test_report_one_query():
 def test_report_files():
     db = _get_test_db()
     qm = QueryManager(db=db, model_managers=[test_mm])
-    qm.db.put_queries('tester@test.com', query_object, ['test'],
+    qm.db.put_queries('tester@test.com', 1, query_object, ['test'],
                       subscribe=True)
     qm.db.put_results('test', [(query_object, 'pysb', query_not_appl)])
     results = qm.db.get_results('tester@test.com', latest_order=1)

--- a/emmaa/tests/test_db.py
+++ b/emmaa/tests/test_db.py
@@ -35,7 +35,7 @@ def test_instantiation():
 @attr('nonpublic')
 def test_put_queries():
     db = _get_test_db()
-    db.put_queries('joshua', test_queries[0], ['aml', 'luad'])
+    db.put_queries('joshua', 1, test_queries[0], ['aml', 'luad'])
     with db.get_session() as sess:
         queries = sess.query(Query).all()
     assert len(queries) == 2, len(queries)
@@ -45,7 +45,7 @@ def test_put_queries():
 def test_get_queries():
     db = _get_test_db()
     for query in test_queries:
-        db.put_queries('joshua', query, ['aml', 'luad'])
+        db.put_queries('joshua', 1, query, ['aml', 'luad'])
     queries = db.get_queries('aml')
     assert len(queries) == 2, len(queries)
     assert all(isinstance(query, PathProperty) for query in queries)
@@ -59,7 +59,7 @@ def _get_random_result():
 @attr('nonpublic')
 def test_put_results():
     db = _get_test_db()
-    db.put_queries('joshua', test_queries[0], ['aml', 'luad'])
+    db.put_queries('joshua', 1, test_queries[0], ['aml', 'luad'])
     queries = db.get_queries('aml')
     results = [(query, '', _get_random_result())
                for query in queries]
@@ -76,7 +76,7 @@ def test_get_results():
 
     # Fill up the database.
     for query in test_queries:
-        db.put_queries('joshua', query, models)
+        db.put_queries('joshua', 1, query, models)
     for model in models:
         db.put_results(model, [(query, 'pysb', _get_random_result())
                                for query in test_queries])
@@ -98,7 +98,7 @@ def test_get_latest_results():
 
     # Fill up the database.
     for query in test_queries:
-        db.put_queries('joshua', query, models)
+        db.put_queries('joshua', 1, query, models)
     for model in models:
         db.put_results(model, [(query, 'pysb', _get_random_result())
                                for query in test_queries])

--- a/emmaa/tests/test_queries.py
+++ b/emmaa/tests/test_queries.py
@@ -5,7 +5,7 @@ from nose.plugins.attrib import attr
 from indra.statements import Phosphorylation, Agent
 from emmaa.queries import (Query, PathProperty, get_agent_from_local_grounding,
                            get_agent_from_grounding_service,
-                           get_grounding_from_name, get_agent_from_text)
+                           get_grounding_from_name, get_agent_from_text,)
 
 
 def test_path_property_from_json():
@@ -76,12 +76,11 @@ def test_local_grounding():
 
 @attr('nonpublic')
 def test_grounding_service():
-    url = os.environ['GROUNDING_SERVICE_URL']
-    agent = get_agent_from_grounding_service('MAPK1', url)
+    agent = get_agent_from_text('MAPK1', use_grouding_service=True)
     assert isinstance(agent, Agent)
     assert agent.name == 'MAPK1'
     assert agent.db_refs == {'HGNC': '6871'}
-    agent = get_agent_from_local_grounding('BRAF')
+    agent = get_agent_from_text('BRAF', use_grouding_service=True)
     assert isinstance(agent, Agent)
     assert agent.name == 'BRAF'
     assert agent.db_refs == {'HGNC': '1097'}

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -136,3 +136,23 @@ def get_class_from_name(cls_name, parent_cls):
 
 class NotAClassName(Exception):
     pass
+
+
+def update_subscription(user_query, new_sub_status):
+    """Update a UserQuery object's subscription status
+
+    user_query : `emmaa.db.schema.UserQuery`
+        The UserQuery object to be updated
+    new_sub_status : Bool
+        The subscription status to change to
+
+    Returns
+    -------
+    user_query : UserQuery(object)
+        The updated UserQuery object
+    """
+    if new_sub_status is not user_query.subscription:
+        user_query.subscription = new_sub_status
+        logger.info(f'Updated subscription status to '
+                    f'{new_sub_status} for query {user_query.query_hash}')
+    return user_query

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -136,23 +136,3 @@ def get_class_from_name(cls_name, parent_cls):
 
 class NotAClassName(Exception):
     pass
-
-
-def update_subscription(user_query, new_sub_status):
-    """Update a UserQuery object's subscription status
-
-    user_query : `emmaa.db.schema.UserQuery`
-        The UserQuery object to be updated
-    new_sub_status : Bool
-        The subscription status to change to
-
-    Returns
-    -------
-    user_query : UserQuery(object)
-        The updated UserQuery object
-    """
-    if new_sub_status is not user_query.subscription:
-        user_query.subscription = new_sub_status
-        logger.info(f'Updated subscription status to '
-                    f'{new_sub_status} for query {user_query.query_hash}')
-    return user_query

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 TITLE = 'emmaa title'
 EMMAA_BUCKET_NAME = 'emmaa'
 ALL_MODEL_TYPES = ['pysb', 'pybel', 'signed_graph', 'unsigned_graph']
-FORMATTED_MODEL_NAMES = {'pysb': 'PySb',
+FORMATTED_MODEL_NAMES = {'pysb': 'PySB',
                          'pybel': 'PyBEL',
                          'signed_graph': 'Signed Graph',
                          'unsigned_graph': 'Unsigned Graph'}

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -228,15 +228,19 @@ def process_query():
     try:
         # If user tries to register query without logging in, refuse query
         # with 401 (unauthorized)
-        if request.json['register'] and user_email:
-            # Logged in
-            subscribe = request.json['register']
+        if request.json['register']:
+            if user_email:
+                # Logged in
+                subscribe = request.json['register']
+            else:
+                # Not logged in
+                logger.warning('User not logged in! Query will not be '
+                               'registered.')
+                return jsonify({'result': 'failure',
+                                'reason': 'Invalid credentials'}), 401
+        # Does not try to register
         else:
-            # Not logged in
-            logger.warning('User not logged in! Query will not be '
-                           'registered.')
-            return jsonify({'result': 'failure',
-                            'reason': 'Invalid credentials'}), 401
+            subscribe = False
         query_json = request.json['query']
         assert set(query_json.keys()) == expected_query_keys, \
             (f'Did not get expected query keys: got {set(query_json.keys())} '

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -14,8 +14,10 @@ from emmaa.model import load_config_from_s3
 from emmaa.answer_queries import QueryManager, load_model_manager_from_s3
 from emmaa.queries import PathProperty, get_agent_from_text, GroundingError
 
+from indralab_auth_tools.auth import auth, config_auth
 
 app = Flask(__name__)
+app.register_blueprint(auth)
 app.config['DEBUG'] = True
 logger = logging.getLogger(__name__)
 
@@ -25,6 +27,7 @@ EMMAA_BUCKET_NAME = 'emmaa'
 link_list = [('./home', 'EMMAA Dashboard'),
              ('./query', 'Queries')]
 
+SC, jwt = config_auth(app)
 
 qm = QueryManager()
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -25,6 +25,11 @@ logger = logging.getLogger(__name__)
 
 TITLE = 'emmaa title'
 EMMAA_BUCKET_NAME = 'emmaa'
+ALL_MODEL_TYPES = ['pysb', 'pybel', 'signed_graph', 'unsigned_graph']
+FORMATTED_MODEL_NAMES = {'pysb': 'PySb',
+                         'pybel': 'PyBEL',
+                         'signed_graph': 'Signed Graph',
+                         'unsigned_graph': 'Unsigned Graph'}
 link_list = [('./home', 'EMMAA Dashboard'),
              ('./query', 'Queries')]
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -210,7 +210,7 @@ def get_query_page():
     return render_template('query_template.html', model_data=model_meta_data,
                            stmt_types=stmt_types, old_results=old_results,
                            link_list=link_list, user_email=user_email,
-                           user_id=user_id)
+                           user_id=user_id, model_names=FORMATTED_MODEL_NAMES)
 
 
 @app.route('/query/submit', methods=['POST'])

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -154,15 +154,20 @@ def _make_query(query_dict, use_grouding_service=True):
 
 @app.route('/')
 @app.route('/home')
+@jwt_optional
 def get_home():
+    user, roles = resolve_auth(dict(request.args))
     model_data = _get_model_meta_data()
-    return render_template('index_template.html',
-                           model_data=model_data,
-                           link_list=link_list)
+    return render_template('index_template.html', model_data=model_data,
+                           link_list=link_list,
+                           user_email=user.email if user else "",
+                           identity=user.identity() if user else None)
 
 
 @app.route('/dashboard/<model>')
+@jwt_optional
 def get_model_dashboard(model):
+    user, roles = resolve_auth(dict(request.args))
     model_meta_data = _get_model_meta_data()
     mod_link_list = [('.' + t[0], t[1]) for t in link_list]
     last_update = model_last_updated(model=model)
@@ -176,13 +181,13 @@ def get_model_dashboard(model):
         logger.warning(f'Could not get last update for {model}')
         last_update = 'Not available'
     model_stats = get_model_stats(model)
-    return render_template('model_template.html',
-                           model=model,
+    return render_template('model_template.html', model=model,
                            model_data=model_meta_data,
                            model_stats_json=model_stats,
                            link_list=mod_link_list,
-                           model_last_updated=last_update,
-                           ndexID=ndex_id)
+                           model_last_updated=last_update, ndexID=ndex_id,
+                           user_email=user.email if user else "",
+                           identity=user.identity() if user else None)
 
 
 @app.route('/query')
@@ -198,7 +203,8 @@ def get_query_page():
 
     return render_template('query_template.html', model_data=model_meta_data,
                            stmt_types=stmt_types, old_results=old_results,
-                           link_list=link_list, user_email=user_email)
+                           link_list=link_list, user_email=user_email,
+                           identity=user.identity() if user else None)
 
 
 @app.route('/query/submit', methods=['POST'])

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -208,6 +208,7 @@ def get_query_page():
 
 
 @app.route('/query/submit', methods=['POST'])
+@jwt_optional
 def process_query():
     # Print inputs.
     logger.info('Got model query')
@@ -217,13 +218,19 @@ def process_query():
     logger.info(str(request.json))
     logger.info("------------------")
 
+    user, roles = resolve_auth(dict(request.args))
+    user_email = user.email if user else ""
+
     # Extract info.
     expected_query_keys = {f'{pos}Selection'
                            for pos in ['subject', 'object', 'type']}
     expected_models = {mid for mid, _ in _get_model_meta_data()}
     try:
-        user_email = request.json['user']['email']
-        subscribe = request.json['register']
+        # user_email = request.json['user']['email']
+        if user_email:
+            subscribe = request.json['register']
+        else:
+            subscribe = False
         query_json = request.json['query']
         assert set(query_json.keys()) == expected_query_keys, \
             (f'Did not get expected query keys: got {set(query_json.keys())} '

--- a/emmaa_service/static/queryFunctions.js
+++ b/emmaa_service/static/queryFunctions.js
@@ -93,7 +93,9 @@ function submitQuery(queryDict, test) {
           break;
         case 401:
           console.log('401 response');
-          queryNotify('Must be signed in to register queries');
+          let msg = 'Must be signed in to subscribe to queries';
+          queryNotify(msg);
+          if (queryDict.register) report_login_result(msg);
           login(
             (type, data) => {submitQuery(queryDict, test)},
             (type, data) => {submitQuery(queryDict, test)}

--- a/emmaa_service/static/queryFunctions.js
+++ b/emmaa_service/static/queryFunctions.js
@@ -13,7 +13,6 @@ function postQuery(queryContainer) {
   }
 
   // Check if user wants to register query
-  // ToDo Prompt user to log in if they are not
   let reg = document.getElementById('register-query').checked;
 
   let ajax_response = submitQuery({
@@ -94,7 +93,11 @@ function submitQuery(queryDict, test) {
           break;
         case 401:
           console.log('401 response');
-          queryNotify('Query failed: Unauthorized (401). Try to sign in again.');
+          queryNotify('Must be signed in to register queries');
+          login(
+            (type, data) => {submitQuery(queryDict, test)},
+            (type, data) => {submitQuery(queryDict, test)}
+          );
           break;
         case 404:
           console.log('404 response');

--- a/emmaa_service/static/queryFunctions.js
+++ b/emmaa_service/static/queryFunctions.js
@@ -5,14 +5,6 @@ let QUERY_STATUS_ID = 'query-status';
 function postQuery(queryContainer) {
   console.log('function postQuery(queryContainer)');
 
-  // Get user info
-  // ToDo: Tie up with login capabilities
-  userInfo = {
-    name: 'joshua',
-    slack_id: '123456abcdef',
-    email: 'joshua@emmaa.com'
-  };
-
   // Collect model query
   let querySel = collectQuery(queryContainer);
   if (querySel.length < 2) {
@@ -21,10 +13,10 @@ function postQuery(queryContainer) {
   }
 
   // Check if user wants to register query
+  // ToDo Prompt user to log in if they are not
   let reg = document.getElementById('register-query').checked;
 
   let ajax_response = submitQuery({
-    user: userInfo,
     models: querySel[0],
     query: querySel[1],
     register: reg

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -64,6 +64,9 @@
     #query-submit {
       background-color: rgb(221, 221, 221);
     }
+    button.btn-primary {
+      background-color: #007bff;
+    }
   </style>
 </head>
 

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -76,18 +76,10 @@
     {{ login_overlay(url_prefix="/dev") }}
     <script>
       function handle_success(type, resp_data) {
-        const user_msg = document.querySelector('#user-loginout-msg');
         if (type === "login") {
           const btn = document.querySelector("#loginout-button");
           btn.innerHTML = 'Logout';
           btn.onclick = () => {return trigger_logout()};
-          document.querySelector('#user-logoin');
-          if (location.href.split(/([?#])/)[0].endsWith('query')) {
-            user_msg.innerHTML = `Reload the page to see your past queries`;
-          } else {
-            user_msg.innerHTML = `Welcome, ${resp_data.user_email}`;
-          }
-
           report_login_result(''); // clear the login result message
         }
         else if (type === "register") {
@@ -97,7 +89,6 @@
           const btn = document.querySelector("#loginout-button");
           btn.innerHTML = 'Login';
           btn.onclick = () => {return trigger_login()};
-          user_msg.innerHTML = ""
         }
       }
 
@@ -150,17 +141,6 @@
               Login
             {% endif %}
           </button>
-        </div>
-      </div>
-      <div class="d-flex flex-row-reverse">
-        <div class="d-inline-flex text-container p-2 text-right">
-          <span id="user-loginout-msg">
-          {% if user_email %}
-            Logged in as {{ user_email }}
-          {% else %}
-            Log in to register queries
-          {% endif %}
-          </span>
         </div>
       </div>
     </header>

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -64,7 +64,7 @@
     #query-submit {
       background-color: rgb(221, 221, 221);
     }
-    button.btn-primary {
+    button.btn-primary { /* For login button */
       background-color: #007bff;
     }
   </style>
@@ -121,44 +121,44 @@
       }
     </style>
 
-    <header>
-      <div class="d-flex flex-column flex-md-row align-items-center p-3 px-md-4 mb-3 bg-white border-bottom shadow-sm navbar fixed-top">
-        <h5 class="my-0 mr-md-auto font-weight-normal">
-          {% for link_address, link_text in link_list %}
-          <a href="{{ link_address }}">{{ link_text }}</a>&nbsp;&nbsp;&nbsp;
-          {% endfor %}
-        </h5>
+    <header class="bg-white border-bottom shadow-sm fixed-top no-horiz-pad">
+      <div class="d-flex flex-row align-items-center">
+        <h5 class="d-inline-flex my-0 mr-md-auto font-weight-normal">
+        {% for link_address, link_text in link_list %}
+        <a class="p-2" href="{{ link_address }}">{{ link_text }}</a>
+        {% endfor %}
+      </h5>
         {% block extend_header %}
         {% endblock %}
-        <nav class="my-2 my-md-0 mr-md-3">
-          <a class="p-2 text-dark" href="https://emmaa.readthedocs.io/en/latest/dashboard/index.html" target="_blank">Help</a>
-          <a class="p-2 text-dark" href="#about">About</a>
-          <a class="p-2 text-dark" href="https://sorger.med.harvard.edu/data/bgyori/emmaa_dashboard_intro.mov">Demo</a>
-        </nav>
-        <button class="btn btn-primary"
+        <nav class="d-inline-flex p-2">
+        <a class="p-2 text-dark" href="https://emmaa.readthedocs.io/en/latest/dashboard/index.html" target="_blank">Help</a>
+        <a class="p-2 text-dark" href="#about">About</a>
+        <a class="p-2 text-dark" href="https://sorger.med.harvard.edu/data/bgyori/emmaa_dashboard_intro.mov">Demo</a>
+      </nav>
+        <div class="d-inline-flex button-container p-2">
+          <button class="btn btn-primary"
                 onclick="return {% if identity %}trigger_logout(){% else %}trigger_login(){% endif %};"
                 id="loginout-button">
-          {% if identity %}
-            Logout
-          {%  else %}
-            Login
-          {% endif %}
-        </button>
+            {% if identity %}
+              Logout
+            {%  else %}
+              Login
+            {% endif %}
+          </button>
+        </div>
+      </div>
+      <div class="d-flex flex-row-reverse">
+        <div class="d-inline-flex text-container p-2 text-right">
+          <span id="user-loginout-msg">
+            {% if identity %}
+              Welcome {{ identity['email'] }}!
+            {% else %}
+              Hello anonymous user!
+            {% endif %}
+          </span>
+        </div>
       </div>
     </header>
-
-  {#  <div class="row align-center">#}
-  {#    <div class="col-auto no-horiz-pad">#}
-  {#      {{ header }}#}
-  {#    </div>#}
-  {#    <div class="col text-right no-horiz-pad">#}
-  {#      <span id="user-loginout-msg">#}
-  {#        {% if identity %}#}
-  {#          Welcome {{ identity['email'] }}!#}
-  {#        {% endif %}#}
-  {#      </span>#}
-  {#    </div>#}
-  {#  </div>#}
   {% endblock %}
 
   <div class="container">

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -1,3 +1,4 @@
+{% from "auth_macros.html" import login_overlay %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -69,6 +70,54 @@
 <body>
 
   {% block header %}
+    {{ login_overlay() }}
+    <script>
+      function handle_success(type, resp_data) {
+        const user_msg = document.querySelector('#user-loginout-msg');
+        if (type === "login") {
+          const btn = document.querySelector("#loginout-button");
+          btn.innerHTML = 'Logout';
+          btn.onclick = () => {return trigger_logout()};
+          document.querySelector('#user-logoin');
+          user_msg.innerHTML = `Welcome, ${resp_data.user_email}`;
+          report_login_result(''); // clear the login result message
+        }
+        else if (type === "register") {
+          trigger_login()
+        }
+        else { // logout
+          const btn = document.querySelector("#loginout-button");
+          btn.innerHTML = 'Login';
+          btn.onclick = () => {return trigger_login()};
+          user_msg.innerHTML = ""
+        }
+      }
+
+      function trigger_login(type=null, data=null) {
+        return login(handle_success, trigger_unchecked_login)
+      }
+
+      function trigger_unchecked_login(type=null, data=null) {
+        return login(handle_success, trigger_unchecked_login, true)
+      }
+
+      function trigger_logout() {
+        return logout(handle_success)
+        }
+    </script>
+
+    <style>
+      #loginout-button, #user-loginout-msg {
+        margin-top: 5px;
+        margin-bottom: 5px;
+      }
+
+      .no-horiz-pad {
+        padding-left: 0;
+        padding-right: 0;
+      }
+    </style>
+
     <header>
       <div class="d-flex flex-column flex-md-row align-items-center p-3 px-md-4 mb-3 bg-white border-bottom shadow-sm navbar fixed-top">
         <h5 class="my-0 mr-md-auto font-weight-normal">
@@ -83,12 +132,35 @@
           <a class="p-2 text-dark" href="#about">About</a>
           <a class="p-2 text-dark" href="https://sorger.med.harvard.edu/data/bgyori/emmaa_dashboard_intro.mov">Demo</a>
         </nav>
+        <button class="btn btn-primary"
+                onclick="return {% if identity %}trigger_logout(){% else %}trigger_login(){% endif %};"
+                id="loginout-button">
+          {% if identity %}
+            Logout
+          {%  else %}
+            Login
+          {% endif %}
+        </button>
       </div>
     </header>
+
+  {#  <div class="row align-center">#}
+  {#    <div class="col-auto no-horiz-pad">#}
+  {#      {{ header }}#}
+  {#    </div>#}
+  {#    <div class="col text-right no-horiz-pad">#}
+  {#      <span id="user-loginout-msg">#}
+  {#        {% if identity %}#}
+  {#          Welcome {{ identity['email'] }}!#}
+  {#        {% endif %}#}
+  {#      </span>#}
+  {#    </div>#}
+  {#  </div>#}
   {% endblock %}
 
   <div class="container">
     {% block body %}
+      {{ login_overlay() }}
     {% endblock %}
   </div>
 

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -147,17 +147,15 @@
           </button>
         </div>
       </div>
+      {% if user_email %}
       <div class="d-flex flex-row-reverse">
         <div class="d-inline-flex text-container p-2 text-right">
           <span id="user-loginout-msg">
-            {% if identity %}
-              Welcome {{ identity['email'] }}!
-            {% else %}
-              Hello anonymous user!
-            {% endif %}
+            Welcome {{ user_email }}!
           </span>
         </div>
       </div>
+      {% endif %}
     </header>
   {% endblock %}
 

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -58,7 +58,7 @@
     body > .container {
       padding: 85px 15px 0;
     }
-    .btn {
+    a.btn {
       background-color: rgb(255, 255, 255);
     }
     #query-submit {

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -56,7 +56,7 @@
       target-new: tab;
     }
     body > .container {
-      padding: 135px 15px 0;
+      padding: 85px 15px 0;
     }
     a.btn {
       background-color: rgb(255, 255, 255);
@@ -106,7 +106,7 @@
     </script>
 
     <style>
-      #loginout-button, #user-loginout-msg {
+      #loginout-button {
         margin-top: 5px;
         margin-bottom: 5px;
       }

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -56,7 +56,7 @@
       target-new: tab;
     }
     body > .container {
-      padding: 85px 15px 0;
+      padding: 135px 15px 0;
     }
     a.btn {
       background-color: rgb(255, 255, 255);
@@ -141,21 +141,23 @@
                 id="loginout-button">
             {% if identity %}
               Logout
-            {%  else %}
+            {% else %}
               Login
             {% endif %}
           </button>
         </div>
       </div>
-      {% if user_email %}
       <div class="d-flex flex-row-reverse">
         <div class="d-inline-flex text-container p-2 text-right">
           <span id="user-loginout-msg">
-            Welcome {{ user_email }}!
+          {% if user_email %}
+            Logged in as {{ user_email }}
+          {% else %}
+            Log in to register queries
+          {% endif %}
           </span>
         </div>
       </div>
-      {% endif %}
     </header>
   {% endblock %}
 

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 
   <!-- C3 css -->
-  <link rel="stylesheet" href="{{ url_for('static', filename='c3.css') }}">
+  <link rel="stylesheet" href="/dev{{ url_for('static', filename='c3.css') }}">
 
   <!-- Optional theme -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
@@ -28,10 +28,10 @@
   <script src="https://d3js.org/d3.v5.min.js"></script>
 
   <!-- C3 -->
-  <script src="{{ url_for('static', filename='c3.min.js') }}"></script>
+  <script src="/dev{{ url_for('static', filename='c3.min.js') }}"></script>
 
   <!-- Script Files -->
-  <script src="{{ url_for('static', filename='emmaaFunctions.js') }}"></script>
+  <script src="/dev{{ url_for('static', filename='emmaaFunctions.js') }}"></script>
 
   {% block additional_scripts %}
   {% endblock %}
@@ -73,7 +73,7 @@
 <body>
 
   {% block header %}
-    {{ login_overlay() }}
+    {{ login_overlay(url_prefix="/dev") }}
     <script>
       function handle_success(type, resp_data) {
         const user_msg = document.querySelector('#user-loginout-msg');

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -54,7 +54,7 @@
 
 {% block extend_header %}
 <!-- Model select dropdown -->
-<div class="input-group" style="width: 410px;">
+<div class="d-inline-flex p-2 input-group" style="width: 410px;">
   <select class="custom-select" id="modelSelectDD" aria-label="Example select with button addon">
     <option selected disabled hidden>Select model...</option>
     {% for model_id, model_meta in model_data %}

--- a/emmaa_service/templates/query_template.html
+++ b/emmaa_service/templates/query_template.html
@@ -135,7 +135,7 @@
             <!-- model, query, response, date -->
             <td><a class="model-link" href="./dashboard/{{ result['model'] }}">{{ result['model'] }}</a></td>
             <td>{{ result['query']['typeSelection'] }}({{ result['query']['subjectSelection'] }}, {{ result['query']['objectSelection'] }})</td>
-            <td>{{ result['mc_type'] }}</td>
+            <td>{{ model_names[result['mc_type']] }}</td>
             <td>{{ result['response']|safe }}</td>
             <td>{{ result['date'] }}</td>
           </tr>

--- a/emmaa_service/templates/query_template.html
+++ b/emmaa_service/templates/query_template.html
@@ -1,7 +1,7 @@
 {% extends "emmaa_page_template.html" %}
 
 {% block additional_scripts %}
-  <script src="{{ url_for('static', filename='queryFunctions.js') }}"></script>
+  <script src="/dev{{ url_for('static', filename='queryFunctions.js') }}"></script>
   <script>
     $(document).ready(function() {
       let modelSelect = new Choices('#model-select');

--- a/emmaa_service/templates/query_template.html
+++ b/emmaa_service/templates/query_template.html
@@ -10,6 +10,11 @@
 {% endblock %}
 
 {% block body %}
+<style>
+  label {
+    margin-bottom: 0;
+  }
+</style>
 <div class="container" id="query-container">
 
   <div class="card">
@@ -35,7 +40,7 @@
       <div class="form-container" style="display: inline-block; vertical-align: top;">
         <div class="text" style="display: table;">
           <form onsubmit="postQuery(document.getElementById('query-container')); return false;">
-            <div class="row">
+            <div class="row" style="align-items: center">
               <div class="dropdown col" style="display: table-cell; padding-right: 2px">
                 <!-- WARNING: The id of the select tag goes into the query dictionary, do NOT change it unless it is
                   changed in the rest API and query handling -->

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(name='emmaa',
       packages=find_packages(),
       install_requires=['indra', 'boto3', 'jsonpickle', 'kappy==4.0.0rc1',
                         'pygraphviz', 'fnvhash', 'sqlalchemy', 'inflection',
-                        'pybel', 'flask_jwt_extended'],
+                        'pybel', 'flask_jwt_extended', 'indralab_auth_tools'],
       extras_require={'test': ['nose', 'coverage', 'python-coveralls']}
       )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(name='emmaa',
       packages=find_packages(),
       install_requires=['indra', 'boto3', 'jsonpickle', 'kappy==4.0.0rc1',
                         'pygraphviz', 'fnvhash', 'sqlalchemy', 'inflection',
-                        'pybel'],
+                        'pybel', 'flask_jwt_extended'],
       extras_require={'test': ['nose', 'coverage', 'python-coveralls']}
       )


### PR DESCRIPTION
This PR sets up the framework needed for being able to login to the emmaa services. All pages are still available to the user without being logged in. Instead, certain capabilities are blocked/not visible to an anonymous user.

The most notable changes in the UI are:
- An added login button on the navbar
- Subscribed queries are now shown on a user basis, provided that the user is logged in
- If a user tries to subscribe to a query without being logged in, they are prompted to log in

Changes on the back-end include:
- Add a new column, 'count', to the UserQuery table that stores how many times a user has made a certain query.
- All handling of users that was previously not done is now handled.

**_The merging of this PR must also coincide with an update of the tables_**