### PR TITLE
Reactome fix

### DIFF
--- a/emmaa/tests/test_reactome_prior.py
+++ b/emmaa/tests/test_reactome_prior.py
@@ -28,6 +28,8 @@ def test_get_pathways_containing_genes():
     assert all([re.match(pattern, pathway_id) for pathway_id in KRAS_pathways])
     # Check if function returns a reasonable number of pathways
     assert len(KRAS_pathways) > 3
+    # Signaling Downstream of RAS mutants
+    assert 'R-HSA-9649948.1' in KRAS_pathways
     
 
 def test_get_genes_contained_in_pathway():
@@ -38,23 +40,32 @@ def test_get_genes_contained_in_pathway():
     assert all([re.match(pattern, up_id) for up_id in RAS_mutants_genes])
     # Check that function returns a reasonable number of genes
     assert len(RAS_mutants_genes) > 30
+    # KRAS
+    assert 'P01116' in RAS_mutants_genes
 
 
 def test_make_prior_from_genes():
     # KRAS prior
-    prior = make_prior_from_genes(['KRAS'])
-
+    prior1 = make_prior_from_genes(['KRAS'])
+    # BRCA prior
+    prior2 = make_prior_from_genes(['TP53', 'PIK3CA', 'GATA3', 'CBFB', 'CDH1'])
     # make sure there are results
-    assert prior
-
+    assert prior1
     # make sure the prior is a list of SearchTerms
-    assert all(isinstance(term, SearchTerm) for term in prior)
-
+    assert all(isinstance(term, SearchTerm) for term in prior1)
     # if we get fewer than 40 genes for KRAS it's likely something is wrong
-    assert len(prior) > 40
+    assert len(prior1) > 40
     # test that the prior contains some of the usual suspects
-    gene_names = set(term.name for term in prior)
-    assert set(['KRAS', 'RAF1', 'MAPK1', 'BRAF']) <= set(gene_names)
+    gene_names = set(term.name for term in prior1)
+    assert set(['KRAS', 'RAF1', 'MAPK1', 'BRAF']) <= gene_names
+
+    assert prior2
+    assert all(isinstance(term, SearchTerm) for term in prior2)
+    assert len(prior2) > 1000
+    gene_names = set(term.name for term in prior2)
+    assert set(['COL1A1', 'ESR1', 'EGFR', 'HRAS']) <= gene_names
+    # some genes expressed only in the brain
+    assert not (gene_names & set(['BARHL1', 'NEUROD2']))
 
 
 def test_find_drugs_for_genes():

--- a/emmaa/tests/test_reactome_prior.py
+++ b/emmaa/tests/test_reactome_prior.py
@@ -8,13 +8,12 @@ from emmaa.priors.reactome_prior import get_pathways_containing_gene
 from emmaa.priors.reactome_prior import get_genes_contained_in_pathway
 
 
-@unittest.skip('Reactome ID lookup by UniProt ID has changed.')
 def test_rx_id_from_up_id():
     """Check that Uniprot ids are being successfully mapped to reactome ids
     """
-    test_cases = [('P01116', 'R-HSA-62719'),   # KRAS
-                  ('P04637', 'R-HSA-69488'),   # TP53
-                  ('Q13485', 'R-HSA-177103')]  # SMAD4
+    test_cases = [('P01116', 'R-HSA-9653079'),   # KRAS
+                  ('P04637', 'R-HSA-69507'),   # TP53
+                  ('Q13485', 'R-HSA-2187323')]  # SMAD4
     for up_id, rx_id in test_cases:
         all_rx_ids = rx_id_from_up_id(up_id)
         assert rx_id in all_rx_ids


### PR DESCRIPTION
This PR updates tests for the reactome prior which were no longer passing due to changes in results returned by the reactome REST API. For most tests, the failures were due to changes in the reactome hierarchy. Some pathways and entities that were included in tests were recently split into multiple pathways and entities respectively, causing assertions to fail. 

There is still a mystery as to why the prior generated from only the gene KRAS has shrank. I suspect this is likely due to changes in the mapping of Uniprot IDs. The priors generated from multiple genes still appear to be of reasonable size and content. For now it appears best to continue mapping genes to reactome IDs based on Uniprot ID. The priors generated when mapping by HGNC symbol are very large; a prior with over 6000 genes is generated when starting with only KRAS. 