### PR TITLE
Query page restructure

### DIFF
--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -171,6 +171,8 @@ class TestRound(object):
             # and do not care about path length
             if res.path_found:
                 return 'Pass'
+            elif res.result_code == 'STATEMENT_TYPE_NOT_HANDLED':
+                return 'n_a'
             else:
                 return 'Fail'
 

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -94,7 +94,7 @@ class QueryManager(object):
     def retrieve_results_from_hashes(self, query_hashes):
         """Retrieve results from a db given a list of query-model hashes."""
         results = self.db.get_results_from_hashes(query_hashes)
-        return format_results
+        return format_results(results)
 
     def make_reports_from_results(
             self, new_results, stored=True, report_format='str'):

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -343,10 +343,9 @@ def format_results(results):
     for qh, res in formatted_results.items():
         model = res['model']
         new_res = [('', res["query"], ''),
-                   (f'/{model}', model,
-                    f'Click to see details about {model}')]
+                   (f'/{model}', model, f'Click to see details about {model}')]
         if 'n_a' in res:
-            new_res.append('', 'n_a', '')
+            new_res.append(('', 'n_a', ''))
         else:
             for mt in model_types:
                 new_res.append((f'/tests/{model}/{mt}/{qh}', res[mt][0],

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -53,16 +53,14 @@ class QueryManager(object):
         new_date = datetime.now()
         for model_name in model_names:
             if model_name not in checked_models:
+                results_to_store = []
                 mm = self.get_model_manager(model_name)
                 response_list = mm.answer_query(query)
                 for (mc_type, response) in response_list:
                     new_results.append(
                         (model_name, query, mc_type, response, new_date))
-                if subscribe:
-                    self.db.put_results(
-                        model_name,
-                        [(query, mc_type, response)
-                         for mc_type, response in response_list])
+                    results_to_store.append((query, mc_type, response))
+                self.db.put_results(model_name, results_to_store)
         all_results = saved_results + new_results
         return format_results(all_results)
 

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -324,7 +324,7 @@ def format_results(results):
         mc_type = result[2]
         response_json = result[3]
         response = []
-        for v in response_json.values:
+        for v in response_json.values():
             if isinstance(v, str):
                 response = v
             elif isinstance(v, dict):

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -91,6 +91,11 @@ class QueryManager(object):
         results = self.db.get_results(user_email)
         return format_results(results)
 
+    def retrieve_results_from_hashes(self, query_hashes):
+        """Retrieve results from a db given a list of query-model hashes."""
+        results = self.db.get_results_from_hashes(query_hashes)
+        return format_results
+
     def make_reports_from_results(
             self, new_results, stored=True, report_format='str'):
         """Make a report given latest results and queries the results are for.

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -414,5 +414,5 @@ def _make_query_simple_dict(query):
 def _make_query_str(query):
     stmt = query.path_stmt
     subj, obj = stmt.agent_list()
-    query_str = type(stmt).__name__ + '(' + subj.name, + ', ' + obj.name + ')'
-    return query_str
+    parts = [type(stmt).__name__, '(', subj.name, ', ', obj.name, ')']
+    return ''.join(parts)

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -318,7 +318,7 @@ def format_results(results):
         query_hash = query.get_hash_with_model(model)
         if query_hash not in formatted_results:
             formatted_results[query_hash] = {
-                'query': _make_query_simple_dict(query),
+                'query': _make_query_str(query),
                 'model': model,
                 'date': make_date_str(result[4])}
         mc_type = result[2]
@@ -340,10 +340,11 @@ def format_results(results):
 
     model_types = ['pysb', 'pybel', 'signed_graph', 'unsigned_graph']
     result_array = []
-    for qh, res in formatted_results.values():
-        new_res = [('', res['query'], ''),
-                   (f'/{res['model']}', res['model'],
-                    f'Click to see details about {res['model']}')]
+    for qh, res in formatted_results.items():
+        model = res['model']
+        new_res = [('', res["query"], ''),
+                   (f'/{model}', model,
+                    f'Click to see details about {model}')]
         if 'n_a' in res:
             new_res.append('', 'n_a', '')
         else:
@@ -408,3 +409,10 @@ def _make_query_simple_dict(query):
     query_dict['subjectSelection'] = subj.name
     query_dict['objectSelection'] = obj.name
     return query_dict
+
+
+def _make_query_str(query):
+    stmt = query.path_stmt
+    subj, obj = stmt.agent_list()
+    query_str = type(stmt).__name__ + '(' + subj.name, + ', ' + obj.name + ')'
+    return query_str

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -296,19 +296,41 @@ def is_query_result_diff(new_result_json, old_result_json=None):
 
 def format_results(results):
     """Format db output to a standard json structure."""
-    formatted_results = []
+    # formatted_results = []
+    # for result in results:
+    #     formatted_result = {}
+    #     formatted_result['model'] = result[0]
+    #     query = result[1]
+    #     formatted_result['query'] = _make_query_simple_dict(query)
+    #     formatted_result['mc_type'] = result[2]
+    #     formatted_result['model_type_name'] = FORMATTED_TYPE_NAMES[result[2]]
+    #     response_json = result[3]
+    #     response = _process_result_to_html(response_json)
+    #     formatted_result['response'] = response
+    #     formatted_result['date'] = make_date_str(result[4])
+    #     formatted_results.append(formatted_result)
+    # return formatted_results
+
+    formatted_results = {}
     for result in results:
-        formatted_result = {}
-        formatted_result['model'] = result[0]
+        model = result[0]
         query = result[1]
-        formatted_result['query'] = _make_query_simple_dict(query)
-        formatted_result['mc_type'] = result[2]
-        formatted_result['model_type_name'] = FORMATTED_TYPE_NAMES[result[2]]
+        query_hash = query.get_hash_with_model(model)
+        if query_hash not in formatted_results:
+            formatted_results[query_hash] = {
+                'query': _make_query_simple_dict(query),
+                'model': model,
+                'date': make_date_str(result[4])}
+        mc_type = result[2]
         response_json = result[3]
-        response = _process_result_to_html(response_json)
-        formatted_result['response'] = response
-        formatted_result['date'] = make_date_str(result[4])
-        formatted_results.append(formatted_result)
+        if mc_type == '' and \
+                response_json == 'Query is not applicable for this model':
+            formatted_results[query_hash]['n_a'] = response_json
+        elif isinstance(response_json, str) and \
+                not response_json == 'Path found but exceeds search depth':
+            formatted_results[query_hash][mc_type] = ['Fail', response_json]
+        else:
+            formatted_results[query_hash][mc_type] = ['Pass', response_json]
     return formatted_results
 
 

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -342,16 +342,7 @@ def format_results(results):
         else:
             formatted_results[query_hash][mc_type] = ['Pass', response]
 
-    result_array = []
-    for qh, res in formatted_results.items():
-        model = res['model']
-        new_res = [('', res["query"], ''),
-                   (f'/{model}', model, f'Click to see details about {model}')]
-        for mt in model_types:
-            new_res.append((f'/tests/{model}/{mt}/{qh}', res[mt][0],
-                            'Click to see detailed results for this query'))
-        result_array.append(new_res)
-    return result_array
+    return formatted_results
 
 
 def load_model_manager_from_s3(model_name):

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -296,20 +296,6 @@ def is_query_result_diff(new_result_json, old_result_json=None):
 
 def format_results(results):
     """Format db output to a standard json structure."""
-    # formatted_results = []
-    # for result in results:
-    #     formatted_result = {}
-    #     formatted_result['model'] = result[0]
-    #     query = result[1]
-    #     formatted_result['query'] = _make_query_simple_dict(query)
-    #     formatted_result['mc_type'] = result[2]
-    #     formatted_result['model_type_name'] = FORMATTED_TYPE_NAMES[result[2]]
-    #     response_json = result[3]
-    #     response = _process_result_to_html(response_json)
-    #     formatted_result['response'] = response
-    #     formatted_result['date'] = make_date_str(result[4])
-    #     formatted_results.append(formatted_result)
-    # return formatted_results
     model_types = ['pysb', 'pybel', 'signed_graph', 'unsigned_graph']
     formatted_results = {}
     for result in results:
@@ -370,35 +356,6 @@ def _process_result_to_str(result_json):
             msg += v['path']
             msg += '\n'
     return msg
-
-
-# def _process_result_to_html(result_json):
-#     # Make clickable links when making htmk report
-#     response_list = []
-#     for v in result_json.values():
-#         for ix, (sentence, link) in enumerate(v):
-#             if ix > 0:
-#                 response_list.append('<br>')
-#             if link:
-#                 response_list.append(
-#                     f'<a href="{link}" target="_blank" '
-#                     f'class="status-link">{sentence}</a>')
-#             else:
-#                 response_list.append(f'<a>{sentence}</a>')
-#         response = ''.join(response_list)
-#     return response
-
-
-def _make_query_simple_dict(query):
-    """Turn Query object into a simple dictionary for easier representation on
-    the dashboard."""
-    query_dict = {}
-    stmt = query.path_stmt
-    query_dict['typeSelection'] = type(stmt).__name__
-    subj, obj = stmt.agent_list()
-    query_dict['subjectSelection'] = subj.name
-    query_dict['objectSelection'] = obj.name
-    return query_dict
 
 
 def _make_query_str(query):

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -330,7 +330,11 @@ def format_results(results):
             formatted_results[query_hash][mc_type] = ['Fail', response]
         else:
             formatted_results[query_hash][mc_type] = ['Pass', response]
-
+    # Loop through the results again to make sure all model types are there
+    for qh in formatted_results:
+        for mt in model_types:
+            if mt not in formatted_results[qh]:
+                formatted_results[qh][mt] = ['n_a', 'Model type not supported']
     return formatted_results
 
 

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -1,8 +1,11 @@
-import logging
 import pickle
+import logging
 from datetime import datetime
-from emmaa.util import get_s3_client, make_date_str
+
+from indra.assemblers.english import EnglishAssembler
+
 from emmaa.db import get_db
+from emmaa.util import get_s3_client, make_date_str
 
 
 logger = logging.getLogger(__name__)
@@ -81,7 +84,8 @@ class QueryManager(object):
             # NOTE: For now the report is presented in the logs. In future we
             # can choose some other ways to keep track of result changes.
             if find_delta:
-                reports = self.make_reports_from_results(new_results, False, 'str')
+                reports = self.make_reports_from_results(new_results, False,
+                                                         'str')
                 for report in reports:
                     logger.info(report)
             self.db.put_results(model_name, results)
@@ -164,7 +168,7 @@ class QueryManager(object):
 
     def get_user_query_delta(
             self, user_email, filename='query_delta', report_format='str'):
-        """Produce a report for all query results per user in a given format."""
+        """Produce a report for all query results per user in a given format"""
         results = self.db.get_results(user_email, latest_order=1)
         if report_format == 'str':
             filename = filename + '.txt'
@@ -366,7 +370,5 @@ def _process_result_to_str(result_json):
 
 
 def _make_query_str(query):
-    stmt = query.path_stmt
-    subj, obj = stmt.agent_list()
-    parts = [type(stmt).__name__, '(', subj.name, ', ', obj.name, ')']
-    return ''.join(parts)
+    ea = EnglishAssembler([query.path_stmt])
+    return ea.make_model()

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -337,7 +337,21 @@ def format_results(results):
             formatted_results[query_hash][mc_type] = ['Fail', response]
         else:
             formatted_results[query_hash][mc_type] = ['Pass', response]
-    return formatted_results
+
+    model_types = ['pysb', 'pybel', 'signed_graph', 'unsigned_graph']
+    result_array = []
+    for qh, res in formatted_results.values():
+        new_res = [('', res['query'], ''),
+                   (f'/{res['model']}', res['model'],
+                    f'Click to see details about {res['model']}')]
+        if 'n_a' in res:
+            new_res.append('', 'n_a', '')
+        else:
+            for mt in model_types:
+                new_res.append((f'/tests/{model}/{mt}/{qh}', res[mt][0],
+                                'Click to see detailed results for this query'))
+        result_array.append(new_res)
+    return result_array
 
 
 def load_model_manager_from_s3(model_name):

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -310,7 +310,7 @@ def format_results(results):
     #     formatted_result['date'] = make_date_str(result[4])
     #     formatted_results.append(formatted_result)
     # return formatted_results
-
+    model_types = ['pysb', 'pybel', 'signed_graph', 'unsigned_graph']
     formatted_results = {}
     for result in results:
         model = result[0]
@@ -331,25 +331,25 @@ def format_results(results):
                 response.append(v)
         if mc_type == '' and \
                 response == 'Query is not applicable for this model':
-            formatted_results[query_hash]['n_a'] = response
+            for mt in model_types:
+                formatted_results[query_hash][mt] = ['n_a', response]
+        elif isinstance(response, str) and \
+                response == 'Statement type not handled':
+            formatted_results[query_hash][mc_type] = ['n_a', response]
         elif isinstance(response, str) and \
                 not response == 'Path found but exceeds search depth':
             formatted_results[query_hash][mc_type] = ['Fail', response]
         else:
             formatted_results[query_hash][mc_type] = ['Pass', response]
 
-    model_types = ['pysb', 'pybel', 'signed_graph', 'unsigned_graph']
     result_array = []
     for qh, res in formatted_results.items():
         model = res['model']
         new_res = [('', res["query"], ''),
                    (f'/{model}', model, f'Click to see details about {model}')]
-        if 'n_a' in res:
-            new_res.append(('', 'n_a', ''))
-        else:
-            for mt in model_types:
-                new_res.append((f'/tests/{model}/{mt}/{qh}', res[mt][0],
-                                'Click to see detailed results for this query'))
+        for mt in model_types:
+            new_res.append((f'/tests/{model}/{mt}/{qh}', res[mt][0],
+                            'Click to see detailed results for this query'))
         result_array.append(new_res)
     return result_array
 

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -292,7 +292,7 @@ class EmmaaDatabaseManager(object):
     def get_results_from_query(self, query, model_ids, latest_order=1):
         logger.info(f"Got request for results of {query} on {model_ids}.")
         hashes = {query.get_hash_with_model(model_id) for model_id in model_ids}
-        return self.get_results_from_hashes(hashes)
+        return self.get_results_from_hashes(hashes, latest_order=latest_order)
 
     def get_results_from_hashes(self, query_hashes, latest_order=1):
         logger.info(f"Got request for results of queries with hashes "

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -258,9 +258,11 @@ class EmmaaDatabaseManager(object):
         queries : list[emmaa.queries.Query]
             A list of queries retrieved from the database.
         """
-        # TODO: check whether a query is registered or not.
         with self.get_session() as sess:
-            q = sess.query(Query.json).filter(Query.model_id == model_id)
+            q = sess.query(Query.json).filter(
+                Query.model_id == model_id,
+                Query.hash == UserQuery.query_hash,
+                UserQuery.subscription)
             queries = [QueryObject._from_json(q) for q, in q.all()]
         return queries
 

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -292,10 +292,15 @@ class EmmaaDatabaseManager(object):
     def get_results_from_query(self, query, model_ids, latest_order=1):
         logger.info(f"Got request for results of {query} on {model_ids}.")
         hashes = {query.get_hash_with_model(model_id) for model_id in model_ids}
+        return self.get_results_from_hashes(hashes)
+
+    def get_results_from_hashes(self, query_hashes, latest_order=1):
+        logger.info(f"Got request for results of queries with hashes "
+                    f"{query_hashes}")
         with self.get_session() as sess:
             q = (sess.query(Query.model_id, Query.json, Result.mc_type,
                             Result.result_json, Result.date)
-                 .filter(Result.query_hash.in_(hashes),
+                 .filter(Result.query_hash.in_(query_hashes),
                          Query.hash == Result.query_hash))
             results = _make_queries_in_results(q.all())
             results = _weed_results(results, latest_order=latest_order)

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -128,40 +128,6 @@ class ModelManager(object):
         for (stmt, result) in results:
             self.add_result(mc_type, result)
 
-    # def make_english_path(self, mc_type, result):
-    #     """Create an English description of a path."""
-    #     paths = []
-    #     if result.paths:
-    #         for path in result.paths:
-    #             sentences = []
-    #             if mc_type == 'signed_graph' or mc_type == 'unsigned_graph':
-    #                 for i in range(len(path[:-1])):
-    #                     sentence = path[i][0] + ' -> ' + path[i+1][0]
-    #                     sentences.append((sentence, ''))
-    #             else:
-    #                 if mc_type == 'pysb':
-    #                     stmts = stmts_from_pysb_path(
-    #                         path, self.mc_types['pysb']['model'],
-    #                         self.model.assembled_stmts)
-    #                 elif mc_type == 'pybel':
-    #                     stmts = stmts_from_pybel_path(
-    #                         path, self.mc_types['pybel']['model'],
-    #                         from_db=False, stmts=self.model.assembled_stmts)
-    #                 for stmt in stmts:
-    #                     if not stmt:
-    #                         continue
-    #                     if isinstance(stmt, list):
-    #                         stmt = stmt[0]
-    #                     ea = EnglishAssembler([stmt])
-    #                     sentence = ea.make_model()
-    #                     if self.make_links:
-    #                         link = get_statement_queries([stmt])[0] + '&format=html'
-    #                         sentences.append((sentence, link))
-    #                     else:
-    #                         sentences.append((sentence, ''))
-    #             paths.append(sentences)
-    #     return paths
-
     def make_path_json(self, mc_type, result):
         paths = []
         if result.paths:
@@ -251,11 +217,6 @@ class ModelManager(object):
                 else:
                     sentences.append(('', sentence, stmt.evidence[0].text))
         return sentences
-
-    # def make_english_result_code(self, result):
-    #     """Get an English explanation of a result code."""
-    #     result_code = result.result_code
-    #     return [[(RESULT_CODES[result_code], result_codes_link)]]
 
     def make_result_code(self, result):
         result_code = result.result_code

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -128,39 +128,39 @@ class ModelManager(object):
         for (stmt, result) in results:
             self.add_result(mc_type, result)
 
-    def make_english_path(self, mc_type, result):
-        """Create an English description of a path."""
-        paths = []
-        if result.paths:
-            for path in result.paths:
-                sentences = []
-                if mc_type == 'signed_graph' or mc_type == 'unsigned_graph':
-                    for i in range(len(path[:-1])):
-                        sentence = path[i][0] + ' -> ' + path[i+1][0]
-                        sentences.append((sentence, ''))
-                else:
-                    if mc_type == 'pysb':
-                        stmts = stmts_from_pysb_path(
-                            path, self.mc_types['pysb']['model'],
-                            self.model.assembled_stmts)
-                    elif mc_type == 'pybel':
-                        stmts = stmts_from_pybel_path(
-                            path, self.mc_types['pybel']['model'],
-                            from_db=False, stmts=self.model.assembled_stmts)
-                    for stmt in stmts:
-                        if not stmt:
-                            continue
-                        if isinstance(stmt, list):
-                            stmt = stmt[0]
-                        ea = EnglishAssembler([stmt])
-                        sentence = ea.make_model()
-                        if self.make_links:
-                            link = get_statement_queries([stmt])[0] + '&format=html'
-                            sentences.append((sentence, link))
-                        else:
-                            sentences.append((sentence, ''))
-                paths.append(sentences)
-        return paths
+    # def make_english_path(self, mc_type, result):
+    #     """Create an English description of a path."""
+    #     paths = []
+    #     if result.paths:
+    #         for path in result.paths:
+    #             sentences = []
+    #             if mc_type == 'signed_graph' or mc_type == 'unsigned_graph':
+    #                 for i in range(len(path[:-1])):
+    #                     sentence = path[i][0] + ' -> ' + path[i+1][0]
+    #                     sentences.append((sentence, ''))
+    #             else:
+    #                 if mc_type == 'pysb':
+    #                     stmts = stmts_from_pysb_path(
+    #                         path, self.mc_types['pysb']['model'],
+    #                         self.model.assembled_stmts)
+    #                 elif mc_type == 'pybel':
+    #                     stmts = stmts_from_pybel_path(
+    #                         path, self.mc_types['pybel']['model'],
+    #                         from_db=False, stmts=self.model.assembled_stmts)
+    #                 for stmt in stmts:
+    #                     if not stmt:
+    #                         continue
+    #                     if isinstance(stmt, list):
+    #                         stmt = stmt[0]
+    #                     ea = EnglishAssembler([stmt])
+    #                     sentence = ea.make_model()
+    #                     if self.make_links:
+    #                         link = get_statement_queries([stmt])[0] + '&format=html'
+    #                         sentences.append((sentence, link))
+    #                     else:
+    #                         sentences.append((sentence, ''))
+    #             paths.append(sentences)
+    #     return paths
 
     def make_path_json(self, mc_type, result):
         paths = []
@@ -252,10 +252,10 @@ class ModelManager(object):
                     sentences.append(('', sentence, stmt.evidence[0].text))
         return sentences
 
-    def make_english_result_code(self, result):
-        """Get an English explanation of a result code."""
-        result_code = result.result_code
-        return [[(RESULT_CODES[result_code], result_codes_link)]]
+    # def make_english_result_code(self, result):
+    #     """Get an English explanation of a result code."""
+    #     result_code = result.result_code
+    #     return [[(RESULT_CODES[result_code], result_codes_link)]]
 
     def make_result_code(self, result):
         result_code = result.result_code
@@ -273,8 +273,8 @@ class ModelManager(object):
                 results.append((mc_type, self.process_response(mc_type, result)))
             return results
         else:
-            return [('', self.hash_response_list([[
-                (RESULT_CODES['QUERY_NOT_APPLICABLE'], result_codes_link)]]))]
+            return [('', self.hash_response_list(
+                RESULT_CODES['QUERY_NOT_APPLICABLE']))]
 
     def answer_queries(self, queries):
         """Answer all queries registered for this model.
@@ -300,8 +300,7 @@ class ModelManager(object):
             else:
                 responses.append(
                     (query, '', self.hash_response_list(
-                        [[(RESULT_CODES['QUERY_NOT_APPLICABLE'],
-                          result_codes_link)]])))
+                        RESULT_CODES['QUERY_NOT_APPLICABLE'])))
         # Only do the following steps if there are applicable queries
         if applicable_queries:
             for mc_type in self.mc_types:
@@ -336,23 +335,30 @@ class ModelManager(object):
         sentence.
         """
         if result.paths:
-            response_list = self.make_english_path(mc_type, result)
+            response = self.make_path_json(mc_type, result)
         else:
-            response_list = self.make_english_result_code(result)
-        return self.hash_response_list(response_list)
+            response = self.make_result_code(result)
+        return self.hash_response_list(response)
 
-    def hash_response_list(self, response_list):
+    def hash_response_list(self, response):
         """Return a dictionary mapping a hash with a response in a response
         list.
         """
         response_dict = {}
-        for response in response_list:
-            sentences = []
-            for sentence, _ in response:
-                sentences.append(sentence)
-            response_str = ' '.join(sentences)
-            response_hash = str(fnv1a_32(response_str.encode('utf-8')))
+        if isinstance(response, str):
+            response_hash = str(fnv1a_32(response.encode('utf-8')))
             response_dict[response_hash] = response
+        elif isinstance(response, list):
+            for resp in response:
+                sentences = []
+                for edge in resp['edge_list']:
+                    for (_, sentence, _) in edge['stmts']:
+                        sentences.append(sentence)
+                response_str = ' '.join(sentences)
+                response_hash = str(fnv1a_32(response_str.encode('utf-8')))
+                response_dict[response_hash] = resp
+        else:
+            raise TypeError('Response should be a string or a list.')
         return response_dict
 
     def assembled_stmts_to_json(self):

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -29,10 +29,6 @@ test_response = {
              'stmts': [
                  ['https://db.indra.bio/statements/from_agents?subject=6840@HGNC&object=6871@HGNC&type=Activation&format=html',
                   'Active MAP2K1 activates MAPK1.', '']]}]}}
