### PR TITLE
Time Machine

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -565,6 +565,8 @@ def get_model_stats(model, date=None, extension='.json'):
     latest_file_key = find_latest_s3_file(bucket=EMMAA_BUCKET_NAME,
                                           prefix=prefix,
                                           extension=extension)
+    if not latest_file_key:
+        return None
     model_data_object = s3.get_object(Bucket=EMMAA_BUCKET_NAME,
                                       Key=latest_file_key)
     return json.loads(model_data_object['Body'].read().decode('utf8'))

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -20,7 +20,8 @@ from emmaa.readers.aws_reader import read_pmid_search_terms
 from emmaa.readers.db_client_reader import read_db_pmid_search_terms
 from emmaa.readers.elsevier_eidos_reader import \
     read_elsevier_eidos_search_terms
-from emmaa.util import make_date_str, find_latest_s3_file, get_s3_client
+from emmaa.util import make_date_str, find_latest_s3_file, get_s3_client, \
+    strip_out_date
 
 
 logger = logging.getLogger(__name__)
@@ -490,3 +491,73 @@ def load_stmts_from_s3(model_name):
     obj = client.get_object(Bucket='emmaa', Key=latest_model_key)
     stmts = pickle.loads(obj['Body'].read())
     return stmts
+
+
+def last_updated_date(model, file_type='model', date_format='datetime',
+                      extension='.pkl'):
+    """Find the most recent pickle file of model and return its creation date
+
+    Example file name:
+    models/aml/model_2018-12-13-18-11-54.pkl
+
+    Parameters
+    ----------
+    model : str
+        Model name to look for
+    file_type : str
+        Type of a file to find the latest file for. Accepted values: 'model',
+        'results', 'stats'.
+    date_format : str
+        Format of the returned date. Accepted values are 'datetime' (returns a
+        date in the format "YYYY-MM-DD-HH-mm-ss") and 'date' (returns a date
+        in the format "YYYY-MM-DD"). Default is 'datetime'.
+    extension : str
+        The extension the model file needs to have. Default is '.pkl'
+
+    Returns
+    -------
+    last_updated : str
+        A string of the selected format.
+    """
+    if file_type == 'model':
+        folder_name = 'models'
+    else:
+        folder_name = file_type
+    prefix = f'{folder_name}/{model}/{file_type}_'
+    try:
+        return strip_out_date(
+            find_latest_s3_file(
+                bucket=EMMAA_BUCKET_NAME,
+                prefix=prefix,
+                extension=extension),
+            date_format=date_format)
+    except TypeError:
+        logger.info('Could not find latest update date')
+        return ''
+
+
+def get_model_stats(model, date, extension='.json'):
+    """Gets the latest statistics for the given model
+
+    Parameters
+    ----------
+    model : str
+        Model name to look for
+    extension : str
+
+    Returns
+    -------
+    model_data : json
+        The json formatted data containing the statistics for the model
+    """
+    s3 = get_s3_client()
+
+    # Need jsons for model meta data and test statistics. File name examples:
+    # stats/skcm/stats_2019-08-20-17-34-40.json
+    prefix = f'stats/{model}/stats_{date}'
+    latest_file_key = find_latest_s3_file(bucket=EMMAA_BUCKET_NAME,
+                                          prefix=prefix,
+                                          extension=extension)
+    model_data_object = s3.get_object(Bucket=EMMAA_BUCKET_NAME,
+                                      Key=latest_file_key)
+    return json.loads(model_data_object['Body'].read().decode('utf8'))

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -25,6 +25,7 @@ from emmaa.util import make_date_str, find_latest_s3_file, get_s3_client, \
 
 
 logger = logging.getLogger(__name__)
+EMMAA_BUCKET_NAME = 'emmaa'
 
 
 class EmmaaModel(object):
@@ -335,12 +336,13 @@ class EmmaaModel(object):
         fname = f'models/{self.name}/model_{date_str}'
         client = get_s3_client(unsigned=False)
         # Dump as pickle
