### PR TITLE
Query settings

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -62,6 +62,7 @@ class EmmaaModel(object):
         self.assembly_config = {}
         self.test_config = {}
         self.reading_config = {}
+        self.query_config = {}
         self.search_terms = []
         self.ndex_network = None
         self._load_config(config)
@@ -101,6 +102,8 @@ class EmmaaModel(object):
             self.assembly_config = config['assembly']
         if 'test' in config:
             self.test_config = config['test']
+        if 'query' in config:
+            self.query_config = config['query']
 
     def search_literature(self, date_limit=None):
         """Search for the model's search terms in the literature.

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -239,7 +239,8 @@ class ModelManager(object):
             results = []
             for mc_type in self.mc_types:
                 mc = self.get_updated_mc(mc_type, [query.path_stmt])
-                max_path_length, max_paths = self._get_test_configs()
+                max_path_length, max_paths = self._get_test_configs(
+                    mode='query', mc_type=mc_type)
                 result = mc.check_statement(
                     query.path_stmt, max_paths, max_path_length)
                 results.append((mc_type, self.process_response(mc_type, result)))
@@ -264,7 +265,6 @@ class ModelManager(object):
         responses = []
         applicable_queries = []
         applicable_stmts = []
-        max_path_length, max_paths = self._get_test_configs()
         for query in queries:
             if ScopeTestConnector.applicable(self, query):
                 applicable_queries.append(query)
@@ -277,7 +277,10 @@ class ModelManager(object):
         if applicable_queries:
             for mc_type in self.mc_types:
                 mc = self.get_updated_mc(mc_type, applicable_stmts)
-                results = mc.check_model()
+                max_path_length, max_paths = self._get_test_configs(
+                    mode='query', mc_type=mc_type, default_paths=5)
+                results = mc.check_model(
+                    max_path_length=max_path_length, max_paths=max_paths)
                 for ix, (_, result) in enumerate(results):
                     responses.append(
                         (applicable_queries[ix], mc_type,

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -284,17 +284,30 @@ class ModelManager(object):
                          self.process_response(mc_type, result)))
         return sorted(responses, key=lambda x: x[0].matches_key())
 
-    def _get_test_configs(self):
+    def _get_test_configs(self, mode='test', mc_type=None, default_length=5,
+                          default_paths=1):
+        if mode == 'test':
+            config = self.model.test_config
+        elif mode == 'query':
+            config = self.model.query_config
         try:
             max_path_length = \
-                self.model.test_config['statement_checking']['max_path_length']
+                config['statement_checking'][mc_type]['max_path_length']
         except KeyError:
-            max_path_length = 5
+            try:
+                max_path_length = \
+                    config['statement_checking']['max_path_length']
+            except KeyError:
+                max_path_length = default_length
         try:
             max_paths = \
-                self.model.test_config['statement_checking']['max_paths']
+                config['statement_checking'][mc_type]['max_paths']
         except KeyError:
-            max_paths = 1
+            try:
+                max_paths = \
+                    config['statement_checking']['max_paths']
+            except KeyError:
+                max_paths = default_paths
         logger.info('Parameters for model checking: %d, %d' %
                     (max_path_length, max_paths))
         return (max_path_length, max_paths)


### PR DESCRIPTION
This PR separates query settings from test settings for EMMAA model checking. The query settings can be configured in config.json for each model or will use the default values if not provided. Default values currently are: max_path_length = 5 and max_paths = 5 (vs test settings where max_paths = 1). Query and test settings can be generic or model type specific. Syntax to add them in config.json:
`"query": {"statement_checking" : {"max_path_length" : 5, "max_paths": 5,
                                                            "pybel": {"max_path_length" : 10, "max_paths": 5}}}`

In this example settings for pybel will override generic settings, but generic will be used for all other model types.