-processed_link = '<a href="https://db.indra.bio/statements/from_agents?'\
-    'subject=1097@HGNC&object=6840@HGNC&type=Activation&format=html" '\
-                 'target="_blank" class="status-link">'\
-                 'BRAF activates MAP2K1.</a>'
 query_not_appl = {'2413475507': 'Query is not applicable for this model'}
 fail_response = {'521653329': 'No path found that satisfies the test statement'}
 # Create a new ModelManager for tests instead of depending on S3 version

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -14,7 +14,7 @@ test_query = {'type': 'path_property', 'path': {'type': 'Activation',
                        'db_refs': {'HGNC': '1097'}},
               'obj': {'type': 'Agent', 'name': 'MAPK1',
                       'db_refs': {'HGNC': '6871'}}}}
-simple_query = 'Activation(BRAF, MAPK1)'
+simple_query = 'BRAF activates MAPK1.'
 query_object = Query._from_json(test_query)
 
 test_response = {

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -14,25 +14,27 @@ test_query = {'type': 'path_property', 'path': {'type': 'Activation',
                        'db_refs': {'HGNC': '1097'}},
               'obj': {'type': 'Agent', 'name': 'MAPK1',
                       'db_refs': {'HGNC': '6871'}}}}
-simple_query = {'typeSelection': 'Activation',
-                'subjectSelection': 'BRAF',
-                'objectSelection': 'MAPK1'}
+simple_query = 'Activation(BRAF, MAPK1)'
 query_object = Query._from_json(test_query)
 