-        client.put_object(Body=pickle.dumps(self.stmts), Bucket='emmaa',
+        client.put_object(Body=pickle.dumps(self.stmts),
+                          Bucket=EMMAA_BUCKET_NAME,
                           Key=fname+'.pkl')
         # Dump as json
         client.put_object(Body=str.encode(json.dumps(self.to_json()),
                                           encoding='utf8'),
-                          Bucket='emmaa', Key=fname+'.json')
+                          Bucket=EMMAA_BUCKET_NAME, Key=fname+'.json')
 
     @classmethod
     def load_from_s3(klass, model_name):

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -536,13 +536,15 @@ def last_updated_date(model, file_type='model', date_format='datetime',
         return ''
 
 
-def get_model_stats(model, date, extension='.json'):
+def get_model_stats(model, date=None, extension='.json'):
     """Gets the latest statistics for the given model
 
     Parameters
     ----------
     model : str
         Model name to look for
+    date : str or None
+        Date for which the stats will be returned in "YYYY-MM-DD" format.
     extension : str
 
     Returns
@@ -550,6 +552,9 @@ def get_model_stats(model, date, extension='.json'):
     model_data : json
         The json formatted data containing the statistics for the model
     """
+    # If date is not specified, get the latest
+    if not date:
+        date = last_updated_date(model, 'stats', 'date', extension)
     s3 = get_s3_client()
 
     # Need jsons for model meta data and test statistics. File name examples:

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -495,7 +495,7 @@ def load_stmts_from_s3(model_name):
     return stmts
 
 
-def last_updated_date(model, file_type='model', date_format='datetime',
+def last_updated_date(model, file_type='model', date_format='date',
                       extension='.pkl'):
     """Find the most recent pickle file of model and return its creation date
 
@@ -512,7 +512,7 @@ def last_updated_date(model, file_type='model', date_format='datetime',
     date_format : str
         Format of the returned date. Accepted values are 'datetime' (returns a
         date in the format "YYYY-MM-DD-HH-mm-ss") and 'date' (returns a date
-        in the format "YYYY-MM-DD"). Default is 'datetime'.
+        in the format "YYYY-MM-DD"). Default is 'date'.
     extension : str
         The extension the model file needs to have. Default is '.pkl'
 

--- a/emmaa/tests/test_api_functions.py
+++ b/emmaa/tests/test_api_functions.py
@@ -1,7 +1,8 @@
 import re
 
-from emmaa.util import RE_DATEFORMAT
-from emmaa_service.api import get_model_stats, model_last_updated
+from emmaa.util import RE_DATETIMEFORMAT, RE_DATEFORMAT
+from emmaa_service.api import get_model_stats, model_last_updated, \
+    latest_stats_date
 
 MODEL = 'aml'
 
@@ -9,9 +10,16 @@ MODEL = 'aml'
 def test_last_updated():
     key_str = model_last_updated(MODEL)
     assert key_str
+    assert re.search(RE_DATETIMEFORMAT, key_str).group()
+
+
+def test_latest_stats():
+    key_str = latest_stats_date(MODEL)
+    assert key_str
     assert re.search(RE_DATEFORMAT, key_str).group()
 
 
 def test_get_model_statistics():
-    model_json = get_model_stats(MODEL)
+    date = latest_stats_date(MODEL)
+    model_json = get_model_stats(MODEL, date)
     assert isinstance(model_json, dict)

--- a/emmaa/tests/test_api_functions.py
+++ b/emmaa/tests/test_api_functions.py
@@ -1,8 +1,10 @@
+from nose.plugins.attrib import attr
 from emmaa_service.api import _get_model_meta_data, get_model_config,\
     _make_query
 from emmaa.queries import PathProperty
 
 
+@attr('nonpublic')
 def test_get_metadata():
     metadata = _get_model_meta_data()
     assert len(metadata) == 11, len(metadata)
@@ -12,6 +14,7 @@ def test_get_metadata():
     assert isinstance(metadata[0][2], str)
 
 
+@attr('nonpublic')
 def test_get_model_config():
     config = get_model_config('aml')
     assert config

--- a/emmaa/tests/test_api_functions.py
+++ b/emmaa/tests/test_api_functions.py
@@ -1,25 +1,29 @@
-import re
-
-from emmaa.util import RE_DATETIMEFORMAT, RE_DATEFORMAT
-from emmaa_service.api import get_model_stats, model_last_updated, \
-    latest_stats_date
-
-MODEL = 'aml'
+from emmaa_service.api import _get_model_meta_data, get_model_config,\
+    _make_query
+from emmaa.queries import PathProperty
 
 
-def test_last_updated():
-    key_str = model_last_updated(MODEL)
-    assert key_str
-    assert re.search(RE_DATETIMEFORMAT, key_str).group()
+def test_get_metadata():
+    metadata = _get_model_meta_data()
+    assert len(metadata) == 11, len(metadata)
+    assert len(metadata[0]) == 3
+    assert isinstance(metadata[0][0], str)
+    assert isinstance(metadata[0][1], dict)
+    assert isinstance(metadata[0][2], str)
 
 
-def test_latest_stats():
-    key_str = latest_stats_date(MODEL)
-    assert key_str
-    assert re.search(RE_DATEFORMAT, key_str).group()
+def test_get_model_config():
+    config = get_model_config('aml')
+    assert config
+    assert isinstance(config, dict)
+    # can't get if there's no human readable name
+    config = get_model_config('test')
+    assert not config
 
 
-def test_get_model_statistics():
-    date = latest_stats_date(MODEL)
-    model_json = get_model_stats(MODEL, date)
-    assert isinstance(model_json, dict)
+def test_make_query():
+    query = _make_query({
+        'typeSelection': 'Activation',
+        'subjectSelection': 'BRAF',
+        'objectSelection': 'MAPK1'})
+    assert isinstance(query, PathProperty)

--- a/emmaa/tests/test_model.py
+++ b/emmaa/tests/test_model.py
@@ -1,9 +1,11 @@
 import datetime
+import re
 from indra.statements import Activation, ActivityCondition, Phosphorylation, \
     Agent, Evidence
-from emmaa.model import EmmaaModel
+from emmaa.model import EmmaaModel, last_updated_date, get_model_stats
 from emmaa.priors import SearchTerm
 from emmaa.statements import EmmaaStatement
+from emmaa.util import RE_DATETIMEFORMAT, RE_DATEFORMAT
 
 
 def test_model_extend():
@@ -116,3 +118,32 @@ def test_filter_relevance():
     emmaa_model.extend_unique(emmaa_stmts)
     emmaa_model.run_assembly()
     assert len(emmaa_model.assembled_stmts) == 0
+
+
+def test_last_updated():
+    # Test for different file types
+    key_str = last_updated_date('test', 'model', 'datetime', '.pkl')
+    assert key_str
+    assert re.search(RE_DATETIMEFORMAT, key_str).group()
+    key_str = last_updated_date('test', 'results', 'datetime', '.json')
+    assert key_str
+    assert re.search(RE_DATETIMEFORMAT, key_str).group()
+    key_str = last_updated_date('test', 'stats', 'datetime', '.json')
+    assert key_str
+    assert re.search(RE_DATETIMEFORMAT, key_str).group()
+    # Test for different date format
+    key_str = last_updated_date('test', 'model', 'date', '.pkl')
+    assert key_str
+    assert re.search(RE_DATEFORMAT, key_str).group()
+    # Test with wrong extension
+    key_str = last_updated_date('test', 'stats', 'datetime', '.pkl')
+    assert not key_str
+
+
+def test_get_model_statistics():
+    # Test with default date
+    model_json = get_model_stats('test')
+    assert isinstance(model_json, dict)
+    # Test with different date
+    model_json = get_model_stats('test', date='2019-08-19')
+    assert isinstance(model_json, dict)

--- a/emmaa/tests/test_reactome_prior.py
+++ b/emmaa/tests/test_reactome_prior.py
@@ -13,7 +13,7 @@ def test_rx_id_from_up_id():
     """
     test_cases = [('P01116', 'R-HSA-9653079'),   # KRAS
                   ('P04637', 'R-HSA-69507'),   # TP53
-                  ('Q13485', 'R-HSA-2187323')]  # SMAD4
+                  ('Q13485', 'R-HSA-3310994')]  # SMAD4
     for up_id, rx_id in test_cases:
         all_rx_ids = rx_id_from_up_id(up_id)
         assert rx_id in all_rx_ids

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 def strip_out_date(keystring, date_format='datetime'):
-    """Strips out datestring of format FORMAT from a keystring"""
+    """Strips out datestring of selected date_format from a keystring"""
     if date_format == 'datetime':
         re_format = RE_DATETIMEFORMAT
     elif date_format == 'date':

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -10,14 +10,19 @@ from indra.statements import get_all_descendants
 
 
 FORMAT = '%Y-%m-%d-%H-%M-%S'
-RE_DATEFORMAT = r'\d{4}\-\d{2}\-\d{2}\-\d{2}\-\d{2}\-\d{2}'
+RE_DATETIMEFORMAT = r'\d{4}\-\d{2}\-\d{2}\-\d{2}\-\d{2}\-\d{2}'
+RE_DATEFORMAT = r'\d{4}\-\d{2}\-\d{2}'
 logger = logging.getLogger(__name__)
 
 
-def strip_out_date(keystring):
+def strip_out_date(keystring, date_format='datetime'):
     """Strips out datestring of format FORMAT from a keystring"""
+    if date_format == 'datetime':
+        re_format = RE_DATETIMEFORMAT
+    elif date_format == 'date':
+        re_format = RE_DATEFORMAT
     try:
-        return re.search(RE_DATEFORMAT, keystring).group()
+        return re.search(re_format, keystring).group()
     except AttributeError:
         logger.warning(f'Can\'t parse string {keystring} for date')
         return None

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -128,16 +128,6 @@ def _make_query(query_dict, use_grouding_service=True):
     return query
 
 
-def _extract_stmt_link(anchor_string):
-    # Matches an anchor with at least an href attribute
-    pattern = '<a.*? href="(.*?)".*?>(.*?)</a>'
-    m = re.search(pattern=pattern, string=anchor_string)
-    if m:
-        return m.group(1), m.group(2)
-    else:
-        return '', anchor_string
-
-
 def _new_applied_tests(model_stats_json, model_types, model_name, date):
     # Extract new applied tests into:
     #   list of tests (one per row)

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -196,7 +196,7 @@ def _extract_stmt_link(anchor_string):
         return '', anchor_string
 
 
-def _new_applied_tests(model_stats_json, model_types, model_name):
+def _new_applied_tests(model_stats_json, model_types, model_name, date):
     # Extract new applied tests into:
     #   list of tests (one per row)
     #       each test is a list of tuples (one tuple per column)
@@ -208,17 +208,17 @@ def _new_applied_tests(model_stats_json, model_types, model_name):
     if len(new_app_hashes) == 0:
         return 'No new tests were applied'
     new_app_tests = [(th, all_test_results[th]) for th in new_app_hashes]
-    return _format_table_array(new_app_tests, model_types, model_name)
+    return _format_table_array(new_app_tests, model_types, model_name, date)
 
 
-def _format_table_array(tests_json, model_types, model_name):
+def _format_table_array(tests_json, model_types, model_name, date):
     # tests_json needs to have the structure: [(test_hash, tests)]
     table_array = []
     for th, test in tests_json:
         new_row = [(*test['test'], stmt_db_link_msg)
                    if len(test['test']) == 2 else test['test']]
         for mt in model_types:
-            new_row.append((f'/tests/{model_name}/{mt}/{th}', test[mt][0],
+            new_row.append((f'/tests/{model_name}/{mt}/{th}/{date}', test[mt][0],
                             pass_fail_msg))
         table_array.append(new_row)
     return sorted(table_array, key=_sort_pass_fail)
@@ -239,7 +239,7 @@ def _format_query_results(formatted_results):
     return result_array
 
 
-def _new_passed_tests(model_name, model_stats_json, current_model_types):
+def _new_passed_tests(model_name, model_stats_json, current_model_types, date):
     new_passed_tests = []
     all_test_results = model_stats_json['test_round_summary'][
         'all_test_results']
@@ -260,7 +260,7 @@ def _new_passed_tests(model_name, model_stats_json, current_model_types):
                 path = path_loc
             new_row = [(*test['test'], stmt_db_link_msg)
                        if len(test['test']) == 2 else test['test'],
-                       (f'/tests/{model_name}/{mt}/{test_hash}', path,
+                       (f'/tests/{model_name}/{mt}/{test_hash}/{date}', path,
                         pass_fail_msg)]
             mt_rows.append(new_row)
         new_passed_tests += mt_rows
@@ -349,13 +349,15 @@ def get_model_dashboard(model, date):
                            new_applied_tests=_new_applied_tests(
                                model_stats_json=model_stats,
                                model_types=current_model_types,
-                               model_name=model),
+                               model_name=model,
+                               date=date),
                            all_test_results=_format_table_array(
                                tests_json=all_tests,
                                model_types=current_model_types,
-                               model_name=model),
+                               model_name=model,
+                               date=date),
                            new_passed_tests=_new_passed_tests(
-                               model, model_stats, current_model_types))
+                               model, model_stats, current_model_types, date))
 
 
 @app.route('/tests/<model>/<model_type>/<test_hash>/<date>')

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -91,7 +91,7 @@ def get_model_config(model):
     return model_cache[model]
 
 
