### PR TITLE
Query link patch

### DIFF
--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -411,9 +411,10 @@ def is_query_result_diff(new_result_json, old_result_json=None):
 
 def _detailed_page_link(domain, model_name, model_type, query_hash):
     # example:
-    # https://emmaa.indra.bio/query/aml/?model_type=pysb&query_hash=4911955502409811
+    # https://emmaa.indra.bio/query/aml/?model_type=pysb&query_hash
+    # =4911955502409811&order=1
     return f'https://{domain}/query/{model_name}/?model_type=' \
-           f'{model_type}&query_hash={query_hash}'
+           f'{model_type}&query_hash={query_hash}&order=1'
 
 
 def format_results(results, query_type='path_property'):

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -452,10 +452,11 @@ class EmmaaDatabaseManager(object):
             logger.exception(e)
             return False
 
-    def get_number_of_results(self, query_hash):
+    def get_number_of_results(self, query_hash, mc_type):
         with self.get_session() as sess:
             q = (sess.query(Result.id).filter(Result.query_hash == query_hash,
-                                              Query.hash == Result.query_hash))
+                                              Query.hash == Result.query_hash,
+                                              Result.mc_type == mc_type))
         return len(q.all())
 
 

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -302,7 +302,7 @@ class EmmaaDatabaseManager(object):
             q = (sess.query(Query.model_id, Query.json, Result.mc_type,
                             Result.result_json, Result.date)
                  .filter(Result.query_hash.in_(query_hashes),
-                         Query.hash == Result.query_hash))
+                         Query.hash == Result.query_hash)).distinct()
             results = _make_queries_in_results(q.all())
             results = _weed_results(results, latest_order=latest_order)
         logger.info(f"Found {len(results)} results.")

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -337,7 +337,8 @@ def get_model_dashboard(model):
     user, roles = resolve_auth(dict(request.args))
     model_meta_data = _get_model_meta_data()
     model_stats, _ = get_model_stats(model, 'model', date=date)
-    test_stats, _ = get_model_stats(model, 'test', tests=test_corpus, date=date)
+    test_stats, _ = get_model_stats(model, 'test', tests=test_corpus,
+                                    date=date)
     if not model_stats or not test_stats:
         abort(Response(f'Data for {model} and {test_corpus} for {date} '
                        f'was not found', 404))

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -533,7 +533,7 @@ def get_query_page():
 def get_query_tests_page(model):
     model_type = request.args.get('model_type')
     query_hash = int(request.args.get('query_hash'))
-    order = int(request.args.get('order'))
+    order = int(request.args.get('order', 1))
     results = qm.retrieve_results_from_hashes(
         [query_hash], 'path_property', order)
     detailed_results = results[query_hash][model_type]\

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -330,7 +330,8 @@ def get_home():
 @app.route('/dashboard/<model>/')
 @jwt_optional
 def get_model_dashboard(model):
-    date = request.args.get('date', datetime.now().strftime('%Y-%m-%d'))
+    date = request.args.get('date', get_latest_available_date(
+        model, _get_test_corpora(model)))
     test_corpus = request.args.get('test_corpus', _default_test(model))
     tab = request.args.get('tab', 'model')
     user, roles = resolve_auth(dict(request.args))

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -239,8 +239,12 @@ def _format_query_results(formatted_results):
     for qh, res in formatted_results.items():
         model_types = [mt for mt in ALL_MODEL_TYPES if mt in res]
         model = res['model']