-test_response = {3801854542: [
-    ('BRAF activates MAP2K1.',
-     'https://db.indra.bio/statements/from_agents?subject=1097@HGNC&object='
-     '6840@HGNC&type=Activation&format=html'),
-    ('Active MAP2K1 activates MAPK1.',
-     'https://db.indra.bio/statements/from_agents?subject=6840@HGNC&object='
-     '6871@HGNC&type=Activation&format=html')]}
+test_response = {
+    '3801854542': {
+        'path': 'BRAF → MAP2K1 → MAPK1',
+        'edge_list': [
+            {'edge': 'BRAF → MAP2K1',
+             'stmts': [
+                 ['https://db.indra.bio/statements/from_agents?subject=1097@HGNC&object=6840@HGNC&type=Activation&format=html',
+                  'BRAF activates MAP2K1.', '']]},
+            {'edge': 'MAP2K1 → MAPK1',
+             'stmts': [
+                 ['https://db.indra.bio/statements/from_agents?subject=6840@HGNC&object=6871@HGNC&type=Activation&format=html',
+                  'Active MAP2K1 activates MAPK1.', '']]}]}}
 processed_link = '<a href="https://db.indra.bio/statements/from_agents?'\
     'subject=1097@HGNC&object=6840@HGNC&type=Activation&format=html" '\
                  'target="_blank" class="status-link">'\
                  'BRAF activates MAP2K1.</a>'
