### PR TITLE
Reload ModelManager

### DIFF
--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -366,10 +366,16 @@ def format_results(results, query_type='path_property'):
 
 def load_model_manager_from_cache(model_name, bucket=EMMAA_BUCKET_NAME):
     model_manager = model_manager_cache.get(model_name)
-    if model_manager and model_manager.date_str in find_latest_s3_file(
-            bucket, f'results/{model_name}/model_manager_', '.pkl'):
-        logger.info(f'Loaded model manager for {model_name} from cache.')
-        return model_manager
+    if model_manager:
+        latest_on_s3 = find_latest_s3_file(
+            bucket, f'results/{model_name}/model_manager_', '.pkl')
+        cached_date = model_manager.date_str
+        logger.info(f'Found model manager cached on {cached_date} and '
+                    f'latest file on S3 is {latest_on_s3}')
+        if cached_date in latest_on_s3:
+            logger.info(f'Loaded model manager for {model_name} from cache.')
+            return model_manager
+    logger.info(f'Loading model manager for {model_name} from S3.')
     model_manager = load_model_manager_from_s3(
         model_name=model_name, bucket=bucket)
     model_manager_cache[model_name] = model_manager

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -4,7 +4,8 @@ from datetime import datetime
 
 from emmaa.model_tests import load_model_manager_from_s3
 from emmaa.db import get_db
-from emmaa.util import get_s3_client, make_date_str, EMMAA_BUCKET_NAME
+from emmaa.util import get_s3_client, make_date_str, find_latest_s3_file, \
+    EMMAA_BUCKET_NAME
 
 
 logger = logging.getLogger(__name__)
@@ -365,7 +366,8 @@ def format_results(results, query_type='path_property'):
 
 def load_model_manager_from_cache(model_name, bucket=EMMAA_BUCKET_NAME):
     model_manager = model_manager_cache.get(model_name)
-    if model_manager:
+    if model_manager and model_manager.date_str in find_latest_s3_file(
+            bucket, f'results/{model_name}/model_manager_', '.pkl'):
         logger.info(f'Loaded model manager for {model_name} from cache.')
         return model_manager
     model_manager = load_model_manager_from_s3(


### PR DESCRIPTION
This PR updates load_model_manager_from_cache function to check if the cached version of the ModelManager is also the latest available on S3 and load a new one otherwise.