### PR TITLE
Update preassembly

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -227,6 +227,16 @@ class EmmaaModel(object):
         stmts = self.get_indra_stmts()
         stmts = self.filter_event_association(stmts)
         stmts = ac.filter_no_hypothesis(stmts)
+        if not self.assembly_config.get('skip_map_grounding'):
+            stmts = ac.map_grounding(stmts)
+        if self.assembly_config.get('filter_ungrounded'):
+            score_threshold = self.assembly_config.get('score_threshold')
+            stmts = ac.filter_grounded_only(
+                stmts, score_threshold=score_threshold)
+        if not self.assembly_config.get('skip_filter_human'):
+            stmts = ac.filter_human_only(stmts)
+        if not self.assembly_config.get('skip_map_sequence'):
+            stmts = ac.map_sequence(stmts)
         # Use WM hierarchies and belief scorer for WM preassembly
         preassembly_mode = self.assembly_config.get('preassembly_mode')
         if preassembly_mode == 'wm':
@@ -240,12 +250,6 @@ class EmmaaModel(object):
             stmts = ac.run_preassembly(stmts, return_toplevel=False)
         if self.assembly_config.get('standardize_names'):
             ac.standardize_names_groundings(stmts)
-        if not self.assembly_config.get('skip_map_grounding'):
-            stmts = ac.map_grounding(stmts)
-        if self.assembly_config.get('filter_ungrounded'):
-            score_threshold = self.assembly_config.get('score_threshold')
-            stmts = ac.filter_grounded_only(
-                stmts, score_threshold=score_threshold)
         if self.assembly_config.get('merge_groundings'):
             stmts = ac.merge_groundings(stmts)
         if self.assembly_config.get('merge_deltas'):
@@ -253,10 +257,6 @@ class EmmaaModel(object):
         relevance_policy = self.assembly_config.get('filter_relevance')
         if relevance_policy:
             stmts = self.filter_relevance(stmts, relevance_policy)
-        if not self.assembly_config.get('skip_filter_human'):
-            stmts = ac.filter_human_only(stmts)
-        if not self.assembly_config.get('skip_map_sequence'):
-            stmts = ac.map_sequence(stmts)
         belief_cutoff = self.assembly_config.get('belief_cutoff')
         if belief_cutoff is not None:
             stmts = ac.filter_belief(stmts, belief_cutoff)

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -227,10 +227,21 @@ class EmmaaModel(object):
         stmts = self.get_indra_stmts()
         stmts = self.filter_event_association(stmts)
         stmts = ac.filter_no_hypothesis(stmts)
-        if not self.assembly_config.get('skip_map_grounding'):
-            stmts = ac.map_grounding(stmts)
+        # Use WM hierarchies and belief scorer for WM preassembly
+        preassembly_mode = self.assembly_config.get('preassembly_mode')
+        if preassembly_mode == 'wm':
+            hierarchies = get_wm_hierarchies()
+            belief_scorer = get_eidos_scorer()
+            stmts = ac.run_preassembly(
+                stmts, return_toplevel=False, belief_scorer=belief_scorer,
+                hierarchies=hierarchies, normalize_equivalences=True,
+                normalize_opposites=True, normalize_ns='WM')
+        else:
+            stmts = ac.run_preassembly(stmts, return_toplevel=False)
         if self.assembly_config.get('standardize_names'):
             ac.standardize_names_groundings(stmts)
