### PR TITLE
Fix subscribing to dynamic query bug

### DIFF
--- a/emmaa_service/static/queryFunctions.js
+++ b/emmaa_service/static/queryFunctions.js
@@ -14,7 +14,7 @@ function postQuery(queryContainer) {
   } else {
     var statusId = 'dyn-query-status';
     var tab = 'dynamic';
-    var reg = document.getElementById('register-dev-query').checked;
+    var reg = document.getElementById('register-dyn-query').checked;
   }
   if (querySel.length < 2) {
     queryNotify('Did not send query', statusId);

--- a/emmaa_service/static/queryFunctions.js
+++ b/emmaa_service/static/queryFunctions.js
@@ -10,17 +10,16 @@ function postQuery(queryContainer) {
   if (queryContainer.id == 'query-container') {
     var statusId = 'query-status';
     var tab = 'static';
+    var reg = document.getElementById('register-query').checked;
   } else {
     var statusId = 'dyn-query-status';
     var tab = 'dynamic';
+    var reg = document.getElementById('register-dev-query').checked;
   }
   if (querySel.length < 2) {
     queryNotify('Did not send query', statusId);
     return;
   }
-
-  // Check if user wants to register query
-  let reg = document.getElementById('register-query').checked;
 
   let ajax_response = submitQuery({
     models: querySel[0],

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -64,7 +64,7 @@
     #query-submit {
       background-color: rgb(221, 221, 221);
     }
-    #dyn-qyery-submit {
+    #dyn-query-submit {
       background-color: rgb(221, 221, 221);
     }
     button.btn-primary { /* For login button */

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -64,6 +64,9 @@
     #query-submit {
       background-color: rgb(221, 221, 221);
     }
+    #dyn-qyery-submit {
+      background-color: rgb(221, 221, 221);
+    }
     button.btn-primary { /* For login button */
       background-color: #007bff;
     }

--- a/emmaa_service/templates/query_template.html
+++ b/emmaa_service/templates/query_template.html
@@ -184,7 +184,7 @@
                   <!-- register -->
                   <div class="register-container col" style="padding-left: 2px; padding-right: 1px">
                     <div class="checkbox">
-                      <input type="checkbox" name="register" id="register-query"><label
+                      <input type="checkbox" name="register" id="register-dev-query"><label
                         for="register-query">Subscribe To Query</label>
                     </div>
                   </div>

--- a/emmaa_service/templates/query_template.html
+++ b/emmaa_service/templates/query_template.html
@@ -184,7 +184,7 @@
                   <!-- register -->
                   <div class="register-container col" style="padding-left: 2px; padding-right: 1px">
                     <div class="checkbox">
-                      <input type="checkbox" name="register" id="register-dev-query"><label
+                      <input type="checkbox" name="register" id="register-dyn-query"><label
                         for="register-query">Subscribe To Query</label>
                     </div>
                   </div>
@@ -192,7 +192,7 @@
                 <!-- formsubmit -->
                 <div class="row">
                   <div class="container">
-                    <input class="btn" style="margin-top: 10px" type="submit" text="Submit query" name="query-submit" id="query-submit">
+                    <input class="btn" style="margin-top: 10px" type="submit" text="Submit query" name="dyn-query-submit" id="dyn-query-submit">
                   </div>
                 </div>
               </form>


### PR DESCRIPTION
This PR fixes a bug that prevented subscription to dynamic queries because the element ID of "Subscribe" checkbox was not unique (it was only possible to subscribe if the checkbox was checked on static tab)