### PR TITLE
Update to detailed results page and loading previous files

### DIFF
--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -705,7 +705,7 @@ class TestStatsGenerator(StatsGenerator):
             logger.info(f'Could not find a key to the previous statistics '
                         f'for {self.model_name} model, trying with the'
                         ' earlier file.')
-            self.previous_round self._get_previous_round(attempt=2)
+            self.previous_round = self._get_previous_round(attempt=2)
             key = (f'stats/{self.model_name}/test_stats_{self.test_corpus}_'
                    f'{self.previous_round.date_str}.json')
             if key is None:

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -116,10 +116,11 @@ class QueryManager(object):
         results = self.db.get_results(user_email, query_type=query_type)
         return format_results(results, query_type)
 
-    def retrieve_results_from_hashes(self, query_hashes,
-                                     query_type='path_property'):
+    def retrieve_results_from_hashes(
+            self, query_hashes, query_type='path_property', latest_order=1):
         """Retrieve results from a db given a list of query-model hashes."""
-        results = self.db.get_results_from_hashes(query_hashes)
+        results = self.db.get_results_from_hashes(
+            query_hashes, latest_order=latest_order)
         return format_results(results, query_type)
 
     def make_reports_from_results(

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -452,6 +452,12 @@ class EmmaaDatabaseManager(object):
             logger.exception(e)
             return False
 
+    def get_number_of_results(self, query_hash):
+        with self.get_session() as sess:
+            q = (sess.query(Result.id).filter(Result.query_hash == query_hash,
+                                              Query.hash == Result.query_hash))
+        return len(q.all())
+
 
 def _weed_results(result_iter, latest_order=1):
     # Each element of result_iter: (model_id, query(object), result_json, date)

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -509,7 +509,8 @@ def _default_test(model):
 def last_updated_date(model, file_type='model', date_format='date',
                       tests='large_corpus_tests', extension='.pkl', n=0,
                       bucket=EMMAA_BUCKET_NAME):
-    """Find the most recent pickle file of model and return its creation date
+    """Find the most recent or the nth file of given type on S3 and return its
+    creation date.
 
     Example file name:
     models/aml/model_2018-12-13-18-11-54.pkl
@@ -527,6 +528,10 @@ def last_updated_date(model, file_type='model', date_format='date',
         in the format "YYYY-MM-DD"). Default is 'date'.
     extension : str
         The extension the model file needs to have. Default is '.pkl'
+    n : int
+        Index of the file in list of S3 files sorted by date (0-indexed).
+    bucket : str
+        Name of bucket on S3.
 
     Returns
     -------
@@ -584,13 +589,17 @@ def get_model_stats(model, mode, tests='large_corpus_tests', date=None,
     date : str or None
         Date for which the stats will be returned in "YYYY-MM-DD" format.
     extension : str
-
+        Extension of the file.
+    n : int
+        Index of the file in list of S3 files sorted by date (0-indexed).
+    bucket : str
+        Name of bucket on S3.
     Returns
     -------
     model_data : json
         The json formatted data containing the statistics for the model
     """
-    # If date is not specified, get the latest
+    # If date is not specified, get the latest or the nth
     if not date:
         if mode == 'model':
             date = last_updated_date(model, 'model_stats', 'date',

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -253,7 +253,7 @@ class ModelManager(object):
             for mc_type in self.mc_types:
                 mc = self.get_updated_mc(mc_type, [query.path_stmt])
                 max_path_length, max_paths = self._get_test_configs(
-                    mode='query', mc_type=mc_type)
+                    mode='query', mc_type=mc_type, default_paths=5)
                 result = mc.check_statement(
                     query.path_stmt, max_paths, max_path_length)
                 results.append((mc_type, self.process_response(mc_type, result)))

--- a/emmaa/tests/test_s3.py
+++ b/emmaa/tests/test_s3.py
@@ -330,9 +330,9 @@ def test_util_find_on_s3_functions():
                                       'results/test/results_')
     assert len(files) == 1
     assert find_latest_s3_file(TEST_BUCKET_NAME, 'results/test/results_')
-    assert not find_second_latest_s3_file(
-        TEST_BUCKET_NAME, 'results/test/results_')
-    assert find_second_latest_s3_file(TEST_BUCKET_NAME, 'results/test/')
+    assert not find_nth_latest_s3_file(
+        1, TEST_BUCKET_NAME, 'results/test/results_')
+    assert find_nth_latest_s3_file(1, TEST_BUCKET_NAME, 'results/test/')
     assert find_number_of_files_on_s3(TEST_BUCKET_NAME, 'results/test/') == 2
     assert find_number_of_files_on_s3(
         TEST_BUCKET_NAME, 'results/test/results_') == 1

--- a/emmaa/tests/test_s3.py
+++ b/emmaa/tests/test_s3.py
@@ -315,7 +315,7 @@ def test_answer_queries_from_s3():
 def test_util_find_on_s3_functions():
     # Local imports are recommended when using moto
     from emmaa.util import sort_s3_files_by_date_str, find_latest_s3_file, \
-        find_second_latest_s3_file, find_number_of_files_on_s3
+        find_nth_latest_s3_file, find_number_of_files_on_s3
     # Bucket has mm (pkl) and results (json) files, both in results folder
     client = setup_bucket(add_mm=True, add_results=True)
     # Get both

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -126,6 +126,17 @@ def sort_s3_files_by_last_mod(bucket, prefix, time_delta=None,
         return key_list if w_dt else [t[0] for t in key_list]
 
 
+def find_nth_latest_s3_file(n, bucket, prefix, extension=None):
+    """Return the key of the file with nth (0-indexed) latest date string on
+    an S3 path"""
+    files = sort_s3_files_by_date_str(bucket, prefix, extension)
+    try:
+        latest = files[n]
+        return latest
+    except IndexError:
+        logger.debug('File is not found.')
+
+
 def find_latest_s3_file(bucket, prefix, extension=None):
     """Return the key of the file with latest date string on an S3 path"""
     files = sort_s3_files_by_date_str(bucket, prefix, extension)
@@ -198,6 +209,12 @@ def get_email_content(key):
     s3 = get_s3_client(unsigned=False)
     email_obj = s3.get_object(Bucket=email_bucket, Key=key)
     return email_obj['Body'].read().decode()
+
+
+def find_index_of_s3_file(key, bucket, prefix, extension=None):
+    files = sort_s3_files_by_date_str(bucket, prefix, extension)
+    ix = files.index(key)
+    return ix
 
 
 def does_exist(bucket, prefix, extension=None):

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -139,23 +139,7 @@ def find_nth_latest_s3_file(n, bucket, prefix, extension=None):
 
 def find_latest_s3_file(bucket, prefix, extension=None):
     """Return the key of the file with latest date string on an S3 path"""
-    files = sort_s3_files_by_date_str(bucket, prefix, extension)
-    try:
-        latest = files[0]
-        return latest
-    except IndexError:
-        logger.debug('File is not found.')
-
-
-def find_second_latest_s3_file(bucket, prefix, extension=None):
-    """Return the key of the file with second latest date string on an S3 path
-    """
-    files = sort_s3_files_by_date_str(bucket, prefix, extension)
-    try:
-        latest = files[1]
-        return latest
-    except IndexError:
-        logger.debug("File is not found.")
+    return find_nth_latest_s3_file(0, bucket, prefix, extension)
 
 
 def find_latest_s3_files(number_of_files, bucket, prefix, extension=None):

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -214,7 +214,8 @@ def _new_applied_tests(
     if len(new_app_hashes) == 0:
         return 'No new tests were applied'
     new_app_tests = [(th, all_test_results[th]) for th in new_app_hashes]
-    return _format_table_array(new_app_tests, model_types, model_name, date)
+    return _format_table_array(
+        new_app_tests, model_types, model_name, date, test_corpus)
 
 
 def _format_table_array(tests_json, model_types, model_name, date, test_corpus):

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -117,6 +117,19 @@ function testRedirect(ddSelect) {
 }
 
 
+function redirectOneStep(value, isQuery) {
+  let loc = window.location.href;
+  if (isQuery) {
+    let currentOrder = new URL(loc).searchParams.get('order')
+    var redirect = loc.replace(`order=${currentOrder}`, `order=${value}`)
+  } else {
+    let currentDate = new URL(loc).searchParams.get('date')
+    var redirect = loc.replace(`date=${currentDate}`, `date=${value}`)
+  };
+  location.replace(redirect);
+}
+
+
 function clearTables(arrayOfTableBodies) {
   for (let tableBody of arrayOfTableBodies) {
     clearTable(tableBody)

--- a/emmaa_service/templates/tests_template.html
+++ b/emmaa_service/templates/tests_template.html
@@ -36,6 +36,6 @@
 
 {% block body %}
 <div class="container">
-  {{ detailed_paths(path_list, test, model, model_type, formatted_names, date, test_status, "test_card", "test_result", is_query_page)}}
+  {{ detailed_paths(path_list, test, model, model_type, formatted_names, date, prev, next, test_status, "test_card", "test_result", is_query_page)}}
 </div>
 {% endblock %}

--- a/emmaa_service/templates/tests_template.html
+++ b/emmaa_service/templates/tests_template.html
@@ -17,6 +17,12 @@
   <button class="btn btn-outline-secondary" onClick="redirectToDate('{{ latest_date }}')" type="button">Go to Latest</button>
   {% endif %}
 </div>
+{% else %}
+<div class="input-group-append">
+  {% if next %}
+  <button class="btn btn-outline-secondary" onClick="redirectOneStep(1, 1)" type="button">Go to Latest</button>
+  {% endif %}
+</div>
 {% endif %}
 <!-- Model type select dropdown -->
 <div class="d-inline-flex p-2 input-group" style="width: 300px; height: 54px;">


### PR DESCRIPTION
This PR enables navigating to previous or next result when on detailed test/query result page. Front end changes depend on https://github.com/indralab/ui_util/pull/6. On the back end, few changes were made to api, util and db manager to enable finding previous/next results for both tests (from s3) and queries (from db). This PR also adds test_corpus as a url parameter on the detailed test page (it was previously only used on the test page with all test results) which enables browsing individual test results for any test corpora (it was only possible for default test corpus before).

Additionally, this PR makes changes to StatsGenerator methods for loading previous round files - backwards compatibility to load files with older filenames is removed and additional checks are added to make sure that we get the correct file. It happened occasionally that Batch jobs were invoked more than once, and  2 model managers or 2 test results were created on the same while there were no corresponding stats for them and because of the backward compatibility handling some of the older files were loaded instead which resulted in missing data from the graphs (which was manually patched when detected). This PR should fix this issue.