+        latest_date = get_latest_available_date(
+            model, _get_test_corpora(model))
         new_res = [('', res["query"], ''),
-                   (f'/dashboard/{model}', model,
+                   (f'/dashboard/{model}/?date={latest_date}' +
+                    f'&test_corpus={_get_test_corpora(model)}&tab=model',
+                    model,
                     f'Click to see details about {model}')]
         for mt in model_types:
             url_param = parse.urlencode(

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -432,7 +432,9 @@ def get_model_tests_page(model):
     latest_date = get_latest_available_date(model, test_corpus)
     prefix = f'stats/{model}/test_stats_{test_corpus}_'
     cur_ix = find_index_of_s3_file(file_key, EMMAA_BUCKET_NAME, prefix)
-    if (cur_ix + 1) < find_number_of_files_on_s3(
+    if test_hash in test_stats['tests_delta']['applied_hashes_delta']['added']:
+        prev_date = None
+    elif (cur_ix + 1) < find_number_of_files_on_s3(
             EMMAA_BUCKET_NAME, prefix, '.json'):
         prev_date = last_updated_date(
             model, 'test_stats', 'date', tests=test_corpus, extension='.json',

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -541,8 +541,8 @@ def get_query_tests_page(model):
     date = results[query_hash]['date']
     card_title = ('', results[query_hash]['query'] if results else '', '')
     next_order = order - 1 if order > 1 else None
-    prev_order = order + 1 if order < qm.db.get_number_of_results(query_hash) \
-        else None
+    prev_order = order + 1 if \
+        order < qm.db.get_number_of_results(query_hash, model_type) else None
     return render_template('tests_template.html',
                            link_list=link_list,
                            model=model,

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -326,8 +326,8 @@ def get_home():
 @app.route('/dashboard/<model>/')
 @jwt_optional
 def get_model_dashboard(model):
-    date = request.args.get('date')
-    test_corpus = request.args.get('test_corpus')
+    date = request.args.get('date', datetime.now().strftime('%Y-%m-%d'))
+    test_corpus = request.args.get('test_corpus', _default_test(model))
     tab = request.args.get('tab', 'model')
     user, roles = resolve_auth(dict(request.args))
     model_meta_data = _get_model_meta_data()

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -120,8 +120,14 @@ function testRedirect(ddSelect) {
 function redirectOneStep(value, isQuery) {
   let loc = window.location.href;
   if (isQuery) {
-    let currentOrder = new URL(loc).searchParams.get('order')
-    var redirect = loc.replace(`order=${currentOrder}`, `order=${value}`)
+    let currentOrder = new URL(loc).searchParams.get('order');
+    var redirect = '';
+    if (currentOrder) {
+      redirect = loc.replace(`order=${currentOrder}`, `order=${value}`)
+    } else {
+      // Default if no order in query string
+      redirect = loc.concat('&order=1')
+    }
   } else {
     let currentDate = new URL(loc).searchParams.get('date')
     var redirect = loc.replace(`date=${currentDate}`, `date=${value}`)

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -38,13 +38,13 @@ function modelRedirect(ddSelect, current_model) {
   window.location.replace(redirect);
 }
 function redirectToPast(x) { 
-  let new_date = x.x
-  static_date = new Date('2019-09-30')
+  let new_date = x.x;
+  let static_date = new Date('2019-09-30');
   if (new_date >= static_date) {
-    var year = new_date.getFullYear();
-    var month = (1 + new_date.getMonth()).toString();
+    let year = new_date.getFullYear();
+    let month = (1 + new_date.getMonth()).toString();
     month = month.length > 1 ? month : '0' + month;
-    day = new_date.getDate().toString();
+    let day = new_date.getDate().toString();
     day = day.length > 1 ? day : '0' + day;
     let new_date_str = year + '-' + month + '-' + day;
     console.log(new_date_str)
@@ -55,9 +55,21 @@ function redirectToPast(x) {
 }
 
 function redirectToDate(new_date_str) {
-  let loc = window.location.href
-  let current_date = new URL(loc).searchParams.get('date')
-  let redirect = loc.replace(current_date, new_date_str)
+  let loc = window.location.href;
+  let current_date = new URL(loc).searchParams.get('date');
+  let redirect = '';
+  if (current_date) {
+    redirect = loc.replace(current_date, new_date_str)
+  } else {
+    if (loc.includes('?')) {
+      // There are already other query paramters, append
+      redirect = loc.concat(`&date=${new_date_str}`)
+    } else {
+      // This is only query paramter, add
+      redirect = loc.concat(`?date=${new_date_str}`)
+    }
+  }
+
   location.replace(redirect);
 }
 


### PR DESCRIPTION
This PR patches some small issues that came up after merging #126 and #128.

Main changes:
- Links to the detailed query results from emails will now work with the update for paging
- `db.get_results_from_hashes()` returns unique results
- Model page links from query page are fixed
- Several pages now have default values if query parameters are missing