-query_not_appl = {2413475507: [
-    ('Query is not applicable for this model',
-     'https://emmaa.readthedocs.io/en/latest/dashboard/response_codes.html')]}
+query_not_appl = {'2413475507': 'Query is not applicable for this model'}
+fail_response = {'521653329': 'No path found that satisfies the test statement'}
 # Create a new ModelManager for tests instead of depending on S3 version
 test_model = EmmaaModel.load_from_s3('test')
 test_mm = ModelManager(test_model)
@@ -44,29 +46,45 @@ def test_load_model_manager_from_s3():
 
 
 def test_format_results():
-    results = [('test', query_object, 'pysb', test_response, datetime.now())]
+    date = datetime.now()
+    results = [('test', query_object, 'pysb', test_response, date),
+               ('test', query_object, 'signed_graph', fail_response, date),
+               ('test', query_object, 'unsigned_graph', test_response, date)]
     formatted_results = format_results(results)
     assert len(formatted_results) == 1
-    assert formatted_results[0]['model'] == 'test'
-    assert formatted_results[0]['query'] == simple_query
-    assert formatted_results[0]['mc_type'] == 'pysb'
-    assert isinstance(formatted_results[0]['response'], str)
-    assert isinstance(formatted_results[0]['date'], str)
+    qh = query_object.get_hash_with_model('test')
+    assert qh in formatted_results
+    assert formatted_results[qh]['model'] == 'test'
+    assert formatted_results[qh]['query'] == simple_query
+    assert isinstance(formatted_results[qh]['date'], str)
+    assert formatted_results[qh]['pysb'] == [
+        'Pass', [test_response['3801854542']]]
+    assert formatted_results[qh]['pybel'] == [
+        'n_a', 'Model type not supported']
+    assert formatted_results[qh]['signed_graph'] == [
+        'Fail', fail_response['521653329']]
+    assert formatted_results[qh]['unsigned_graph'] == [
+        'Pass', [test_response['3801854542']]]
 
 
 @attr('nonpublic')
 def test_answer_immediate_query():
     db = _get_test_db()
     qm = QueryManager(db=db, model_managers=[test_mm])
-    results = qm.answer_immediate_query('tester@test.com', 1, query_object,
-                                        ['test'], subscribe=False)
+    query_hashes = qm.answer_immediate_query('tester@test.com', 1, query_object,
+                                             ['test'], subscribe=False)
+    assert query_hashes == [-4326204908289564]
+    results = qm.retrieve_results_from_hashes(query_hashes)
     assert len(results) == 1
-    assert results[0]['model'] == 'test'
-    assert results[0]['query'] == simple_query
-    assert isinstance(results[0]['response'], str)
-    assert 'BRAF activates MAP2K1.' in results[0]['response'], \
-        results[0]['response']
-    assert isinstance(results[0]['date'], str)
+    assert query_hashes[0] in results
+    result_values = results[query_hashes[0]]
+    assert result_values['model'] == 'test'
+    assert result_values['query'] == simple_query
+    assert isinstance(result_values['date'], str)
+    assert result_values['pysb'] == ['Pass', [test_response['3801854542']]]
+    assert result_values['pybel'] == ['n_a', 'Model type not supported']
+    assert result_values['signed_graph'] == ['n_a', 'Model type not supported']
+    assert result_values['unsigned_graph'] == ['n_a', 'Model type not supported']
 
 
 @attr('nonpublic')
@@ -77,13 +95,16 @@ def test_answer_get_registered_queries():
                       subscribe=True)
     qm.answer_registered_queries('test')
     results = qm.get_registered_queries('tester@test.com')
+    qh = query_object.get_hash_with_model('test')
+    assert qh in results
     assert len(results) == 1