+        if not self.assembly_config.get('skip_map_grounding'):
+            stmts = ac.map_grounding(stmts)
         if self.assembly_config.get('filter_ungrounded'):
             score_threshold = self.assembly_config.get('score_threshold')
             stmts = ac.filter_grounded_only(
@@ -246,16 +257,6 @@ class EmmaaModel(object):
             stmts = ac.filter_human_only(stmts)
         if not self.assembly_config.get('skip_map_sequence'):
             stmts = ac.map_sequence(stmts)
-        # Use WM hierarchies and belief scorer for WM preassembly
-        preassembly_mode = self.assembly_config.get('preassembly_mode')
-        if preassembly_mode == 'wm':
-            hierarchies = get_wm_hierarchies()
-            belief_scorer = get_eidos_scorer()
-            stmts = ac.run_preassembly(
-                stmts, return_toplevel=False, belief_scorer=belief_scorer,
-                hierarchies=hierarchies)
-        else:
-            stmts = ac.run_preassembly(stmts, return_toplevel=False)
         belief_cutoff = self.assembly_config.get('belief_cutoff')
         if belief_cutoff is not None:
             stmts = ac.filter_belief(stmts, belief_cutoff)

--- a/emmaa/priors/world_modelers_prior.py
+++ b/emmaa/priors/world_modelers_prior.py
@@ -19,6 +19,7 @@ def make_search_terms(terms, ontology_file, db_ns):
         having standardized names.
     """
     search_terms = set()
+    search_names = set()
     with open(ontology_file, 'r') as f:
         lines = f.readlines()
     ontologies = []
@@ -37,7 +38,9 @@ def make_search_terms(terms, ontology_file, db_ns):
                 st = SearchTerm(type='concept', name=name,
                                 db_refs={db_ns.upper(): ont},
                                 search_term='\"%s\"' % search_term)
-                search_terms.add(st)
+                if name not in search_names:
+                    search_terms.add(st)
+                    search_names.add(name)
     return search_terms
 
 

--- a/emmaa/priors/world_modelers_prior.py
+++ b/emmaa/priors/world_modelers_prior.py
@@ -31,11 +31,11 @@ def make_search_terms(terms, ontology_file, db_ns):
     for ont in ontologies:
         for term in terms:
             if term in ont:
-            # if ont.endswith(term):
                 search_term = ont.split('/')[-1]
                 search_term = search_term.replace('_', ' ')
                 name = search_term.capitalize()
-                st = SearchTerm(type='concept', name=name, db_refs={db_ns: ont},
+                st = SearchTerm(type='concept', name=name,
+                                db_refs={db_ns.upper(): ont},
                                 search_term='\"%s\"' % search_term)
                 search_terms.add(st)
     return search_terms

--- a/emmaa/priors/world_modelers_prior.py
+++ b/emmaa/priors/world_modelers_prior.py
@@ -56,7 +56,8 @@ def make_config(search_terms, human_readable_name, description,
                       'max_paths': 1},
                       'test_corpus': 'world_modelers_tests.pkl',
                       'mc_types': ['pysb', 'signed_graph', 'unsigned_graph'],
-                      'make_links': False}
+                      'make_links': False,
+                      'link_type': 'elsevier'}
     config['assembly'] = {'skip_map_grounding': True,
                           'skip_filter_human': True,
                           'skip_map_sequence': True,

--- a/emmaa/priors/world_modelers_prior.py
+++ b/emmaa/priors/world_modelers_prior.py
@@ -1,5 +1,8 @@
 from emmaa.priors import SearchTerm
 from emmaa.model import save_config_to_s3
+from emmaa.model_tests import StatementCheckingTest
+from indra.sources.eidos import process_text
+from indra.tools.assemble_corpus import standardize_names_groundings
 
 
 def make_search_terms(terms, ontology_file, db_ns):
@@ -74,3 +77,14 @@ def make_config(search_terms, human_readable_name, description,
     if save_to_s3:
         save_config_to_s3(short_name, config)
     return config
+
+
+def reground_tests(tests, webservice):
+    """Reground tests to updated ontology."""
+    stmts = [test.stmt for test in tests]
+    texts = [stmt.evidence[0].text for stmt in stmts]
+    text = ' '.join(texts)
+    new_stmts = process_text(text, webservice=webservice).statements
+    new_stmts = standardize_names_groundings(new_stmts)
+    new_tests = [StatementCheckingTest(stmt) for stmt in new_stmts]
+    return new_tests


### PR DESCRIPTION
This PR updates EMMAA model assembly pipeline and reorders assembly steps to incorporate new changes introduced in https://github.com/sorgerlab/indra/pull/978 (normalizing opposite concepts). 
This PR also updates the script regrounding WM model search terms and tests to the latest WM ontology. I already regrounded search terms (that might affect the model in some ways now before regrounding the statements but should not cause any major issues). Model statements and tests also need to be regrounded to pick up ontology changes. `reground_tests` function should be run on current tests and then they need to be reuploaded to s3. One thing to note: running this assembly on statements with old grounding does not pick up all of the opposites because old grounding sometimes don't have underscores, while the normalizing function uses latest ontology with underscores in all cases. There should be no problems when Eidos reader is configured to use latest ontology.