-def get_model_stats(model, extension='.json'):
+def get_model_stats(model, date, extension='.json'):
     """Gets the latest statistics for the given model
 
     Parameters
@@ -109,7 +109,7 @@ def get_model_stats(model, extension='.json'):
 
     # Need jsons for model meta data and test statistics. File name examples:
     # stats/skcm/stats_2019-08-20-17-34-40.json
-    prefix = f'stats/{model}/stats_'
+    prefix = f'stats/{model}/stats_{date}'
     latest_file_key = find_latest_s3_file(bucket=EMMAA_BUCKET_NAME,
                                           prefix=prefix,
                                           extension=extension)
@@ -287,9 +287,9 @@ def get_home():
                            user_email=user.email if user else "")
 
 
-@app.route('/dashboard/<model>')
+@app.route('/dashboard/<model>/<date>')
 @jwt_optional
-def get_model_dashboard(model):
+def get_model_dashboard(model, date):
     user, roles = resolve_auth(dict(request.args))
     model_meta_data = _get_model_meta_data()
 
@@ -308,7 +308,7 @@ def get_model_dashboard(model):
         [('', 'Network on Ndex', ''),
          (f'http://www.ndexbio.org/#/network/{ndex_id}', ndex_id,
           'Click to see network on Ndex')]]
-    model_stats = get_model_stats(model)
+    model_stats = get_model_stats(model, date)
     current_model_types = [mt for mt in ALL_MODEL_TYPES if mt in
                            model_stats['test_round_summary']]
 
@@ -357,11 +357,11 @@ def get_model_dashboard(model):
                                model, model_stats, current_model_types))
 
 
-@app.route('/tests/<model>/<model_type>/<test_hash>')
-def get_model_tests_page(model, model_type, test_hash):
+@app.route('/tests/<model>/<model_type>/<test_hash>/<date>')
+def get_model_tests_page(model, model_type, test_hash, date):
     if model_type not in ALL_MODEL_TYPES:
         abort(Response(f'Model type {model_type} does not exist', 404))
-    model_stats = get_model_stats(model)
+    model_stats = get_model_stats(model, date)
     current_test = \
         model_stats['test_round_summary']['all_test_results'][test_hash]
     current_model_types = [mt for mt in ALL_MODEL_TYPES if mt in

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -32,7 +32,6 @@ logger = logging.getLogger(__name__)
 
 
 TITLE = 'emmaa title'
-EMMAA_BUCKET_NAME = 'emmaa'
 ALL_MODEL_TYPES = ['pysb', 'pybel', 'signed_graph', 'unsigned_graph']
 LINKAGE_SYMBOLS = {'LEFT TACK': '\u22a3',
                    'RIGHTWARDS ARROW': '\u2192'}
@@ -64,7 +63,7 @@ def _sort_pass_fail(row):
 
 def _get_model_meta_data():
     s3 = boto3.client('s3')
-    resp = s3.list_objects(Bucket=EMMAA_BUCKET_NAME, Prefix='models/',
+    resp = s3.list_objects(Bucket='emmaa', Prefix='models/',
                            Delimiter='/')
     model_data = []
     for pref in resp['CommonPrefixes']:

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -236,15 +236,18 @@ def get_model_dashboard(model, date):
     if not last_update:
         logger.warning(f'Could not get last update for {model}')
         last_update = 'Not available'
+    latest_date = last_updated_date(model, 'stats', 'date', '.json')
     model_info_contents = [
-        [('', 'Last Updated', ''), ('', last_update, '')],
+        [('', 'Model Last Updated', ''), ('', last_update, '')],
+        [('', 'Model Last Tested', ''), ('', latest_date, '')],
+        [('', 'Data Displayed', ''),
+         ('', date, 'Click on the point on time graph to see earlier results')],
         [('', 'Network on Ndex', ''),
          (f'http://www.ndexbio.org/#/network/{ndex_id}', ndex_id,
           'Click to see network on Ndex')]]
     model_stats = get_model_stats(model, date)
     current_model_types = [mt for mt in ALL_MODEL_TYPES if mt in
                            model_stats['test_round_summary']]
-    latest_date = last_updated_date(model, 'stats', 'date', '.json')
     # Filter out rows with all tests == 'n_a'
     all_tests = []
     for k, v in model_stats['test_round_summary']['all_test_results'].items():

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -383,6 +383,7 @@ def get_query_tests_page(model, model_type, query_hash):
     results = qm.retrieve_results_from_hashes([query_hash])
     detailed_results = results[query_hash][model_type]\
         if results else ['query', f'{query_hash}']
+    date = results[query_hash]['date']
     card_title = ('', results[query_hash]['query'] if results else '', '')
     return render_template('tests_template.html',
                            link_list=link_list,
@@ -394,7 +395,8 @@ def get_query_tests_page(model, model_type, query_hash):
                            is_query_page=True,
                            test_status=detailed_results[0],
                            path_list=detailed_results[1],
-                           formatted_names=FORMATTED_TYPE_NAMES)
+                           formatted_names=FORMATTED_TYPE_NAMES,
+                           date=date)
 
 
 @app.route('/query/submit', methods=['POST'])

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -302,12 +302,18 @@ def get_model_tests_page(model, model_type, test_hash, date):
     if model_type not in ALL_MODEL_TYPES:
         abort(Response(f'Model type {model_type} does not exist', 404))
     model_stats = get_model_stats(model, date)
-    current_test = \
-        model_stats['test_round_summary']['all_test_results'][test_hash]
+    if not model_stats:
+        abort(Response(f'Data for {model} for {date} was not found', 404))
+    try:
+        current_test = \
+            model_stats['test_round_summary']['all_test_results'][test_hash]
+    except KeyError:
+        abort(Response(f'Result for this test does not exist for {date}', 404))
     current_model_types = [mt for mt in ALL_MODEL_TYPES if mt in
                            model_stats['test_round_summary']]
     test = current_test["test"]
     test_status, path_list = current_test[model_type]
+    latest_date = last_updated_date(model, 'stats', 'date', '.json')
     return render_template('tests_template.html',
                            link_list=link_list,
                            model=model,
@@ -318,7 +324,9 @@ def get_model_tests_page(model, model_type, test_hash, date):
                            test=test,
                            test_status=test_status,
                            path_list=path_list,
-                           formatted_names=FORMATTED_TYPE_NAMES)
+                           formatted_names=FORMATTED_TYPE_NAMES,
+                           date=date,
+                           latest_date=latest_date)
 
 
 @app.route('/query')

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -67,12 +67,13 @@ def _get_model_meta_data():
     resp = s3.list_objects(Bucket=EMMAA_BUCKET_NAME, Prefix='models/',
                            Delimiter='/')
     model_data = []
+    date = '2019-12-10'
     for pref in resp['CommonPrefixes']:
         model = pref['Prefix'].split('/')[1]
         config_json = get_model_config(model)
         if not config_json:
             continue
-        model_data.append((model, config_json))
+        model_data.append((model, config_json, date))
     return model_data
 
 
@@ -154,7 +155,7 @@ if GLOBAL_PRELOAD:
     # Load all the model configs
     model_meta_data = _get_model_meta_data()
     # Load all the model managers for queries
-    for model, _ in model_meta_data:
+    for model, _, _ in model_meta_data:
         load_model_manager_from_s3(model)
 
 
@@ -295,7 +296,7 @@ def get_model_dashboard(model, date):
 
     last_update = model_last_updated(model=model)
     ndex_id = 'None available'
-    for mid, mmd in model_meta_data:
+    for mid, mmd, _ in model_meta_data:
         if mid == model:
             ndex_id = mmd['ndex']['network']
     if ndex_id == 'None available':

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -37,6 +37,47 @@ function modelRedirect(ddSelect, current_model) {
   console.log(redirect);
   window.location.replace(redirect);
 }
+function redirectToPast(x) { 
+  let new_date = x.x
+  console.log(new_date)
+  static_date = new Date('2019-09-30')
+  if (new_date >= static_date) {
+    let new_date_str = new_date.toISOString().substring(0, 10)
+    redirectToDate(new_date_str)
+  };
+}
+
+function redirectToDate(new_date_str) {
+  let loc = window.location.href
+  let current_date = loc.substring(loc.length - 10, loc.length)
+  let redirect = loc.replace(current_date, new_date_str)
+  location.replace(redirect);
+}
+
+function modelDateRedirect(ddSelect, current_model) {
+
+  // Get selected option
+  let newModel = '';
+  for (child of ddSelect.children) {
+    if (child.selected) {
+      console.log(child.value)
+      selection_str = child.value.split(" ");
+      newModel = selection_str[0];
+      newDate = selection_str[1];
+      break;
+    }
+  }
+
+  console.log(newModel)
+  console.log(newDate)
+  let loc = window.location.href
+  let current_date = loc.substring(loc.length - 10, loc.length)
+
+  // redirect url:
+  let redirectModel = loc.replace(current_model, newModel)
+  let redirectDate = redirectModel.replace(current_date, newDate);
+  location.replace(redirectDate);
+}
 
 function clearTables(arrayOfTableBodies) {
   for (let tableBody of arrayOfTableBodies) {
@@ -329,22 +370,4 @@ function generateLineArea(chartDivId, dataParams, chartTitle) {
       enabled: true
     }
   });
-}
-
-
-function redirectToPast(x) { 
-  let new_date = x.x
-  console.log(new_date)
-  static_date = new Date('2019-09-30')
-  if (new_date >= static_date) {
-    let new_date_str = new_date.toISOString().substring(0, 10)
-    redirectToDate(new_date_str)
-  };
-}
-
-function redirectToDate(new_date_str) {
-  let loc = window.location.href
-  let current_date = loc.substring(loc.length - 10, loc.length)
-  let redirect = loc.replace(current_date, new_date_str)
-  location.replace(redirect);
 }

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -338,9 +338,13 @@ function redirectToPast(x) {
   static_date = new Date('2019-09-30')
   if (new_date >= static_date) {
     let new_date_str = new_date.toISOString().substring(0, 10)
-    let loc = window.location.href
-    let current_date = loc.substring(loc.length - 10, loc.length)
-    redirect = loc.replace(current_date, new_date_str)
-    location.replace(redirect);
+    redirectToDate(new_date_str)
   };
+}
+
+function redirectToDate(new_date_str) {
+  let loc = window.location.href
+  let current_date = loc.substring(loc.length - 10, loc.length)
+  redirect = loc.replace(current_date, new_date_str)
+  location.replace(redirect);
 }

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -209,7 +209,15 @@ function populateTestResultTable(tableBody, json) {
     columns: [
       dates,
       stmtsOverTime
-    ]
+    ],
+    onclick: function (x) { 
+      let new_date = x.x.toISOString().substring(0, 10)
+      console.log(new_date)
+      let loc = window.location.href
+      let current_date = loc.substring(loc.length - 10, loc.length)
+      redirect = loc.replace(current_date, new_date)
+      location.replace(redirect); 
+    },
   };
 
   let stmtsCountChart = generateLineArea(stmtTime, stmtsCountDataParams, '');
@@ -235,7 +243,15 @@ function populateTestResultTable(tableBody, json) {
   lineDataParams = {
     x: 'x',
     xFormat: '%Y-%m-%d-%H-%M-%S',
-    columns: passedRatioColumns
+    columns: passedRatioColumns,
+    onclick: function (x) { 
+      let new_date = x.x.toISOString().substring(0, 10)
+      console.log(new_date)
+      let loc = window.location.href
+      let current_date = loc.substring(loc.length - 10, loc.length)
+      redirect = loc.replace(current_date, new_date)
+      location.replace(redirect); 
+    },
   };
 
   let lineChart = generateLineArea(pasRatId, lineDataParams, '');
@@ -261,7 +277,15 @@ function populateTestResultTable(tableBody, json) {
     x: 'x',
     xFormat: '%Y-%m-%d-%H-%M-%S',
     columns: appliedPassedColumns,
-    type: 'area'
+    type: 'area',
+    onclick: function (x) { 
+      let new_date = x.x.toISOString().substring(0, 10)
+      console.log(new_date)
+      let loc = window.location.href
+      let current_date = loc.substring(loc.length - 10, loc.length)
+      redirect = loc.replace(current_date, new_date)
+      location.replace(redirect); 
+    },
   };
 
   let areaChart = generateLineArea(pasAppId, passedAppliedParams, '');

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -345,6 +345,6 @@ function redirectToPast(x) {
 function redirectToDate(new_date_str) {
   let loc = window.location.href
   let current_date = loc.substring(loc.length - 10, loc.length)
-  redirect = loc.replace(current_date, new_date_str)
+  let redirect = loc.replace(current_date, new_date_str)
   location.replace(redirect);
 }

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -210,14 +210,7 @@ function populateTestResultTable(tableBody, json) {
       dates,
       stmtsOverTime
     ],
-    onclick: function (x) { 
-      let new_date = x.x.toISOString().substring(0, 10)
-      console.log(new_date)
-      let loc = window.location.href
-      let current_date = loc.substring(loc.length - 10, loc.length)
-      redirect = loc.replace(current_date, new_date)
-      location.replace(redirect); 
-    },
+    onclick: redirectToPast
   };
 
   let stmtsCountChart = generateLineArea(stmtTime, stmtsCountDataParams, '');
@@ -244,14 +237,7 @@ function populateTestResultTable(tableBody, json) {
     x: 'x',
     xFormat: '%Y-%m-%d-%H-%M-%S',
     columns: passedRatioColumns,
-    onclick: function (x) { 
-      let new_date = x.x.toISOString().substring(0, 10)
-      console.log(new_date)
-      let loc = window.location.href
-      let current_date = loc.substring(loc.length - 10, loc.length)
-      redirect = loc.replace(current_date, new_date)
-      location.replace(redirect); 
-    },
+    onclick: redirectToPast
   };
 
   let lineChart = generateLineArea(pasRatId, lineDataParams, '');
@@ -278,14 +264,7 @@ function populateTestResultTable(tableBody, json) {
     xFormat: '%Y-%m-%d-%H-%M-%S',
     columns: appliedPassedColumns,
     type: 'area',
-    onclick: function (x) { 
-      let new_date = x.x.toISOString().substring(0, 10)
-      console.log(new_date)
-      let loc = window.location.href
-      let current_date = loc.substring(loc.length - 10, loc.length)
-      redirect = loc.replace(current_date, new_date)
-      location.replace(redirect); 
-    },
+    onclick: redirectToPast
   };
 
   let areaChart = generateLineArea(pasAppId, passedAppliedParams, '');
@@ -350,4 +329,18 @@ function generateLineArea(chartDivId, dataParams, chartTitle) {
       enabled: true
     }
   });
+}
+
+
+function redirectToPast(x) { 
+  let new_date = x.x
+  console.log(new_date)
+  static_date = new Date('2019-09-30')
+  if (new_date >= static_date) {
+    let new_date_str = new_date.toISOString().substring(0, 10)
+    let loc = window.location.href
+    let current_date = loc.substring(loc.length - 10, loc.length)
+    redirect = loc.replace(current_date, new_date_str)
+    location.replace(redirect);
+  };
 }

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -44,6 +44,8 @@ function redirectToPast(x) {
   if (new_date >= static_date) {
     let new_date_str = new_date.toISOString().substring(0, 10)
     redirectToDate(new_date_str)
+  } else {
+    alert("Sorry, you cannot see the data before 2019-09-30")
   };
 }
 

--- a/emmaa_service/templates/index_template.html
+++ b/emmaa_service/templates/index_template.html
@@ -3,7 +3,7 @@
 {% block body %}
 <div class="container">
   <div class="row card-deck mb-3 text-center">
-    {% for model_id, model_meta in model_data %}
+    {% for model_id, model_meta, date in model_data %}
     <div class="col-md-4">
       <div class="card mb-4 shadow-sm">
         <div class="card-header">
@@ -19,7 +19,7 @@
           <p class="card-text">{{ model_meta['description'] }}</p>
           <div class="d-flex justify-content-between align-items-center">
             <div class="btn-group">
-              <a class="btn btn-sm btn-outline-secondary" href="./dashboard/{{ model_id }}">Details</a>
+              <a class="btn btn-sm btn-outline-secondary" href="./dashboard/{{ model_id }}/{{ date }}">Details</a>
               <a class="btn btn-sm btn-outline-secondary"
                  href="http://www.ndexbio.org/#/network/{{ model_meta['ndex']['network'] }}" target="_blank">View on NDEX</a>
             </div>

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -31,12 +31,12 @@
   <select class="custom-select" id="modelSelectDD" aria-label="Example select with button addon">
     <option selected disabled hidden>Select model...</option>
     {% for model_id, model_meta, date in model_data %}
-    <option value="{{ model_id }}">{{ model_meta['human_readable_name'] }} ({{ model_id.upper() }})</option>
+    <option value="{{ model_id }} {{ date }}">{{ model_meta['human_readable_name'] }} ({{ model_id.upper() }})</option>
     {% endfor %}
   </select>
   <!-- selectModel(modelInfoTableBody, listTestResultsTableBody, testResultTableBody, ddSelect) -->
   <div class="input-group-append">
-    <button class="btn btn-outline-secondary" onClick="modelRedirect(document.getElementById('modelSelectDD'), '{{ model }}')" type="button">Load Model</button>
+    <button class="btn btn-outline-secondary" onClick="modelDateRedirect(document.getElementById('modelSelectDD'), '{{ model }}')" type="button">Load Model</button>
   </div>
 </div>
 {% endblock %}

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -24,6 +24,9 @@
 
 {% block extend_header %}
 <!-- Model select dropdown -->
+<div class="input-group-append">
+  <button class="btn btn-outline-secondary" onClick="redirectToDate('{{ latest_date }}')" type="button">Latest Stats</button>
+</div>
 <div class="d-inline-flex p-2 input-group" style="width: 410px;">
   <select class="custom-select" id="modelSelectDD" aria-label="Example select with button addon">
     <option selected disabled hidden>Select model...</option>

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -27,7 +27,7 @@
 <div class="d-inline-flex p-2 input-group" style="width: 410px;">
   <select class="custom-select" id="modelSelectDD" aria-label="Example select with button addon">
     <option selected disabled hidden>Select model...</option>
-    {% for model_id, model_meta in model_data %}
+    {% for model_id, model_meta, date in model_data %}
     <option value="{{ model_id }}">{{ model_meta['human_readable_name'] }} ({{ model_id.upper() }})</option>
     {% endfor %}
   </select>

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -25,7 +25,9 @@
 {% block extend_header %}
 <!-- Model select dropdown -->
 <div class="input-group-append">
-  <button class="btn btn-outline-secondary" onClick="redirectToDate('{{ latest_date }}')" type="button">Latest Stats</button>
+  {% if not latest_date == date %}
+  <button class="btn btn-outline-secondary" onClick="redirectToDate('{{ latest_date }}')" type="button">Go to Latest</button>
+{% endif %}
 </div>
 <div class="d-inline-flex p-2 input-group" style="width: 410px;">
   <select class="custom-select" id="modelSelectDD" aria-label="Example select with button addon">

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -27,13 +27,17 @@
 <div class="input-group-append">
   {% if not latest_date == date %}
   <button class="btn btn-outline-secondary" onClick="redirectToDate('{{ latest_date }}')" type="button">Go to Latest</button>
-{% endif %}
+  {% endif %}
 </div>
 <div class="d-inline-flex p-2 input-group" style="width: 410px;">
   <select class="custom-select" id="modelSelectDD" aria-label="Example select with button addon">
     <option selected disabled hidden>Select model...</option>
     {% for model_id, model_meta, date in model_data %}
-    <option value="{{ model_id }} {{ date }}">{{ model_meta['human_readable_name'] }} ({{ model_id.upper() }})</option>
+      {% if model_id == model %}
+        <option selected value="{{ model_id }} {{ date }}">{{ model_meta['human_readable_name'] }} ({{ model_id.upper() }})</option>
+      {% else %}
+        <option value="{{ model_id }} {{ date }}">{{ model_meta['human_readable_name'] }} ({{ model_id.upper() }})</option>
+      {% endif %}
     {% endfor %}
   </select>
   <!-- selectModel(modelInfoTableBody, listTestResultsTableBody, testResultTableBody, ddSelect) -->

--- a/emmaa_service/templates/query_template.html
+++ b/emmaa_service/templates/query_template.html
@@ -29,7 +29,7 @@
       <div class="checkbox-container">
         <div class="form-select">
           <select name="model-select" id="model-select" placeholder="Select models" multiple>
-          {% for model_id, config_json in model_data %}
+          {% for model_id, config_json, _ in model_data %}
             <option value="{{ model_id }}">{{ config_json.human_readable_name }}</option>
           {% endfor %}
           </select>

--- a/emmaa_service/templates/tests_template.html
+++ b/emmaa_service/templates/tests_template.html
@@ -11,11 +11,13 @@
 {% endblock %}
 
 {% block extend_header %}
+{% if not is_query_page %}
 <div class="input-group-append">
   {% if not latest_date == date %}
   <button class="btn btn-outline-secondary" onClick="redirectToDate('{{ latest_date }}')" type="button">Go to Latest</button>
   {% endif %}
 </div>
+{% endif %}
 <!-- Model type select dropdown -->
 <div class="d-inline-flex p-2 input-group" style="width: 300px; height: 54px;">
   <select class="custom-select" id="modelTypeSelectDD" aria-label="Example select with button addon">

--- a/emmaa_service/templates/tests_template.html
+++ b/emmaa_service/templates/tests_template.html
@@ -11,8 +11,13 @@
 {% endblock %}
 
 {% block extend_header %}
+<div class="input-group-append">
+  {% if not latest_date == date %}
+  <button class="btn btn-outline-secondary" onClick="redirectToDate('{{ latest_date }}')" type="button">Go to Latest</button>
+  {% endif %}
+</div>
 <!-- Model type select dropdown -->
-<div class="d-inline-flex p-2 input-group" style="width: 300px;">
+<div class="d-inline-flex p-2 input-group" style="width: 300px; height: 54px;">
   <select class="custom-select" id="modelTypeSelectDD" aria-label="Example select with button addon">
     <option selected disabled hidden>Select model...</option>
     {% for mt in all_model_types %}
@@ -29,6 +34,6 @@
 
 {% block body %}
 <div class="container">
-  {{ detailed_paths(path_list, test, model, model_type, formatted_names, test_status, "test_card", "test_result", is_query_page)}}
+  {{ detailed_paths(path_list, test, model, model_type, formatted_names, date, test_status, "test_card", "test_result", is_query_page)}}
 </div>
 {% endblock %}


### PR DESCRIPTION
This PR adds 'time travel' functionality to EMMAA dashboard. User can click on the earlier point on any of three time graphs and be redirected to the dashboard displaying statistics for that date. This functionality is supported on model/tests page and on detailed test results page. It is possible to go back to present by clicking the button on top of the page. This PR also moves some more generic useful functions from emmaa_service/api.py to emmaa/model.py and adds more tests. 
Changes are deployed on EMMAA dev machine.
This PR depends on https://github.com/indralab/ui_util/pull/4