-    assert results[0]['model'] == 'test'
-    assert results[0]['query'] == simple_query
-    assert isinstance(results[0]['response'], str)
-    assert 'BRAF activates MAP2K1.' in results[0]['response'], \
-        results[0]['response']
-    assert isinstance(results[0]['date'], str)
+    assert results[qh]['model'] == 'test'
+    assert results[qh]['query'] == simple_query
+    assert isinstance(results[qh]['date'], str)
+    assert results[qh]['pysb'] == ['Pass', [test_response['3801854542']]]
+    assert results[qh]['pybel'] == ['n_a', 'Model type not supported']
+    assert results[qh]['signed_graph'] == ['n_a', 'Model type not supported']
+    assert results[qh]['unsigned_graph'] == ['n_a', 'Model type not supported']
 
 
 def test_is_diff():
@@ -104,21 +125,20 @@ def test_report_one_query():
     assert str_msg
     assert 'A new result to query' in str_msg
     assert 'Query is not applicable for this model' in str_msg
-    assert 'BRAF activates MAP2K1.' in str_msg
+    assert 'BRAF → MAP2K1 → MAPK1' in str_msg
     # String report given two responses explicitly
     str_msg = qm.make_str_report_one_query(
         'test', query_object, 'pysb', test_response, query_not_appl)
     assert str_msg
     assert 'A new result to query' in str_msg, str_msg
     assert 'Query is not applicable for this model' in str_msg
-    assert 'BRAF activates MAP2K1.' in str_msg
+    assert 'BRAF → MAP2K1 → MAPK1' in str_msg
     # Html report given two responses explicitly
     html_msg = qm.make_html_one_query_report(
         'test', query_object, 'pysb', test_response, query_not_appl)
     assert html_msg
     assert 'A new result to query' in html_msg
     assert 'Query is not applicable for this model' in html_msg
-    assert processed_link in html_msg
 
 
 @attr('nonpublic')
@@ -147,4 +167,4 @@ def test_report_files():
         msg = f.read()
     assert msg
     assert 'A new result to query' in msg
-    assert 'BRAF activates MAP2K1.' in msg
+    assert 'BRAF → MAP2K1 → MAPK1' in msg

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -390,7 +390,7 @@ def get_query_page():
         if sub_res:
             subscribed_results = _format_query_results(sub_res)
             subscribed_headers = \
-                ['Model', 'Query'] + \
+                ['Query', 'Model'] + \
                 [FORMATTED_TYPE_NAMES[mt] for mt in list(sub_res.values())[0]
                  if mt in ALL_MODEL_TYPES]
         else:

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -367,8 +367,14 @@ def get_query_page():
         immediate_table_headers = None
     # Subscribed results
     # user_email = 'joshua@emmaa.com'
-    subscribed_results = qm.get_registered_queries(user_email)\
-        if user_email else {}
+    if user_email:
+        sub_res = qm.get_registered_queries(user_email)
+        if sub_res:
+            subscribed_results = _format_query_results(sub_res)
+        else:
+            subscribed_results = 'You have no subscribed queries'
+    else:
+        subscribed_results = 'Please log in to see your subscribed queries'
     subscribed_headers =\
         ['Model', 'Query'] + \
         [mt for mt in list(subscribed_results.values())[0]
@@ -377,7 +383,7 @@ def get_query_page():
                            immediate_table_headers=immediate_table_headers,
                            model_data=model_meta_data,
                            stmt_types=stmt_types,
-                           subscribed_results=_format_query_results(subscribed_results),
+                           subscribed_results=subscribed_results,
                            subscribed_headers=subscribed_headers,
                            link_list=link_list,
                            user_email=user_email)

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -28,7 +28,7 @@ app = Flask(__name__)
 app.register_blueprint(auth)
 app.register_blueprint(path_temps)
 app.config['DEBUG'] = True
-app.config['SECRET_KEY'] = os.environ['EMMAA_SERVICE_SESSION_KEY']
+app.config['SECRET_KEY'] = os.environ.get('EMMAA_SERVICE_SESSION_KEY', '')
 logger = logging.getLogger(__name__)
 
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -372,9 +372,9 @@ def get_query_page():
     if session.get('query_hashes'):
         queried_hashes = session['query_hashes']
         qr = qm.retrieve_results_from_hashes(queried_hashes)
-        immediate_table_headers = ['Query', 'Model'] + \
-                                  [mt for mt in ALL_MODEL_TYPES if mt in
-                                   list(qr.values())[0]]
+        immediate_table_headers = ['Query', 'Model'] + [
+            FORMATTED_TYPE_NAMES[mt] for mt in ALL_MODEL_TYPES if mt in
+            list(qr.values())[0]]
         queried_results = _format_query_results(qr)
     else:
         queried_results = 'Results for submitted queries'
@@ -389,7 +389,7 @@ def get_query_page():
             subscribed_results = _format_query_results(sub_res)
             subscribed_headers = \
                 ['Model', 'Query'] + \
-                [mt for mt in list(sub_res.values())[0]
+                [FORMATTED_TYPE_NAMES[mt] for mt in list(sub_res.values())[0]
                  if mt in ALL_MODEL_TYPES]
         else:
             subscribed_results = 'You have no subscribed queries'

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -10,7 +10,6 @@ from flask import abort, Flask, request, Response, render_template, jsonify,\
     session
 from flask_jwt_extended import jwt_optional
 
-from indra.config import CONFIG_DICT
 from indra.statements import get_all_descendants, IncreaseAmount, \
     DecreaseAmount, Activation, Inhibition, AddModification, \
     RemoveModification, get_statement_by_name

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -367,14 +367,21 @@ def get_query_page():
         immediate_table_headers = None
     # Subscribed results
     # user_email = 'joshua@emmaa.com'
-    old_results = qm.get_registered_queries(user_email) if user_email else []
+    subscribed_results = qm.get_registered_queries(user_email)\
+        if user_email else {}
+    subscribed_headers =\
+        ['Model', 'Query'] + \
+        [mt for mt in list(subscribed_results.values())[0]
+         if mt in ALL_MODEL_TYPES] if subscribed_results else []
     return render_template('query_template.html',
                            immediate_table_headers=immediate_table_headers,
                            model_data=model_meta_data,
                            stmt_types=stmt_types,
-                           old_results=old_results,
+                           subscribed_results=_format_query_results(subscribed_results),
+                           subscribed_headers=subscribed_headers,
                            link_list=link_list,
                            user_email=user_email)
+
 
 @app.route('/query/<model>/<model_type>/<query_hash>')
 def get_query_tests_page(model, model_type, query_hash):

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -217,7 +217,7 @@ def _format_query_results(formatted_results):
                    (f'/dashboard/{model}', model,
                     f'Click to see details about {model}')]
         for mt in model_types:
-            new_res.append((f'/tests/{model}/{mt}/{qh}', res[mt][0],
+            new_res.append((f'/query/{model}/{mt}/{qh}', res[mt][0],
                             'Click to see detailed results for this query'))
         result_array.append(new_res)
     return result_array

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -215,7 +215,8 @@ def _format_query_results(formatted_results):
         model_types = [mt for mt in ALL_MODEL_TYPES if mt in res]
         model = res['model']
         new_res = [('', res["query"], ''),
-                   (f'/{model}', model, f'Click to see details about {model}')]
+                   (f'/dashboard/{model}', model,
+                    f'Click to see details about {model}')]
         for mt in model_types:
             new_res.append((f'/tests/{model}/{mt}/{qh}', res[mt][0],
                             'Click to see detailed results for this query'))

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -367,18 +367,19 @@ def get_query_page():
         immediate_table_headers = None
     # Subscribed results
     # user_email = 'joshua@emmaa.com'
+    subscribed_headers = []
     if user_email:
         sub_res = qm.get_registered_queries(user_email)
         if sub_res:
             subscribed_results = _format_query_results(sub_res)
+            subscribed_headers = \
+                ['Model', 'Query'] + \
+                [mt for mt in list(sub_res.values())[0]
+                 if mt in ALL_MODEL_TYPES]
         else:
             subscribed_results = 'You have no subscribed queries'
     else:
         subscribed_results = 'Please log in to see your subscribed queries'
-    subscribed_headers =\
-        ['Model', 'Query'] + \
-        [mt for mt in list(subscribed_results.values())[0]
-         if mt in ALL_MODEL_TYPES] if subscribed_results else []
     return render_template('query_template.html',
                            immediate_table_headers=immediate_table_headers,
                            model_data=model_meta_data,

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -3,7 +3,6 @@ import json
 import boto3
 import logging
 import argparse
-from urllib import parse
 from botocore.exceptions import ClientError
 from flask import abort, Flask, request, Response, render_template, jsonify,\
     session
@@ -270,7 +269,6 @@ def get_home():
 def get_model_dashboard(model):
     user, roles = resolve_auth(dict(request.args))
     model_meta_data = _get_model_meta_data()
-    mod_link_list = [('.' + t[0], t[1]) for t in link_list]
 
     last_update = model_last_updated(model=model)
     ndex_id = 'None available'
@@ -333,7 +331,6 @@ def get_model_dashboard(model):
 def get_model_tests_page(model, model_type, test_hash):
     if model_type not in ALL_MODEL_TYPES:
         abort(Response(f'Model type {model_type} does not exist', 404))
-    mod_link_list = [('../../../.' + t[0], t[1]) for t in link_list]
     model_stats = get_model_stats(model)
     current_test = \
         model_stats['test_round_summary']['all_test_results'][test_hash]

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -363,6 +363,12 @@ def get_query_page():
 
     # user_email = 'joshua@emmaa.com'
     old_results = qm.get_registered_queries(user_email) if user_email else []
+    return render_template('query_template.html',
+                           model_data=model_meta_data,
+                           stmt_types=stmt_types,
+                           old_results=old_results,
+                           link_list=link_list,
+                           user_email=user_email)
 
 @app.route('/query/<model>/<model_type>/<query_hash>')
 def get_query_tests_page(model, model_type, query_hash):

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -399,16 +399,21 @@ def get_query_page():
 
 @app.route('/query/<model>/<model_type>/<query_hash>')
 def get_query_tests_page(model, model_type, query_hash):
-    queried_hashes = session['query_hashes']
+    query_hash = int(query_hash)
+    queried_hashes = [int(h) for h in session['query_hashes']]\
+        if query_hash in session.get('query_hashes', []) else []
     results = qm.retrieve_results_from_hashes(queried_hashes)
-    detailed_results = results[query_hash][model_type]
+    detailed_results = results[query_hash][model_type]\
+        if results else ['query', f'{query_hash}']
+    card_title = ('', results[query_hash]['query'] if results else '', '')
     return render_template('tests_template.html',
                            link_list=link_list,
                            model=model,
                            model_type=model_type,
                            all_model_types=ALL_MODEL_TYPES,
                            test_hash=query_hash,
-                           test=('', results[query_hash]['query'], 'No link'),
+                           test=card_title,
+                           is_query_page=True,
                            test_status=detailed_results[0],
                            path_list=detailed_results[1],
                            formatted_names=FORMATTED_TYPE_NAMES)

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -374,8 +374,10 @@ def get_query_page():
         qr = qm.retrieve_results_from_hashes(queried_hashes)
         immediate_table_headers = ['Query', 'Model'] + [
             FORMATTED_TYPE_NAMES[mt] for mt in ALL_MODEL_TYPES if mt in
-            list(qr.values())[0]]
-        queried_results = _format_query_results(qr)
+            list(qr.values())[0]] if qr else []
+        queried_results = _format_query_results(qr) if qr else\
+            'No stashed results for subscribed queries. Please re-run query ' \
+            'to see latest result.'
     else:
         queried_results = 'Results for submitted queries'
         immediate_table_headers = None

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -3,6 +3,7 @@ import json
 import boto3
 import logging
 import argparse
+from datetime import timedelta
 from botocore.exceptions import ClientError
 from flask import abort, Flask, request, Response, render_template, jsonify,\
     session
@@ -251,6 +252,14 @@ def _new_passed_tests(model_name, model_stats_json, current_model_types):
     if len(new_passed_tests) > 0:
         return new_passed_tests
     return 'No new tests were passed'
+
+
+# Deletes session after the specified time
+@app.before_request
+def session_expiration_check():
+    session.permanent = True
+    session.modified = True
+    app.permanent_session_lifetime = timedelta(minutes=10)
 
 
 @app.route('/')

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -1,3 +1,4 @@
+import os
 import re
 import json
 import boto3
@@ -27,7 +28,7 @@ app = Flask(__name__)
 app.register_blueprint(auth)
 app.register_blueprint(path_temps)
 app.config['DEBUG'] = True
-app.config['SECRET_KEY'] = CONFIG_DICT['EMMAA_SERVICE_SESSION_KEY']
+app.config['SECRET_KEY'] = os.environ['EMMAA_SERVICE_SESSION_KEY']
 logger = logging.getLogger(__name__)
 
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -399,16 +399,16 @@ def get_query_page():
 
 @app.route('/query/<model>/<model_type>/<query_hash>')
 def get_query_tests_page(model, model_type, query_hash):
-    raw_query_json = session['raw_query_result']
-    detailed_results = raw_query_json[query_hash][model_type]
+    queried_hashes = session['query_hashes']
+    results = qm.retrieve_results_from_hashes(queried_hashes)
+    detailed_results = results[query_hash][model_type]
     return render_template('tests_template.html',
                            link_list=link_list,
                            model=model,
                            model_type=model_type,
                            all_model_types=ALL_MODEL_TYPES,
                            test_hash=query_hash,
-                           model_stats_json=raw_query_json,
-                           test=('', raw_query_json['query'], 'No link'),
+                           test=('', results[query_hash]['query'], 'No link'),
                            test_status=detailed_results[0],
                            path_list=detailed_results[1],
                            formatted_names=FORMATTED_TYPE_NAMES)

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -33,8 +33,8 @@ EMMAA_BUCKET_NAME = 'emmaa'
 ALL_MODEL_TYPES = ['pysb', 'pybel', 'signed_graph', 'unsigned_graph']
 LINKAGE_SYMBOLS = {'LEFT TACK': '\u22a3',
                    'RIGHTWARDS ARROW': '\u2192'}
-link_list = [('./home', 'EMMAA Dashboard'),
-             ('./query', 'Queries')]
+link_list = [('/home', 'EMMAA Dashboard'),
+             ('/query', 'Queries')]
 pass_fail_msg = 'Click to see detailed results for this test'
 stmt_db_link_msg = 'Click to see the evidence for this statement'
 SC, jwt = config_auth(app)
@@ -291,7 +291,7 @@ def get_model_dashboard(model):
                            model=model,
                            model_data=model_meta_data,
                            model_stats_json=model_stats,
-                           link_list=mod_link_list,
+                           link_list=link_list,
                            user_email=user.email if user else "",
                            stmts_counts=top_stmts_counts,
                            added_stmts=added_stmts,
@@ -324,7 +324,7 @@ def get_model_tests_page(model, model_type, test_hash):
     test = current_test["test"]
     test_status, path_list = current_test[model_type]
     return render_template('tests_template.html',
-                           link_list=mod_link_list,
+                           link_list=link_list,
                            model=model,
                            model_type=model_type,
                            all_model_types=current_model_types,

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -410,9 +410,7 @@ def get_query_page():
 @app.route('/query/<model>/<model_type>/<query_hash>')
 def get_query_tests_page(model, model_type, query_hash):
     query_hash = int(query_hash)
-    queried_hashes = [int(h) for h in session['query_hashes']]\
-        if query_hash in session.get('query_hashes', []) else []
-    results = qm.retrieve_results_from_hashes(queried_hashes)
+    results = qm.retrieve_results_from_hashes([query_hash])
     detailed_results = results[query_hash][model_type]\
         if results else ['query', f'{query_hash}']
     card_title = ('', results[query_hash]['query'] if results else '', '')

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -361,9 +361,17 @@ def get_query_page():
     model_meta_data = _get_model_meta_data()
     stmt_types = get_queryable_stmt_types()
 
+    if session.get('raw_query_result'):
+        res = list(session['raw_query_result'].values())[0]
+        immediate_table_headers =\
+            ['Query', 'Model', *[mt for mt in ALL_MODEL_TYPES if mt in res]]
+    else:
+        immediate_table_headers = None
+    # Subscribed results
     # user_email = 'joshua@emmaa.com'
     old_results = qm.get_registered_queries(user_email) if user_email else []
     return render_template('query_template.html',
+                           immediate_table_headers=immediate_table_headers,
                            model_data=model_meta_data,
                            stmt_types=stmt_types,
                            old_results=old_results,

--- a/emmaa_service/static/queryFunctions.js
+++ b/emmaa_service/static/queryFunctions.js
@@ -85,7 +85,10 @@ function submitQuery(queryDict, test) {
         case 200:
           console.log('200 response');
           queryNotify('Query resolved');
-          populateQueryResults(xhr.responseJSON);
+          if (xhr.responseJSON.redirectURL) {
+            window.location.replace(xhr.responseJSON.redirectURL);
+          }
+          // populateQueryResults(xhr.responseJSON);
           break;
         case 400:
           console.log('400 response');

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -69,7 +69,7 @@
     }
     .fa-check {color: #00ff00}
     .fa-times {color: #ff0000}
-    .fa-ban {color: #dddddd}
+    .fa-ban {color: #a5a5a5}
     .nav-tabs .nav-item.show .nav-link, .nav-tabs .nav-link.active {background-color: #f8f9fa}
   </style>
 </head>

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -67,6 +67,10 @@
     button.btn-primary { /* For login button */
       background-color: #007bff;
     }
+    .fa-check {color: #00ff00}
+    .fa-times {color: #ff0000}
+    .fa-ban {color: #dddddd}
+    .nav-tabs .nav-item.show .nav-link, .nav-tabs .nav-link.active {background-color: #f8f9fa}
   </style>
 </head>
 

--- a/emmaa_service/templates/index_template.html
+++ b/emmaa_service/templates/index_template.html
@@ -14,7 +14,7 @@
              alt="Thumbnail [100%x225]"
              src="https://s3.amazonaws.com/emmaa/models/{{ model_id }}/{{ model_id }}_image.png"
              data-holder-rendered="true"
-             style="height: 225px; width: 100%; display: block;">
+             style="height: 225px; width: 100%; display: block; padding: 1px;">
         <div class="card-body">
           <p class="card-text">{{ model_meta['description'] }}</p>
           <div class="d-flex justify-content-between align-items-center">

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -16,16 +16,6 @@
   });
 </script>
 <style>
-  .fa-check {color: #00ff00}
-  .fa-times {color: #ff0000}
-  .nav-tabs .nav-item.show .nav-link, .nav-tabs .nav-link.active {background-color: #f8f9fa}
-  a.stmt-dblink {
-    color: #000000;
-    text-decoration: none;
-  }
-  a {
-    target-new: tab;
-  }
   body > .container {
     padding: 85px 15px 0;
   }

--- a/emmaa_service/templates/query_template.html
+++ b/emmaa_service/templates/query_template.html
@@ -98,9 +98,7 @@
 
 <!-- Query results -->
 <div class="container">
-{% if session['immediate_query_result'] %}
-  {{ path_card(session['immediate_query_result'], 'Query Results', 'query-results', immediate_table_headers, 'queryResults') }}
-{% endif %}
+{{ path_card(immediate_query_result, 'Query Results', 'query-results', immediate_table_headers, 'queryResults') }}
 </div>
 <!-- List user queries -->
 <div class="container">

--- a/emmaa_service/templates/query_template.html
+++ b/emmaa_service/templates/query_template.html
@@ -105,7 +105,7 @@
 <!-- List user queries -->
 <div class="container">
 {% if subscribed_results %}
-  {{ path_card(subscribed_results, 'Subscribed Queries', 'user-queries', subscribed_headers=[], table_id=None, merge=false) }}
+  {{ path_card(subscribed_results, 'Subscribed Queries', 'user-queries', subscribed_headers, 'old-results') }}
 {% endif %}
 </div>
 {% endblock %}

--- a/emmaa_service/templates/query_template.html
+++ b/emmaa_service/templates/query_template.html
@@ -104,38 +104,9 @@
 </div>
 <!-- List user queries -->
 <div class="container">
-  {% if old_results %}
-    {{ path_card(old_results, 'Subscribed Queries', 'user-queries', table_headers=[], table_id=None, merge=false) }}
-  {% endif %}
+{% if old_results %}
+  {{ path_card(old_results, 'Subscribed Queries', 'user-queries', table_headers=[], table_id=None, merge=false) }}
+{% endif %}
 </div>
-{#  <div class="card">#}
-{#    <div class="card-header">#}
-{#      <h4 class="my-0 font-weight-normal">Subscribed Queries</h4>#}
-{#    </div>#}
-{#    <div class="card-body" id="user-queries">#}
-{#      <table class="table">#}
-{#        <thead>#}
-{#          <th>Model</th>#}
-{#          <th style="width: 29%;">Query</th>#}
-{#          <th>Model Type</th>#}
-{#          <th>Path Found or Result Code</th>#}
-{#          <th style="width: 19%;">Date</th>#}
-{#        </thead>#}
-{#        <tbody class="table-body" id="old-results">#}
-{#          {% for result in old_results %}#}
-{#          <tr>#}
-{#            <!-- model, query, response, date -->#}
-{#            <td><a class="model-link" href="./dashboard/{{ result['model'] }}">{{ result['model'] }}</a></td>#}
-{#            <td>{{ result['query']['typeSelection'] }}({{ result['query']['subjectSelection'] }}, {{ result['query']['objectSelection'] }})</td>#}
-{#            <td>{{ result['model_type_name'] }}</td>#}
-{#            <td>{{ result['response']|safe }}</td>#}
-{#            <td>{{ result['date'] }}</td>#}
-{#          </tr>#}
-{#          {% endfor %}#}
-{#        </tbody>#}
-{#      </table>#}
-{#    </div>#}
-{#  </div>#}
-
 {% endblock %}
 

--- a/emmaa_service/templates/query_template.html
+++ b/emmaa_service/templates/query_template.html
@@ -101,33 +101,6 @@
 {% if session['immediate_query_result'] %}
   {{ path_card(session['immediate_query_result'], 'Query Results', 'query-results', immediate_table_headers, 'queryResults') }}
 {% endif %}
-{#  <div class="card">#}
-{#    <div class="card-header">#}
-{#      <h4 class="my-0 font-weight-normal">Results</h4>#}
-{#    </div>#}
-{#    <div class="card-body" id="query-results">#}
-{#    {% if session['immediate_query_result'] %}#}
-{#      <table class="table">#}
-{#        <thead>#}
-{#          <th>Model</th>#}
-{#          <th>Model Type</th>#}
-{#          <th>Result</th>#}
-{#        </thead>#}
-{#        <tbody class="table-body" id="queryResults">#}
-{#          {% for res in session['immediate_query_result'] %}#}
-{#            <tr>#}
-{#              <td>{{ res['model'] }}</td>#}
-{#              <td>{{ res['model_type_name'] }}</td>#}
-{#              <td>{{ res['response']|safe }}</td>#}
-{#            </tr>#}
-{#          {% endfor %}#}
-{#        </tbody>#}
-{#      </table>#}
-{#    {% else %}#}
-{#      <i>No query response</i>#}
-{#    {% endif %}#}
-{#    </div>#}
-{#  </div>#}
 </div>
 <!-- List user queries -->
 <div class="container">

--- a/emmaa_service/templates/query_template.html
+++ b/emmaa_service/templates/query_template.html
@@ -104,34 +104,38 @@
 </div>
 <!-- List user queries -->
 <div class="container">
-  <div class="card">
-    <div class="card-header">
-      <h4 class="my-0 font-weight-normal">Subscribed Queries</h4>
-    </div>
-    <div class="card-body" id="user-queries">
-      <table class="table">
-        <thead>
-          <th>Model</th>
-          <th style="width: 29%;">Query</th>
-          <th>Model Type</th>
-          <th>Path Found or Result Code</th>
-          <th style="width: 19%;">Date</th>
-        </thead>
-        <tbody class="table-body" id="old-results">
-          {% for result in old_results %}
-          <tr>
-            <!-- model, query, response, date -->
-            <td><a class="model-link" href="./dashboard/{{ result['model'] }}">{{ result['model'] }}</a></td>
-            <td>{{ result['query']['typeSelection'] }}({{ result['query']['subjectSelection'] }}, {{ result['query']['objectSelection'] }})</td>
-            <td>{{ result['model_type_name'] }}</td>
-            <td>{{ result['response']|safe }}</td>
-            <td>{{ result['date'] }}</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  </div>
+  {% if old_results %}
+    {{ path_card(old_results, 'Subscribed Queries', 'user-queries', table_headers=[], table_id=None, merge=false) }}
+  {% endif %}
 </div>
+{#  <div class="card">#}
+{#    <div class="card-header">#}
+{#      <h4 class="my-0 font-weight-normal">Subscribed Queries</h4>#}
+{#    </div>#}
+{#    <div class="card-body" id="user-queries">#}
+{#      <table class="table">#}
+{#        <thead>#}
+{#          <th>Model</th>#}
+{#          <th style="width: 29%;">Query</th>#}
+{#          <th>Model Type</th>#}
+{#          <th>Path Found or Result Code</th>#}
+{#          <th style="width: 19%;">Date</th>#}
+{#        </thead>#}
+{#        <tbody class="table-body" id="old-results">#}
+{#          {% for result in old_results %}#}
+{#          <tr>#}
+{#            <!-- model, query, response, date -->#}
+{#            <td><a class="model-link" href="./dashboard/{{ result['model'] }}">{{ result['model'] }}</a></td>#}
+{#            <td>{{ result['query']['typeSelection'] }}({{ result['query']['subjectSelection'] }}, {{ result['query']['objectSelection'] }})</td>#}
+{#            <td>{{ result['model_type_name'] }}</td>#}
+{#            <td>{{ result['response']|safe }}</td>#}
+{#            <td>{{ result['date'] }}</td>#}
+{#          </tr>#}
+{#          {% endfor %}#}
+{#        </tbody>#}
+{#      </table>#}
+{#    </div>#}
+{#  </div>#}
+
 {% endblock %}
 

--- a/emmaa_service/templates/query_template.html
+++ b/emmaa_service/templates/query_template.html
@@ -104,9 +104,7 @@
 </div>
 <!-- List user queries -->
 <div class="container">
-{% if subscribed_results %}
-  {{ path_card(subscribed_results, 'Subscribed Queries', 'user-queries', subscribed_headers, 'old-results') }}
-{% endif %}
+{{ path_card(subscribed_results, 'Subscribed Queries', 'user-queries', subscribed_headers, 'old-results') }}
 </div>
 {% endblock %}
 

--- a/emmaa_service/templates/query_template.html
+++ b/emmaa_service/templates/query_template.html
@@ -1,4 +1,5 @@
 {% extends "emmaa_page_template.html" %}
+{% from "path_macros.html" import path_card %}
 
 {% block additional_scripts %}
   <script src="{{ url_for('static', filename='queryFunctions.js') }}"></script>
@@ -97,23 +98,37 @@
 
 <!-- Query results -->
 <div class="container">
-  <div class="card">
-    <div class="card-header">
-      <h4 class="my-0 font-weight-normal">Results</h4>
-    </div>
-    <div class="card-body" id="query-results">
-      <table class="table">
-        <thead>
-          <th>Model</th>
-          <th>Model Type</th>
-          <th>Result</th>
-        </thead>
-        <tbody class="table-body" id="queryResults"></tbody>
-      </table>
-    </div>
-  </div>
+{% if session['immediate_query_result'] %}
+  {{ path_card(session['immediate_query_result'], 'Query Results', 'query-results', immediate_table_headers, 'queryResults') }}
+{% endif %}
+{#  <div class="card">#}
+{#    <div class="card-header">#}
+{#      <h4 class="my-0 font-weight-normal">Results</h4>#}
+{#    </div>#}
+{#    <div class="card-body" id="query-results">#}
+{#    {% if session['immediate_query_result'] %}#}
+{#      <table class="table">#}
+{#        <thead>#}
+{#          <th>Model</th>#}
+{#          <th>Model Type</th>#}
+{#          <th>Result</th>#}
+{#        </thead>#}
+{#        <tbody class="table-body" id="queryResults">#}
+{#          {% for res in session['immediate_query_result'] %}#}
+{#            <tr>#}
+{#              <td>{{ res['model'] }}</td>#}
+{#              <td>{{ res['model_type_name'] }}</td>#}
+{#              <td>{{ res['response']|safe }}</td>#}
+{#            </tr>#}
+{#          {% endfor %}#}
+{#        </tbody>#}
+{#      </table>#}
+{#    {% else %}#}
+{#      <i>No query response</i>#}
+{#    {% endif %}#}
+{#    </div>#}
+{#  </div>#}
 </div>
-
 <!-- List user queries -->
 <div class="container">
   <div class="card">

--- a/emmaa_service/templates/query_template.html
+++ b/emmaa_service/templates/query_template.html
@@ -104,8 +104,8 @@
 </div>
 <!-- List user queries -->
 <div class="container">
-{% if old_results %}
-  {{ path_card(old_results, 'Subscribed Queries', 'user-queries', table_headers=[], table_id=None, merge=false) }}
+{% if subscribed_results %}
+  {{ path_card(subscribed_results, 'Subscribed Queries', 'user-queries', subscribed_headers=[], table_id=None, merge=false) }}
 {% endif %}
 </div>
 {% endblock %}

--- a/emmaa_service/templates/tests_template.html
+++ b/emmaa_service/templates/tests_template.html
@@ -29,6 +29,6 @@
 
 {% block body %}
 <div class="container">
-  {{ detailed_paths(path_list, test, model, model_type, formatted_names, test_status, "test_card", "test_result")}}
+  {{ detailed_paths(path_list, test, model, model_type, formatted_names, test_status, "test_card", "test_result", is_query_page)}}
 </div>
 {% endblock %}


### PR DESCRIPTION
This PR makes use of ui_util web templates for queries page similarly to tests page.

Back end changes
-------------------
- Query results format is changed to the same format as in test results
- Adding some functionality to easily retrieve results from database with query hashes

Front end changes
-------------------
- Query page is switched to using templates
- Query page now shows high level grid like (pass/fail/NA) table of results for recent and subscribed queries
- Pass/fail/NA signs link out to detailed query result page with detailed paths and explanations
- Only query hashes are stored in session and used to retrieve results from the database