### PR TITLE
Curation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - tar xzf bionetgen.tar.gz
   - export BNGPATH=`pwd`/BioNetGen-2.4.0
   - pip install git+https://github.com/sorgerlab/indra.git
-  - pip install enum34==1.1.9
+  - pip uninstall enum34
   - pip install git+https://github.com/indralab/indra_db.git
   - pip install git+https://github.com/indralab/indra_reading.git
   - pip install git+https://github.com/sorgerlab/bioagents.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - tar xzf bionetgen.tar.gz
   - export BNGPATH=`pwd`/BioNetGen-2.4.0
   - pip install git+https://github.com/sorgerlab/indra.git
-  - pip uninstall enum34
+  - pip uninstall -y enum34
   - pip install git+https://github.com/indralab/indra_db.git
   - pip install git+https://github.com/indralab/indra_reading.git
   - pip install git+https://github.com/sorgerlab/bioagents.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
   - tar xzf bionetgen.tar.gz
   - export BNGPATH=`pwd`/BioNetGen-2.4.0
   - pip install git+https://github.com/sorgerlab/indra.git
+  - pip install enum34==1.1.9
   - pip install git+https://github.com/indralab/indra_db.git
   - pip install git+https://github.com/indralab/indra_reading.git
   - pip install git+https://github.com/sorgerlab/bioagents.git

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -291,7 +291,8 @@ class TestRound(Round):
     def get_path_stmt_counts(self):
         path_stmt_counts = self.json_results[0].get('path_stmt_counts')
         if path_stmt_counts:
-            return sorted(path_stmt_counts.items(), key=lambda x: x[1])
+            return sorted(
+                path_stmt_counts.items(), key=lambda x: x[1], reverse=True)
         return []
 
     def _get_results(self, mc_type):

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -3,7 +3,7 @@ import logging
 import jsonpickle
 from collections import defaultdict
 from emmaa.model import _default_test
-from emmaa.model_tests import elsevier_url, load_model_manager_from_s3
+from emmaa.model_tests import load_model_manager_from_s3
 from emmaa.util import (find_latest_s3_file, find_nth_latest_s3_file,
                         strip_out_date, get_s3_client, EMMAA_BUCKET_NAME,
                         FORMAT)
@@ -28,9 +28,6 @@ class Round(object):
 
     Parameters
     ----------
-    link_type : str
-        A name of a source to link the statements to (e.g. 'indra_db' or
-        'elsevier')
     date_str : str
         Time when ModelManager responsible for this round was created.
 
@@ -44,8 +41,7 @@ class Round(object):
         while the second returns an English description of a given content type
         for a single hash.
     """
-    def __init__(self, link_type, date_str):
-        self.link_type = link_type
+    def __init__(self, date_str):
         self.date_str = date_str
         self.function_mapping = CONTENT_TYPE_FUNCTION_MAPPING
 
@@ -56,19 +52,7 @@ class Round(object):
     def get_english_statement(self, stmt):
         ea = EnglishAssembler([stmt])
         sentence = ea.make_model()
-        if self.link_type == 'indra_db':
-            link = get_statement_queries([stmt])[0] + '&format=html'
-            evid_text = ''
-        elif self.link_type == 'elsevier':
-            pii = stmt.evidence[0].annotations.get('pii', None)
-            if pii:
-                link = elsevier_url + pii
-            else:
-                link = ''
-            evid_text = stmt.evidence[0].text
-        elif self.link_type == 'test':
-            link = evid_text = ''
-        return (link, sentence, evid_text)
+        return ('', sentence, '')
 
     def find_delta_hashes(self, other_round, content_type, **kwargs):
         """Return a dictionary of changed hashes of a given content type. This
@@ -116,8 +100,8 @@ class ModelRound(Round):
     statements : list[indra.statements.Statement]
         A list of INDRA Statements used to assemble a model.
     """
-    def __init__(self, statements, link_type, date_str):
-        super().__init__(link_type, date_str)
+    def __init__(self, statements, date_str):
+        super().__init__(date_str)
         self.statements = statements
 
     @classmethod
@@ -126,7 +110,6 @@ class ModelRound(Round):
         if not mm:
             return
         statements = mm.model.assembled_stmts
-        link_type = mm.link_type
         try:
             date_str = mm.date_str
         except AttributeError:
@@ -136,7 +119,7 @@ class ModelRound(Round):
                 Prefix='results/rasmodel/latest_model_manager.pkl')
             date = keys['Contents'][0]['LastModified']
             date_str = date.strftime(FORMAT)
-        return cls(statements, link_type, date_str)
+        return cls(statements, date_str)
 
     def get_total_statements(self):
         """Return a total number of statements in a model."""
@@ -210,8 +193,8 @@ class TestRound(Round):
         description, result in Pass/Fail/n_a form and either a path if it
         was found or a result code if it was not.
     """
-    def __init__(self, json_results, link_type, date_str):
-        super().__init__(link_type, date_str)
+    def __init__(self, json_results, date_str):
+        super().__init__(date_str)
         self.json_results = json_results
         mc_types = self.json_results[0].get('mc_types', ['pysb'])
         self.mc_types_results = {}
@@ -226,9 +209,8 @@ class TestRound(Round):
         logger.info(f'Loading json from {key}')
         obj = client.get_object(Bucket=bucket, Key=key)
         json_results = json.loads(obj['Body'].read().decode('utf8'))
-        link_type = json_results[0].get('link_type', 'indra_db')
         date_str = json_results[0].get('date_str', strip_out_date(key))
-        return cls(json_results, link_type, date_str)
+        return cls(json_results, date_str)
 
     def get_applied_test_hashes(self):
         """Return a list of hashes for all applied tests."""

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -288,6 +288,12 @@ class TestRound(Round):
                         get_path_or_code(ix, result, mc_type)]
         return tests_by_hash
 
+    def get_path_stmt_counts(self):
+        path_stmt_counts = self.json_results[0].get('path_stmt_counts')
+        if path_stmt_counts:
+            return sorted(path_stmt_counts.items(), key=lambda x: x[1])
+        return []
+
     def _get_results(self, mc_type):
         unpickler = jsonpickle.unpickler.Unpickler()
         test_results = [unpickler.restore(result[mc_type]['result_json'])
@@ -573,7 +579,8 @@ class TestStatsGenerator(StatsGenerator):
         logger.info(f'Generating test summary for {self.model_name}.')
         self.json_stats['test_round_summary'] = {
             'number_applied_tests': self.latest_round.get_total_applied_tests(),
-            'all_test_results': self.latest_round.english_test_results}
+            'all_test_results': self.latest_round.english_test_results,
+            'path_stmt_counts': self.latest_round.get_path_stmt_counts()}
         for mc_type in self.latest_round.mc_types_results:
             self.json_stats['test_round_summary'][mc_type] = {
                 'number_passed_tests': (

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -498,12 +498,12 @@ def load_stmts_from_s3(model_name, bucket=EMMAA_BUCKET_NAME):
     return stmts
 
 
-def _default_test(model):
-    if model == 'food_insecurity':
-        test = 'world_modelers_tests'
+def _default_test(model, config=None):
+    if config:
+        return config['test']['default_test_corpus']
     else:
-        test = 'large_corpus_tests'
-    return test
+        config = load_config_from_s3(model)
+        return _default_test(model, config)
 
 
 def last_updated_date(model, file_type='model', date_format='date',

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -498,12 +498,12 @@ def load_stmts_from_s3(model_name, bucket=EMMAA_BUCKET_NAME):
     return stmts
 
 
-def _default_test(model, config=None):
+def _default_test(model, config=None, bucket=EMMAA_BUCKET_NAME):
     if config:
         return config['test']['default_test_corpus']
     else:
-        config = load_config_from_s3(model)
-        return _default_test(model, config)
+        config = load_config_from_s3(model, bucket=bucket)
+        return _default_test(model, config, bucket=bucket)
 
 
 def last_updated_date(model, file_type='model', date_format='date',
@@ -600,7 +600,7 @@ def get_model_stats(model, mode, tests=None, date=None,
         The json formatted data containing the statistics for the model
     """
     if not tests:
-        tests = _default_test(model)
+        tests = _default_test(model, bucket=bucket)
     # If date is not specified, get the latest or the nth
     if not date:
         if mode == 'model':

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -574,7 +574,7 @@ def last_updated_date(model, file_type='model', date_format='date',
             return ''
 
 
-def get_model_stats(model, mode, tests='large_corpus_tests', date=None,
+def get_model_stats(model, mode, tests=None, date=None,
                     extension='.json', n=0, bucket=EMMAA_BUCKET_NAME):
     """Gets the latest statistics for the given model
 
@@ -599,6 +599,8 @@ def get_model_stats(model, mode, tests='large_corpus_tests', date=None,
     model_data : json
         The json formatted data containing the statistics for the model
     """
+    if not tests:
+        tests = _default_test(model)
     # If date is not specified, get the latest or the nth
     if not date:
         if mode == 'model':

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -583,7 +583,7 @@ def get_model_stats(model, mode, tests='large_corpus_tests', date=None,
     model : str
         Model name to look for
     mode : str
-        Type of stats to generate (model or tests)
+        Type of stats to generate (model or test)
     tests : str
         A name of a test corpus. Default is large_corpus_tests.
     date : str or None

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -264,7 +264,8 @@ class EmmaaModel(object):
         if not self.assembly_config.get('skip_curations'):
             curations = get_curations()
             stmts = ac.filter_by_curation(
-                stmts, curations, 'any', ['correct'], update_belief=True)
+                stmts, curations, 'any',
+                ['correct', 'act_vs_amt', 'hypothesis'], update_belief=True)
         belief_cutoff = self.assembly_config.get('belief_cutoff')
         if belief_cutoff is not None:
             stmts = ac.filter_belief(stmts, belief_cutoff)

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 
 result_codes_link = 'https://emmaa.readthedocs.io/en/latest/dashboard/response_codes.html'
-elsevier_url = 'https://www.sciencedirect.com/science/article/pii/'
 RESULT_CODES = {
     'STATEMENT_TYPE_NOT_HANDLED': 'Statement type not handled',
     'SUBJECT_MONOMERS_NOT_FOUND': 'Statement subject not in model',
@@ -67,11 +66,6 @@ class ModelManager(object):
         A list of entities of EMMAA model.
     applicable_tests : list[emmaa.model_tests.EmmaaTest]
         A list of EMMAA tests applicable for given EMMAA model.
-    make_links : bool
-        Whether to include links to INDRA db in test results.
-    link_type : str
-        A name of a source to link the statements to (e.g. 'indra_db' or
-        'elsevier')
     date_str : str
         Time when this object was created.
     """
@@ -98,8 +92,6 @@ class ModelManager(object):
             self.mc_types[mc_type]['test_results'] = []
         self.entities = self.model.get_assembled_entities()
         self.applicable_tests = []
-        self.make_links = model.test_config.get('make_links', True)
-        self.link_type = model.test_config.get('link_type', 'indra_db')
         self.date_str = make_date_str()
 
     def get_updated_mc(self, mc_type, stmts):
@@ -408,8 +400,7 @@ class ModelManager(object):
         results_json = []
         results_json.append({
             'model_name': self.model.name,
-            'mc_types': [mc_type for mc_type in self.mc_types.keys()],
-            'link_type': self.link_type})
+            'mc_types': [mc_type for mc_type in self.mc_types.keys()]})
         for ix, test in enumerate(self.applicable_tests):
             test_ix_results = {'test_type': test.__class__.__name__,
                                'test_json': test.to_json()}

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -573,7 +573,7 @@ def load_tests_from_s3(test_name, bucket=EMMAA_BUCKET_NAME):
     logger.info(f'Loading tests from {test_key}')
     obj = client.get_object(Bucket=bucket, Key=test_key)
     tests = pickle.loads(obj['Body'].read())
-    return tests
+    return tests, test_key
 
 
 def save_model_manager_to_s3(model_name, model_manager,
@@ -657,7 +657,7 @@ def run_model_tests_from_s3(model_name, test_corpus='large_corpus_tests',
         tests and the test results.
     """
     mm = load_model_manager_from_s3(model_name=model_name, bucket=bucket)
-    tests = load_tests_from_s3(test_corpus, bucket=bucket)
+    tests, _ = load_tests_from_s3(test_corpus, bucket=bucket)
     tm = TestManager([mm], tests)
     tm.make_tests(ScopeTestConnector())
     tm.run_tests()

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -24,11 +24,11 @@ test_response = {
         'edge_list': [
             {'edge': 'BRAF → MAP2K1',
              'stmts': [
-                 ['https://db.indra.bio/statements/from_agents?subject=1097@HGNC&object=6840@HGNC&type=Activation&format=html',
+                 ['/evidence/?stmt_hash=-23078353002754841&source=model_statement&model=test',
                   'BRAF activates MAP2K1.', '']]},
             {'edge': 'MAP2K1 → MAPK1',
              'stmts': [
-                 ['https://db.indra.bio/statements/from_agents?subject=6840@HGNC&object=6871@HGNC&type=Activation&format=html',
+                 ['/evidence/?stmt_hash=-34603994586320440&source=model_statement&model=test',
                   'Active MAP2K1 activates MAPK1.', '']]}]}}
 query_not_appl = {'2413475507': 'Query is not applicable for this model'}
 fail_response = {'521653329': 'No path found that satisfies the test statement'}
@@ -203,8 +203,8 @@ def test_user_query_delta():
     # Using results from db
     qm.db.put_queries(test_email, 1, query_object, ['test'],
                       subscribe=True)
-    qm.db.put_results('test', [(query_object, 'pysb', test_response),
-                               (query_object, 'pysb', query_not_appl)])
+    qm.db.put_results('test', [(query_object, 'pysb', test_response)])
+    qm.db.put_results('test', [(query_object, 'pysb', query_not_appl)])
     str_rep, html_rep = qm.get_user_query_delta(user_email=test_email)
     assert str_rep, print(str_rep)
     assert html_rep, print(html_rep)

--- a/emmaa/tests/test_model_tests.py
+++ b/emmaa/tests/test_model_tests.py
@@ -34,8 +34,6 @@ def test_model_manager_structure():
         mm.mc_types['unsigned_graph']['model_checker'],
         UnsignedGraphModelChecker)
     assert isinstance(mm.entities[0], Agent)
-    assert mm.make_links is True
-    assert mm.link_type == 'indra_db'
     assert isinstance(mm.date_str, str)
 
 

--- a/emmaa/tests/test_s3.py
+++ b/emmaa/tests/test_s3.py
@@ -49,7 +49,8 @@ def setup_bucket(
             'ndex': {'network': 'a08479d1-24ce-11e9-bb6a-0ac135e8bacf'},
             'search_terms': [{'db_refs': {'HGNC': '20974'}, 'name': 'MAPK1',
                               'search_term': 'MAPK1', 'type': 'gene'}],
-            'test': {'test_corpus': 'simple_tests'},
+            'test': {'test_corpus': 'simple_tests',
+                     'default_test_corpus': 'simple_tests'},
             'human_readable_name': 'Test Model',
             'assembly': {'skip_curations': True}
             }
@@ -152,7 +153,7 @@ def test_last_updated():
 def test_get_model_statistics():
     # Local imports are recommended when using moto
     from emmaa.model import get_model_stats
-    client = setup_bucket(add_model_stats=True, add_test_stats=True)
+    client = setup_bucket(add_model=True, add_model_stats=True, add_test_stats=True)
     # Get latest model stats
     model_stats, key = get_model_stats(
         'test', 'model', bucket=TEST_BUCKET_NAME)
@@ -360,7 +361,7 @@ def test_api_load_from_s3():
     assert config
     test_corpora = _get_test_corpora('test', TEST_BUCKET_NAME)
     assert test_corpora == {'simple_tests': today}
-    # metadata always looks for 'large_corpus_tests'
+    # metadata always looks for default test
     date_str = last_updated_date(
         'test', 'test_stats', 'datetime', 'simple_tests', '.json', 0,
         TEST_BUCKET_NAME)
@@ -373,5 +374,5 @@ def test_api_load_from_s3():
     assert len(metadata[0]) == 4
     assert metadata[0][0] == 'test'
     assert metadata[0][1] == config
-    assert metadata[0][2] == 'large_corpus_tests'
+    assert metadata[0][2] == 'simple_tests'
     assert metadata[0][3] == today

--- a/emmaa/tests/test_s3.py
+++ b/emmaa/tests/test_s3.py
@@ -185,7 +185,7 @@ def test_load_tests_from_s3():
     # Local imports are recommended when using moto
     from emmaa.model_tests import load_tests_from_s3, StatementCheckingTest
     client = setup_bucket(add_tests=True)
-    tests = load_tests_from_s3('simple_tests', bucket=TEST_BUCKET_NAME)
+    tests, _ = load_tests_from_s3('simple_tests', bucket=TEST_BUCKET_NAME)
     assert isinstance(tests, list)
     assert len(tests) == 1
     test = tests[0]
@@ -247,7 +247,7 @@ def test_model_to_tests():
     tests = model_to_tests('test', bucket=TEST_BUCKET_NAME)
     assert len(tests) == 2
     assert isinstance(tests[0], StatementCheckingTest)
-    loaded_tests = load_tests_from_s3('test_tests', bucket=TEST_BUCKET_NAME)
+    loaded_tests, _ = load_tests_from_s3('test_tests', bucket=TEST_BUCKET_NAME)
     assert loaded_tests
 
 

--- a/emmaa/tests/test_stats.py
+++ b/emmaa/tests/test_stats.py
@@ -46,7 +46,7 @@ new_stmts = previous_stmts + [
 
 
 def test_model_round():
-    mr = ModelRound(previous_stmts, 'test', '2020-01-01-00-00-00')
+    mr = ModelRound(previous_stmts, '2020-01-01-00-00-00')
     assert mr
     assert mr.get_total_statements() == 2
     assert len(mr.get_stmt_hashes()) == 2
@@ -55,7 +55,7 @@ def test_model_round():
                [('BRAF', 1), ('MAP2K1', 2), ('MAPK1', 1)])
     assert all((stmt_hash, 1) in mr.get_statements_by_evidence() for stmt_hash
                in mr.get_stmt_hashes())
-    mr2 = ModelRound(new_stmts, 'test', '2020-01-02-00-00-00')
+    mr2 = ModelRound(new_stmts, '2020-01-02-00-00-00')
     assert mr2
     assert mr2.get_total_statements() == 4
     assert len(mr2.get_stmt_hashes()) == 4
@@ -67,13 +67,13 @@ def test_model_round():
 
 
 def test_test_round():
-    tr = TestRound(previous_results, 'test', '2020-01-01-00-00-00')
+    tr = TestRound(previous_results, '2020-01-01-00-00-00')
     assert tr
     assert tr.get_total_applied_tests() == 1
     assert tr.get_number_passed_tests() == 1
     assert tr.get_applied_test_hashes() == tr.get_passed_test_hashes()
     assert tr.passed_over_total() == 1.0
-    tr2 = TestRound(new_results, 'test', '2020-01-02-00-00-00')
+    tr2 = TestRound(new_results, '2020-01-02-00-00-00')
     assert tr2
     assert tr2.get_total_applied_tests() == 2
     assert tr2.get_number_passed_tests() == 2
@@ -85,8 +85,8 @@ def test_test_round():
 
 
 def test_model_stats_generator():
-    latest_round = ModelRound(new_stmts, 'test', '2020-01-02-00-00-00')
-    previous_round = ModelRound(previous_stmts, 'test', '2020-01-01-00-00-00')
+    latest_round = ModelRound(new_stmts, '2020-01-02-00-00-00')
+    previous_round = ModelRound(previous_stmts, '2020-01-01-00-00-00')
     sg = ModelStatsGenerator('test', latest_round=latest_round,
                              previous_round=previous_round,
                              previous_json_stats=previous_model_stats)
@@ -109,8 +109,8 @@ def test_model_stats_generator():
 
 
 def test_test_stats_generator():
-    latest_round = TestRound(new_results, 'test', '2020-01-02-00-00-00')
-    previous_round = TestRound(previous_results, 'test', '2020-01-01-00-00-00')
+    latest_round = TestRound(new_results, '2020-01-02-00-00-00')
+    previous_round = TestRound(previous_results, '2020-01-01-00-00-00')
     sg = TestStatsGenerator('test', latest_round=latest_round,
                             previous_round=previous_round,
                             previous_json_stats=previous_test_stats)

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -75,6 +75,8 @@ def sort_s3_files_by_date_str(bucket, prefix, extension=None):
         date_str = fname.split('_')[-1]
         return get_date_from_str(date_str)
     keys = list_s3_files(bucket, prefix, extension=extension)
+    if len(keys) < 2:
+        return keys
     keys = sorted(keys, key=lambda k: process_key(k), reverse=True)
     return keys
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -363,7 +363,8 @@ def _set_curation(stmt_hash, correct, incorrect):
 
 def _label_curations(**kwargs):
     curations = get_curations(**kwargs)
-    correct = {str(c.pa_hash) for c in curations if c.tag == 'correct'}
+    correct_tags = ['correct', 'act_vs_amt', 'hypothesis']
+    correct = {str(c.pa_hash) for c in curations if c.tag in correct_tags}
     incorrect = {str(c.pa_hash) for c in curations if
                  str(c.pa_hash) not in correct}
     return correct, incorrect

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -619,7 +619,7 @@ def get_statement_evidence_page():
     source = request.args.get('source')
     model = request.args.get('model')
     test_corpus = request.args.get('test_corpus', '')
-    curations = get_curations(pa_hash=stmt_hash)
+    curations = get_curations(pa_hash=stmt_hashes)
     cur_count = len(curations)
     stmt_rows = []
     if source == 'model_statement':

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -257,7 +257,8 @@ def _format_dynamic_query_results(formatted_results):
     return result_array
 
 
-def _new_passed_tests(model_name, test_stats_json, current_model_types, date):
+def _new_passed_tests(model_name, test_stats_json, current_model_types, date,
+                      test_ev_count, cur_counts):
     new_passed_tests = []
     all_test_results = test_stats_json['test_round_summary'][
         'all_test_results']
@@ -269,17 +270,16 @@ def _new_passed_tests(model_name, test_stats_json, current_model_types, date):
         mt_rows = [[('', f'New passed tests for '
                          f'{FORMATTED_TYPE_NAMES[mt]} model.',
                      '')]]
-        for test_hash in new_passed_hashes:
-            test = all_test_results[test_hash]
+        for th in new_passed_hashes:
+            test = all_test_results[th]
             path_loc = test[mt][1]
             if isinstance(path_loc, list):
                 path = path_loc[0]['path']
             else:
                 path = path_loc
             url_param = parse.urlencode(
-                {'model_type': mt, 'test_hash': test_hash, 'date': date})
-            new_row = [(*test['test'], stmt_db_link_msg)
-                       if len(test['test']) == 2 else test['test'],
+                {'model_type': mt, 'test_hash': th, 'date': date})
+            new_row = [(th, test['test'][1], test_ev_count[th], cur_counts[th]),
                        (f'/tests/{model_name}?{url_param}', path,
                         pass_fail_msg)]
             mt_rows.append(new_row)
@@ -429,7 +429,8 @@ def get_model_dashboard(model):
                            new_applied_tests=new_applied_test_results,
                            all_test_results=all_test_results,
                            new_passed_tests=_new_passed_tests(
-                               model, test_stats, current_model_types, date),
+                               model, test_stats, current_model_types, date,
+                               test_ev_count, cur_counts),
                            date=date,
                            latest_date=latest_date,
                            tab=tab,

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -258,7 +258,7 @@ def _format_dynamic_query_results(formatted_results):
 
 
 def _new_passed_tests(model_name, test_stats_json, current_model_types, date,
-                      test_ev_count, cur_counts):
+                      test_corpus, test_ev_count, cur_counts):
     new_passed_tests = []
     all_test_results = test_stats_json['test_round_summary'][
         'all_test_results']
@@ -278,7 +278,8 @@ def _new_passed_tests(model_name, test_stats_json, current_model_types, date,
             else:
                 path = path_loc
             url_param = parse.urlencode(
-                {'model_type': mt, 'test_hash': th, 'date': date})
+                {'model_type': mt, 'test_hash': th, 'date': date,
+                 'test_corpus': test_corpus})
             new_row = [(th, test['test'][1], test_ev_count[th], cur_counts[th]),
                        (f'/tests/{model_name}?{url_param}', path,
                         pass_fail_msg)]

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -406,7 +406,7 @@ def get_model_dashboard(model):
         model_name=model, date=date, test_corpus=test_corpus)
     if new_applied_tests:
         new_applied_test_results = _format_table_array(
-            tests_json=new_applied_model_tests,
+            tests_json=new_applied_tests,
             model_types=current_model_types, model_name=model,
             date=date, test_corpus=test_corpus)
     else:

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -801,8 +801,8 @@ def email_unsubscribe_post():
         return jsonify({'result': False, 'reason': 'Invalid signature'}), 401
 
 
-@app.route('/statements/from_hash/<model>/<test_corpus>/<hash_val>', methods=['GET'])
-def get_statement_by_hash_model(model, test_corpus, hash_val):
+@app.route('/statements/from_hash/<model>/<hash_val>', methods=['GET'])
+def get_statement_by_hash_model(model, hash_val):
     mm = load_model_manager_from_cache(model)
     st_json = {}
     for st in mm.model.assembled_stmts:
@@ -810,12 +810,16 @@ def get_statement_by_hash_model(model, test_corpus, hash_val):
             st_json = st.to_json()
             for evid in st_json['evidence']:
                 evid['source_hash'] = str(evid['source_hash'])
-    if not st_json:
-        if test_corpus[:-6] in all_models:
-            mm = load_model_manager_from_cache(test_corpus[:-6])
-            for st in mm.model.assembled_stmts:
-                if str(st.get_hash()) == str(hash_val):
-                    st_json = st.to_json()
+    return {'statements': {hash_val: st_json}}
+
+
+@app.route('/tests/from_hash/<test_corpus>/<hash_val>', methods=['GET'])
+def get_tests_by_hash(test_corpus, hash_val):
+    tests = _load_tests_from_cache(test_corpus)
+    st_json = {}
+    for test in tests:
+        if str(test.stmt.get_hash()) == str(hash_val):
+            st_json = test.stmt.to_json()
                     for evid in st_json['evidence']:
                         evid['source_hash'] = str(evid['source_hash'])
     return {'statements': {hash_val: st_json}}

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -311,6 +311,16 @@ def _new_passed_tests(model_name, test_stats_json, current_model_types, date):
     return 'No new tests were passed'
 
 
+def _load_tests_from_cache(test_corpus):
+    tests, file_key = tests_cache.get(test_corpus, (None, None))
+    latest_on_s3 = find_latest_s3_file(
+        EMMAA_BUCKET_NAME, f'tests/{test_corpus}', '.pkl')
+    if file_key != latest_on_s3:
+        tests, file_key = load_tests_from_s3(test_corpus, EMMAA_BUCKET_NAME)
+        tests_cache[test_corpus] = (tests, file_key)
+    return tests
+
+
 # Deletes session after the specified time
 @app.before_request
 def session_expiration_check():

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -14,6 +14,8 @@ from collections import defaultdict
 from indra.statements import get_all_descendants, IncreaseAmount, \
     DecreaseAmount, Activation, Inhibition, AddModification, \
     RemoveModification, get_statement_by_name
+from indra.assemblers.html.assembler import _format_evidence_text, \
+    _format_stmt_text
 from indra_db.client.principal.curation import get_curations, submit_curation
 
 from emmaa.util import find_latest_s3_file, strip_out_date, get_s3_client, \
@@ -821,8 +823,8 @@ def get_statement_by_hash_model(model, hash_val):
     for st in mm.model.assembled_stmts:
         if str(st.get_hash()) == str(hash_val):
             st_json = st.to_json()
-            for evid in st_json['evidence']:
-                evid['source_hash'] = str(evid['source_hash'])
+            ev_list = _format_evidence_text(st)
+            st_json['evidence'] = ev_list
     return {'statements': {hash_val: st_json}}
 
 
@@ -833,8 +835,8 @@ def get_tests_by_hash(test_corpus, hash_val):
     for test in tests:
         if str(test.stmt.get_hash()) == str(hash_val):
             st_json = test.stmt.to_json()
-            for evid in st_json['evidence']:
-                evid['source_hash'] = str(evid['source_hash'])
+            ev_list = _format_evidence_text(test.stmt)
+            st_json['evidence'] = ev_list
     return {'statements': {hash_val: st_json}}
 
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -124,7 +124,7 @@ def _get_test_corpora(model, bucket=EMMAA_BUCKET_NAME):
     return tests_with_dates
 
 
-def _get_all_tests():
+def _get_all_tests(bucket=EMMAA_BUCKET_NAME):
     s3 = boto3.client('s3')
     resp = s3.list_objects(Bucket=bucket, Prefix='tests/',
                            Delimiter='_tests')

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -361,7 +361,8 @@ def _set_curation(stmt_hash, correct, incorrect):
 def _label_curations(**kwargs):
     curations = get_curations(**kwargs)
     correct = {str(c.pa_hash) for c in curations if c.tag == 'correct'}
-    incorrect = {str(c.pa_hash) for c in curations if c.pa_hash not in correct}
+    incorrect = {str(c.pa_hash) for c in curations if
+                 str(c.pa_hash) not in correct}
     return correct, incorrect
 
 
@@ -661,7 +662,7 @@ def get_all_statements_page(model):
     mm = load_model_manager_from_cache(model)
     stmts = sorted(mm.model.assembled_stmts, key=lambda x: len(x.evidence),
                    reverse=True)
-    curations = get_curations(pa_hash=set(all_stmts.keys()))
+    curations = get_curations()
     cur_counts = defaultdict(int)
     for curation in curations:
         cur_counts[str(curation.pa_hash)] += 1

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -155,7 +155,7 @@ def _get_model_meta_data(refresh=False, bucket=EMMAA_BUCKET_NAME):
         config_json = get_model_config(model, bucket=bucket)
         if not config_json:
             continue
-        test_corpus = _default_test(model)
+        test_corpus = _default_test(model, config_json)
         latest_date = get_latest_available_date(
             model, test_corpus, refresh=refresh, bucket=bucket)
         if refresh:
@@ -393,9 +393,10 @@ def get_home():
 @app.route('/dashboard/<model>/')
 @jwt_optional
 def get_model_dashboard(model):
+    test_corpus = request.args.get('test_corpus', _default_test(
+        model, get_model_config(model)))
     date = request.args.get('date', get_latest_available_date(
-        model, _get_test_corpora(model)))
-    test_corpus = request.args.get('test_corpus', _default_test(model))
+        model, test_corpus))
     tab = request.args.get('tab', 'model')
     user, roles = resolve_auth(dict(request.args))
     model_meta_data = _get_model_meta_data()

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -411,7 +411,8 @@ def get_model_dashboard(model):
                                model, test_stats, current_model_types, date),
                            date=date,
                            latest_date=latest_date,
-                           tab=tab)
+                           tab=tab,
+                           all_stmts=all_stmts)
 
 
 @app.route('/tests/<model>/')
@@ -733,6 +734,19 @@ def email_unsubscribe_post():
     else:
         logger.info('Could not verify signature, aborting unsubscribe')
         return jsonify({'result': False, 'reason': 'Invalid signature'}), 401
+
+
+@app.route('/statements/from_hash/<model>/<hash_val>', methods=['GET'])
+def get_statement_by_hash_model(model, hash_val):
+    mm = load_model_manager_from_cache(model)
+    for st in mm.model.assembled_stmts:
+        if str(st.get_hash()) == str(hash_val):
+            st_json = st.to_json()
+            for evid in st_json['evidence']:
+                evid['source_hash'] = str(evid['source_hash'])
+        else:
+            st_json = {}
+    return {'statements': {hash_val: st_json}}
 
 
 if __name__ == '__main__':

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -258,8 +258,6 @@ def _format_table_array(tests_json, model_types, model_name, date, test_corpus,
              'test_corpus': test_corpus})
         test['test'][0] = f'/evidence/?{ev_url_par}'
         test['test'][2] = stmt_db_link_msg
-        cur = _set_curation(th, correct, incorrect)
-        test['test'].append(cur)
         new_row = [(test['test'])]
         for mt in model_types:
             url_param = parse.urlencode(
@@ -327,8 +325,6 @@ def _new_passed_tests(model_name, test_stats_json, current_model_types, date,
                  'test_corpus': test_corpus})
             test['test'][0] = f'/evidence/?{ev_url_par}'
             test['test'][2] = stmt_db_link_msg
-            cur = _set_curation(correct, incorrect)
-            test['test'].append(cur)
             path_loc = test[mt][1]
             if isinstance(path_loc, list):
                 path = path_loc[0]['path']
@@ -431,6 +427,8 @@ def get_model_dashboard(model):
     # Filter out rows with all tests == 'n_a'
     all_tests = []
     for k, v in test_stats['test_round_summary']['all_test_results'].items():
+        cur = _set_curation(k, correct, incorrect)
+        v['test'].append(cur)
         if all(v[mt][0].lower() == 'n_a' for mt in current_model_types):
             continue
         else:

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -97,7 +97,6 @@ def get_latest_available_date(
             model_dates[model] = model_date
         return model_date
     min_date = min(model_date, test_date)
-    print(min_date)
     if is_available(model, test_corpus, min_date, bucket=bucket):
         if test_corpus == _default_test(model):
             model_dates[model] = min_date
@@ -136,7 +135,8 @@ def _get_model_meta_data(refresh=False, bucket=EMMAA_BUCKET_NAME):
         test_corpus = _default_test(model)
         latest_date = get_latest_available_date(
             model, test_corpus, refresh=refresh, bucket=bucket)
-        logger.info(f'Latest available date for {model} is {latest_date}')
+        if refresh:
+            logger.info(f'Latest available date for {model} is {latest_date}')
         model_data.append((model, config_json, test_corpus, latest_date))
     return model_data
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -431,7 +431,7 @@ def get_model_dashboard(model):
                            all_test_results=all_test_results,
                            new_passed_tests=_new_passed_tests(
                                model, test_stats, current_model_types, date,
-                               test_ev_count, cur_counts),
+                               test_corpus, test_ev_count, cur_counts),
                            date=date,
                            latest_date=latest_date,
                            tab=tab,

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -596,7 +596,8 @@ def get_statement_evidence_page():
             if str(stmt.get_hash()) == str(stmt_hash):
                 english = _format_stmt_text(stmt)
                 evid_count = len(stmt.evidence)
-                    stmt_row = [(stmt_hash, english, evid_count, cur_count)]
+                    evid = _format_evidence_text(stmt)[:10]
+                    stmt_row = [(stmt_hash, english, evid, evid_count, cur_count)]
                     stmt_rows.append(stmt_row)
     elif source == 'test':
         if not test_corpus:
@@ -607,7 +608,8 @@ def get_statement_evidence_page():
             if str(t.stmt.get_hash()) == str(stmt_hash):
                 english = _format_stmt_text(t.stmt)
                 evid_count = len(t.stmt.evidence)
-                    stmt_row = [(stmt_hash, english, evid_count, cur_count)]
+                    evid = _format_evidence_text(t.stmt)[:10]
+                    stmt_row = [(stmt_hash, english, evid, evid_count, cur_count)]
                     stmt_rows.append(stmt_row)
     else:
         abort(Response(f'Source should be model_statement or test', 404))

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -503,15 +503,17 @@ def get_model_tests_page(model):
     test = current_test["test"]
     test_status, path_list = current_test[model_type]
     correct, incorrect = _label_curations()
-    for path in path_list:
-        for edge in path['edge_list']:
-            for stmt in edge['stmts']:
-                cur = ''
-                url = stmt[0]
-                if 'stmt_hash' in url:
-                    stmt_hashes = parse.parse_qs(parse.urlparse(url).query)['stmt_hash']
-                    cur = _set_curation(stmt_hashes, correct, incorrect)
-                stmt.append(cur)
+    if isinstance(path_list, list):
+        for path in path_list:
+            for edge in path['edge_list']:
+                for stmt in edge['stmts']:
+                    cur = ''
+                    url = stmt[0]
+                    if 'stmt_hash' in url:
+                        stmt_hashes = parse.parse_qs(
+                            parse.urlparse(url).query)['stmt_hash']
+                        cur = _set_curation(stmt_hashes, correct, incorrect)
+                    stmt.append(cur)
     latest_date = get_latest_available_date(model, test_corpus)
     prefix = f'stats/{model}/test_stats_{test_corpus}_'
     cur_ix = find_index_of_s3_file(file_key, EMMAA_BUCKET_NAME, prefix)

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -253,7 +253,7 @@ def _format_table_array(tests_json, model_types, model_name, date, test_corpus):
         ev_url_par = parse.urlencode(
             {'source': 'test', 'model': model_name,
              'test_corpus': test_corpus})
-        test['test'][0] = '/evidence/{st_hash}?{ev_url_par}'
+        test['test'][0] = f'/evidence/{th}?{ev_url_par}'
         test['test'][2] = stmt_db_link_msg
         new_row = [(test['test'])]
         for mt in model_types:
@@ -320,7 +320,7 @@ def _new_passed_tests(model_name, test_stats_json, current_model_types, date,
             ev_url_par = parse.urlencode(
                 {'source': 'test', 'model': model_name,
                  'test_corpus': test_corpus})
-            test['test'][0] = '/evidence/{st_hash}?{url_par}'
+            test['test'][0] = f'/evidence/{th}?{ev_url_par}'
             test['test'][2] = stmt_db_link_msg
             path_loc = test[mt][1]
             if isinstance(path_loc, list):

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -87,27 +87,31 @@ def is_available(model, test_corpus, date, bucket=EMMAA_BUCKET_NAME):
 
 def get_latest_available_date(
         model, test_corpus, refresh=False, bucket=EMMAA_BUCKET_NAME):
-    if test_corpus == _default_test(model) and not refresh and \
-            model in model_dates:
+    if test_corpus == _default_test(
+        model, config=get_model_config(model, bucket=bucket)) and not refresh \
+            and model in model_dates:
         return model_dates[model]
     model_date = last_updated_date(model, 'model_stats', extension='.json',
                                    bucket=bucket)
     test_date = last_updated_date(model, 'test_stats', tests=test_corpus,
                                   extension='.json', bucket=bucket)
     if model_date == test_date:
-        if test_corpus == _default_test(model):
+        if test_corpus == _default_test(
+                model, config=get_model_config(model, bucket=bucket)):
             model_dates[model] = model_date
         return model_date
     min_date = min(model_date, test_date)
     if is_available(model, test_corpus, min_date, bucket=bucket):
-        if test_corpus == _default_test(model):
+        if test_corpus == _default_test(
+                model, config=get_model_config(model, bucket=bucket)):
             model_dates[model] = min_date
         return min_date
     min_date_obj = datetime.strptime(min_date, "%Y-%m-%d")
     for day_count in range(1, 30):
         earlier_date = min_date_obj - timedelta(days=day_count)
         if is_available(model, test_corpus, earlier_date, bucket=bucket):
-            if test_corpus == _default_test(model):
+            if test_corpus == _default_test(
+                    model, config=get_model_config(model, bucket=bucket)):
                 model_dates[model] = earlier_date
             return earlier_date
     logger.info(f'Could not find latest available date for {model} model '

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -696,6 +696,19 @@ def get_query_tests_page(model):
     next_order = order - 1 if order > 1 else None
     prev_order = order + 1 if \
         order < qm.db.get_number_of_results(query_hash, model_type) else None
+    correct, incorrect = _label_curations()
+    path_list = detailed_results[1]
+    if isinstance(path_list, list):
+        for path in path_list:
+            for edge in path['edge_list']:
+                for stmt in edge['stmts']:
+                    cur = ''
+                    url = stmt[0]
+                    if 'stmt_hash' in url:
+                        stmt_hashes = parse.parse_qs(
+                            parse.urlparse(url).query)['stmt_hash']
+                        cur = _set_curation(stmt_hashes, correct, incorrect)
+                    stmt.append(cur)
     return render_template('tests_template.html',
                            link_list=link_list,
                            model=model,
@@ -705,7 +718,7 @@ def get_query_tests_page(model):
                            test=card_title,
                            is_query_page=True,
                            test_status=detailed_results[0],
-                           path_list=detailed_results[1],
+                           path_list=path_list,
                            formatted_names=FORMATTED_TYPE_NAMES,
                            date=date,
                            prev=prev_order,

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -232,7 +232,7 @@ def _make_query(query_dict, use_grouding_service=True):
 
 
 def _new_applied_tests(test_stats_json, model_types, model_name, date,
-                       test_corpus, correct, incorrect):
+                       test_corpus):
     # Extract new applied tests into:
     #   list of tests (one per row)
     #       each test is a list of tuples (one tuple per column)
@@ -245,11 +245,10 @@ def _new_applied_tests(test_stats_json, model_types, model_name, date,
         return 'No new tests were applied'
     new_app_tests = [(th, all_test_results[th]) for th in new_app_hashes]
     return _format_table_array(new_app_tests, model_types, model_name, date,
-                               test_corpus, correct, incorrect)
+                               test_corpus)
 
 
-def _format_table_array(tests_json, model_types, model_name, date, test_corpus,
-                        correct, incorrect):
+def _format_table_array(tests_json, model_types, model_name, date, test_corpus):
     # tests_json needs to have the structure: [(test_hash, tests)]
     table_array = []
     for th, test in tests_json:
@@ -306,7 +305,7 @@ def _format_dynamic_query_results(formatted_results):
 
 
 def _new_passed_tests(model_name, test_stats_json, current_model_types, date,
-                      test_corpus, correct, incorrect):
+                      test_corpus):
     new_passed_tests = []
     all_test_results = test_stats_json['test_round_summary'][
         'all_test_results']
@@ -469,13 +468,13 @@ def get_model_dashboard(model):
                                                   current_model_types]],
                            new_applied_tests=_new_applied_tests(
                                test_stats, current_model_types, model, date,
-                               test_corpus, correct, incorrect),
+                               test_corpus),
                            all_test_results=_format_table_array(
                                all_tests, current_model_types, model, date,
-                               test_corpus, correct, incorrect),
+                               test_corpus),
                            new_passed_tests=_new_passed_tests(
                                model, test_stats, current_model_types, date,
-                               test_corpus, correct, incorrect),
+                               test_corpus),
                            date=date,
                            latest_date=latest_date,
                            tab=tab)

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -150,7 +150,7 @@ function redirectOneStep(value, isQuery) {
 
 function redirectToAllStmts() {
   let model = window.location.pathname.split('/')[2]
-  window.open(`/all_statements/${model}`, target="_blank")
+  window.open(`/all_statements/${model}/?sort_by=evidence&page=1&filter_curated=false`, target="_blank")
 }
 
 function clearTables(arrayOfTableBodies) {

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -148,6 +148,27 @@ function redirectOneStep(value, isQuery) {
 }
 
 
+function redirectOneArgument(newValue, param) {
+  let loc = window.location.href;
+  let currentValue = new URL(loc).searchParams.get(param);
+  var redirect = loc.replace(`${param}=${currentValue}`, `${param}=${newValue}`)
+  location.replace(redirect);
+}
+
+
+function redirectSelection(ddSelect, param) {
+  // Get selected option
+  let newValue = ''
+  for (child of ddSelect.children) {
+    if (child.selected) {
+      newValue = child.value
+      break;
+    }
+  }
+  console.log(newValue)
+  redirectOneArgument(newValue, param);
+}
+
 function redirectToAllStmts() {
   let model = window.location.pathname.split('/')[2]
   window.open(`/all_statements/${model}/?sort_by=evidence&page=1&filter_curated=false`, target="_blank")

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -148,6 +148,11 @@ function redirectOneStep(value, isQuery) {
 }
 
 
+function redirectToAllStmts() {
+  let model = window.location.pathname.split('/')[2]
+  window.open(`/all_statements/${model}`, target="_blank")
+}
+
 function clearTables(arrayOfTableBodies) {
   for (let tableBody of arrayOfTableBodies) {
     clearTable(tableBody)

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -51,7 +51,7 @@
       border: #007bff;
     }
     a.stmt-dblink {
-      color: #000000;https://bigmech.s3.amazonaws.com/indra-db/indralabvue-dev/IndralabVue.css
+      color: #000000;
       text-decoration: none;
     }
     a.status-link {

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -33,6 +33,11 @@
   <!-- Script Files -->
   <script src="{{ url_for('static', filename='emmaaFunctions.js') }}"></script>
 
+  <!-- Vue scripts -->
+  <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+  <script src="https://bigmech.s3.amazonaws.com/indra-db/IndralabVue.umd.js"></script>
+  <link href="https://bigmech.s3.amazonaws.com/indra-db/IndralabVue.css" rel="stylesheet">
+
   {% block additional_scripts %}
   {% endblock %}
 

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -35,9 +35,10 @@
 
   <!-- Vue scripts -->
   <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-  <script src="https://bigmech.s3.amazonaws.com/indra-db/IndralabVue.umd.js"></script>
-  <link href="https://bigmech.s3.amazonaws.com/indra-db/IndralabVue.css" rel="stylesheet">
-
+  <!-- <script src="https://bigmech.s3.amazonaws.com/indra-db/IndralabVue.umd.js"></script> -->
+  <!-- <link href="https://bigmech.s3.amazonaws.com/indra-db/IndralabVue.css" rel="stylesheet"> -->
+  <script src="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-dev/IndralabVue.umd.min.js"></script>
+  <link href="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-dev/IndralabVue.css" rel="stylesheet">
   {% block additional_scripts %}
   {% endblock %}
 
@@ -50,7 +51,7 @@
       border: #007bff;
     }
     a.stmt-dblink {
-      color: #000000;
+      color: #000000;https://bigmech.s3.amazonaws.com/indra-db/indralabvue-dev/IndralabVue.css
       text-decoration: none;
     }
     a.status-link {

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -22,21 +22,21 @@
     cursor: pointer;
   }
 
-  .frozen-box {
-    background-color: #f0f0f0;
-    border: 1px solid #a0a0a0;
-    border-radius: 2px;
-    padding: 5px;
-  }
-
-  #search-reopen {
-    cursor: pointer;
-  }
-
   .nvm {
     padding-left: 0;
     padding-right: 0;
   }
+
+  .text-right {
+    flex: 12%;
+    max-width: 12%;
+  }
+
+  .col-10 {
+    flex: 76%;
+    max-width: 76%;
+  }
+
 </style>
 {% endblock %}
 

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -1,0 +1,19 @@
+{% extends "emmaa_page_template.html" %}
+{% from "path_macros.html" import path_table, path_card %}
+
+{% block body %}
+<div class="container" id="app">
+  {% if tab == 'model_statement' %}
+  {% set url = url_for('get_statement_by_hash_model', model=model, hash_val='') %}
+  {% else %}
+  {% set url = url_for('get_tests_by_hash', test_corpus=test_corpus, hash_val='') %}
+  {% endif %}
+  {{ path_card(stmt_row, "Statement Evidence and Curation", "EvidId", [], url=url) }}
+</div>
+<script>
+  Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, hash_val='') }}";
+  Vue.prototype.$curation_url = "{{ url_for('submit_curation_endpoint', hash_val='') }}";
+  Vue.prototype.$curation_list_url = "{{ url_for('list_curations', stmt_hash='', src_hash='') }}".slice(0, -2);
+  var app = new Vue({el: '#app'});
+</script>
+{% endblock %}

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -47,7 +47,7 @@
   {% else %}
   {% set url = url_for('get_tests_by_hash', test_corpus=test_corpus, hash_val='') %}
   {% endif %}
-  {{ path_card(stmt_row, "Statement Evidence and Curation", "EvidId", [], url=url) }}
+  {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
 </div>
 <script>
   Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, hash_val='') }}";

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -1,6 +1,45 @@
 {% extends "emmaa_page_template.html" %}
 {% from "path_macros.html" import path_table, path_card %}
 
+{% block additional_scripts %}
+<style>
+  .badge-subject {
+    background-color: #4a36aa;
+    color: #FFFFFF;
+  }
+  .badge-object {
+    background-color: #2d8e4c;
+    color: #FFFFFF;
+  }
+  .badge-other {
+    background-color: #606060;
+    color: #FFFFFF;
+  }
+  .badge-source {
+    font-size: 8pt;
+    margin: 0;
+    padding-left: 5px;
+    cursor: pointer;
+  }
+
+  .frozen-box {
+    background-color: #f0f0f0;
+    border: 1px solid #a0a0a0;
+    border-radius: 2px;
+    padding: 5px;
+  }
+
+  #search-reopen {
+    cursor: pointer;
+  }
+
+  .nvm {
+    padding-left: 0;
+    padding-right: 0;
+  }
+</style>
+{% endblock %}
+
 {% block body %}
 <div class="container" id="app">
   {% if source == 'model_statement' %}

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -3,7 +3,7 @@
 
 {% block body %}
 <div class="container" id="app">
-  {% if tab == 'model_statement' %}
+  {% if source == 'model_statement' %}
   {% set url = url_for('get_statement_by_hash_model', model=model, hash_val='') %}
   {% else %}
   {% set url = url_for('get_tests_by_hash', test_corpus=test_corpus, hash_val='') %}

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -41,6 +41,35 @@
 {% endblock %}
 
 {% block body %}
+{% if is_all_stmts %}
+  {% if msg %}
+  {{ msg }}
+  {% endif %}
+  <div>
+    <button class="btn btn-outline-secondary" {% if not prev %} disabled {% endif %} onClick="redirectOneArgument('{{ prev }}', 'page')" type="button">❮ Previous</button>
+    <button class="btn btn-outline-secondary" {% if not next %} disabled {% endif %} onClick="redirectOneArgument('{{ next }}', 'page')" type="button">Next ❯</button>
+    {% if filter_curated %}
+    <button class="btn btn-outline-secondary" onClick="redirectOneArgument('false', 'filter_curated')" type="button">Show Curated</button>
+    {% else %}
+    <button class="btn btn-outline-secondary" onClick="redirectOneArgument('true', 'filter_curated')" type="button">Filter Curated</button>
+    {% endif %}
+    <div class="d-inline-flex p-2 input-group" style="width: 410px;">
+      <select class="custom-select" id="sortSelect" aria-label="Example select with button addon">
+      {% for sorting in ['evidence', 'paths'] %}
+        {% if sort_by == sorting %}
+          <option selected value="{{ sorting }}">Sorting by {{ sorting }}</option>
+        {% else %}
+          <option value="{{ sorting }}">Sorting by {{ sorting }}</option>
+        {% endif %}
+      {% endfor %}
+      </select>
+      <!-- selectModel(modelInfoTableBody, listTestResultsTableBody, testResultTableBody, ddSelect) -->
+      <div class="input-group-append">
+        <button class="btn btn-outline-secondary" onClick="redirectSelection(document.getElementById('sortSelect'), 'sort_by')" type="button">Load Statements</button>
+      </div>
+    </div>
+  </div>
+{% endif %}
 <div class="container" id="app">
   {% if source == 'model_statement' %}
   {% set url = url_for('get_statement_by_hash_model', model=model, hash_val='') %}

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -89,7 +89,26 @@
           <div class="container" id="agentDistr"></div>
         </div>
       </div>
-      {{ path_card(stmts_counts, "Most Supported Statements", "stmtEvidenceTable", ["Statement", "Evidence Count"], "stmtEvidence") }}
+      <div class="card">
+        <div class="card-header">
+          <h4 class="my-0 font-weight-normal">Most Supported Statements</h4>
+        </div>
+        <div class="card-body">
+          <div id="app0">
+            {% for sh, stmt, evid in stmts_counts %}
+            <statement english="{{ stmt }}"
+                      hash="{{ sh }}"
+                      :evidence="[]"
+                      :loadable="true"
+                      :total_evidence="{{ evid }}"></statement>
+            {% endfor %}
+          </div>
+          <script>
+            Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, hash_val='') }}";
+            var app = new Vue({el: '#app0'});
+          </script>
+        </div>
+      </div>
       <div class="card">
         <div class="card-header">
           <h4 class="my-0 font-weight-normal">Number of Statements over Time</h4>
@@ -98,25 +117,28 @@
           <div class="container" id="stmtsOverTime"></div>
         </div>
       </div>
-      {{ path_card(added_stmts, "New Added Statements", "addedStmtsTable", ["Statement"], "addedStmts") }}
       <div class="card">
         <div class="card-header">
-          <h4 class="my-0 font-weight-normal">Vue statements</h4>
+          <h4 class="my-0 font-weight-normal">New Added Statements</h4>
         </div>
         <div class="card-body">
+          {% if added_stmts is string %}
+          <p>{{ added_stmts }}</p>
+          {% else %}
           <div id="app">
-            {% for sh in all_stmts %}
-            <statement english="{{ all_stmts[sh][1] }}"
+            {% for sh, stmt, evid in added_stmts %}
+            <statement english="{{ stmt }}"
                        hash="{{ sh }}"
                        :evidence="[]"
                        :loadable="true"
-                       :total_evidence="10"></statement>
+                       :total_evidence="{{ evid }}"></statement>
             {% endfor %}
           </div>
           <script>
             Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, hash_val='') }}";
             var app = new Vue({el: '#app'});
           </script>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -62,6 +62,7 @@
     </div>
   </nav>
 </div>
+<div id="app">
 <div class="tab-content" id="nav-tabContent">
   {% if tab == 'model' %}
   <div class="tab-pane fade show active" id="nav-model" role="tabpanel" aria-labelledby="nav-model-tab">
@@ -71,7 +72,7 @@
     <!-- Model stuff goes here -->
 
     <!-- This table displays model data -->
-    <div class="container" id="app">
+    <div class="container">
       {{ path_card(model_info_contents, "Model Info", "modelInfoTable", ["Item", "Details"], "modelInfoTableBody") }}
       <div class="card">
         <div class="card-header">
@@ -89,21 +90,7 @@
           <div class="container" id="agentDistr"></div>
         </div>
       </div>
-      <div class="card">
-        <div class="card-header">
-          <h4 class="my-0 font-weight-normal">Most Supported Statements</h4>
-        </div>
-        <div class="card-body">
-          {% for sh, stmt, num_evid, num_cur in stmts_counts %}
-          <statement english="{{ stmt }}"
-                    hash="{{ sh }}"
-                    :evidence="[]"
-                    :loadable="true"
-                    :total_evidence="{{ num_evid }}"
-                    :num_curations="{{ num_cur }}"></statement>
-          {% endfor %}
-        </div>
-      </div>
+      {{ path_card(stmts_counts, "Most Supported Statements", "stmtEvidenceTable", ["Statement", "Evidence Count"], "stmtEvidence") }}
       <div class="card">
         <div class="card-header">
           <h4 class="my-0 font-weight-normal">Number of Statements over Time</h4>
@@ -112,47 +99,10 @@
           <div class="container" id="stmtsOverTime"></div>
         </div>
       </div>
-      <div class="card">
-        <div class="card-header">
-          <h4 class="my-0 font-weight-normal">New Added Statements</h4>
-        </div>
-        <div class="card-body">
-          {% if added_stmts is string %}
-          <p>{{ added_stmts }}</p>
-          {% else %}
-          {% for sh, stmt, num_evid, num_cur in added_stmts %}  
-          <statement english="{{ stmt }}"
-                      hash="{{ sh }}"
-                      :evidence="[]"
-                      :loadable="true"
-                      :total_evidence="{{ num_evid }}"
-                      :num_curations="{{ num_cur }}"></statement>
-          {% endfor %}
-          {% endif %}
-        </div>
-      </div>
-      <div class="card">
-        <div class="card-header">
-          <h4 class="my-0 font-weight-normal"> All Model Statements</h4>
-        </div>
-        <div class="card-body">
-          {% for sh, stmt, num_evid, num_cur in model_stmts %}
-          <statement english="{{ stmt }}"
-                      hash="{{ sh }}"
-                      :evidence="[]"
-                      :loadable="true"
-                      :total_evidence="{{ num_evid }}"
-                      :num_curations="{{ num_cur }}"></statement>
-          {% endfor %}
-        </div>
-      </div>
+      {{ path_card(added_stmts, "New Added Statements", "addedStmtsTable", ["Statement"], "addedStmts") }}
+      {{ path_card(model_stmts, "All Statements", "allStmtsTable", ["Statement"], "allStmts") }}
     </div>
-    <script>
-      Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, hash_val='') }}";
-      Vue.prototype.$curation_url = "{{ url_for('submit_curation_endpoint', hash_val='') }}";
-      Vue.prototype.$curation_list_url = "{{ url_for('list_curations', stmt_hash='', src_hash='') }}".slice(0, -2);
-      var app = new Vue({el: '#app'});
-    </script>
+
   </div>
   {% if tab == 'model' %}
   <div class="tab-pane fade" id="nav-tests" role="tabpanel" aria-labelledby="nav-tests-tab">
@@ -206,4 +156,11 @@
 
   </div>
 </div>
+</div>
+<script>
+  Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, test_corpus=test_corpus, hash_val='') }}";
+  Vue.prototype.$curation_url = "{{ url_for('submit_curation_endpoint', hash_val='') }}";
+  Vue.prototype.$curation_list_url = "{{ url_for('list_curations', stmt_hash='', src_hash='') }}".slice(0, -2);
+  var app = new Vue({el: '#app'});
+</script>
 {% endblock %}

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -99,6 +99,28 @@
         </div>
       </div>
       {{ path_card(added_stmts, "New Added Statements", "addedStmtsTable", ["Statement"], "addedStmts") }}
+      <div class="card">
+        <div class="card-header">
+          <h4 class="my-0 font-weight-normal">Vue statements</h4>
+        </div>
+        <div class="card-body">
+          <div id="app">
+            <statement :english="'Crotonaldehyde activates cPLA2alpha.'"
+                       :hash="'-35078834544876951'"
+                       :evidence="[{
+                        source_api: 'reach',
+                        text: 'We propose a testable model in which cPLA2alpha is activated by CRD agonist occupied Smo at the ciliary base or transition zone to produce arachidonic acid derivatives, which in turn target the 7TM of active Smo to enhance its ciliary trafficking and activity (XREF_FIG).',
+                        annotations: {'found_by': 'Positive_activation_syntax_2_verb',
+                        agents: {'coords': [[64, 67], [37, 47]]}},
+                        epistemics: {'direct': false, 'section_type': null},
+                        text_refs: {'PMID': '22153363'},
+                        source_hash: '-2472852236292526022'}]"></statement> 
+          </div>
+          <script>
+            var app = new Vue({el: '#app'});
+          </script>
+        </div>
+      </div>
     </div>
 
   </div>

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -105,18 +105,16 @@
         </div>
         <div class="card-body">
           <div id="app">
-            <statement :english="'Crotonaldehyde activates cPLA2alpha.'"
-                       :hash="'-35078834544876951'"
-                       :evidence="[{
-                        source_api: 'reach',
-                        text: 'We propose a testable model in which cPLA2alpha is activated by CRD agonist occupied Smo at the ciliary base or transition zone to produce arachidonic acid derivatives, which in turn target the 7TM of active Smo to enhance its ciliary trafficking and activity (XREF_FIG).',
-                        annotations: {'found_by': 'Positive_activation_syntax_2_verb',
-                        agents: {'coords': [[64, 67], [37, 47]]}},
-                        epistemics: {'direct': false, 'section_type': null},
-                        text_refs: {'PMID': '22153363'},
-                        source_hash: '-2472852236292526022'}]"></statement> 
+            {% for sh in all_stmts %}
+            <statement english="{{ all_stmts[sh][1] }}"
+                       hash="{{ sh }}"
+                       :evidence="[]"
+                       :loadable="true"
+                       :total_evidence="10"></statement>
+            {% endfor %}
           </div>
           <script>
+            Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, hash_val='') }}";
             var app = new Vue({el: '#app'});
           </script>
         </div>

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -62,107 +62,96 @@
     </div>
   </nav>
 </div>
-<div id="app">
-  {% set model_url = url_for('get_statement_by_hash_model', model=model, hash_val='') %}
-  {% set test_url = url_for('get_tests_by_hash', test_corpus=test_corpus, hash_val='') %}
-  <div class="tab-content" id="nav-tabContent">
-    {% if tab == 'model' %}
-    <div class="tab-pane fade show active" id="nav-model" role="tabpanel" aria-labelledby="nav-model-tab">
-    {% else %}
-    <div class="tab-pane" id="nav-model" role="tabpanel" aria-labelledby="nav-model-tab">
-    {% endif %} 
-      <!-- Model stuff goes here -->
+<div class="tab-content" id="nav-tabContent">
+  {% if tab == 'model' %}
+  <div class="tab-pane fade show active" id="nav-model" role="tabpanel" aria-labelledby="nav-model-tab">
+  {% else %}
+  <div class="tab-pane" id="nav-model" role="tabpanel" aria-labelledby="nav-model-tab">
+  {% endif %} 
+    <!-- Model stuff goes here -->
 
-      <!-- This table displays model data -->
-      <div class="container">
-        {{ path_card(model_info_contents, "Model Info", "modelInfoTable", ["Item", "Details"], "modelInfoTableBody") }}
-        <div class="card">
-          <div class="card-header">
-            <h4 class="my-0 font-weight-normal">Statement Types Distribution</h4>
-          </div>
-          <div class="card-body">
-            <div class="container" id="modelTestResultBody"></div>
-          </div>
+    <!-- This table displays model data -->
+    <div class="container">
+      {{ path_card(model_info_contents, "Model Info", "modelInfoTable", ["Item", "Details"], "modelInfoTableBody") }}
+      <div class="card">
+        <div class="card-header">
+          <h4 class="my-0 font-weight-normal">Statement Types Distribution</h4>
         </div>
-        <div class="card">
-          <div class="card-header">
-            <h4 class="my-0 font-weight-normal">Top 10 Agents</h4>
-          </div>
-          <div class="card-body">
-            <div class="container" id="agentDistr"></div>
-          </div>
+        <div class="card-body">
+          <div class="container" id="modelTestResultBody"></div>
         </div>
-        {{ path_card(stmts_counts, "Most Supported Statements", "stmtEvidenceTable", ["Statement"], "stmtEvidence", url=model_url) }}
-        <div class="card">
-          <div class="card-header">
-            <h4 class="my-0 font-weight-normal">Number of Statements over Time</h4>
-          </div>
-          <div class="card-body">
-            <div class="container" id="stmtsOverTime"></div>
-          </div>
-        </div>
-        {{ path_card(added_stmts, "New Added Statements", "addedStmtsTable", ["Statement"], "addedStmts", url=model_url) }}
-        {{ path_card(model_stmts, "All Statements", "allStmtsTable", ["Statement"], "allStmts", url=model_url) }}
       </div>
-
-    </div>
-    {% if tab == 'model' %}
-    <div class="tab-pane fade" id="nav-tests" role="tabpanel" aria-labelledby="nav-tests-tab">
-    {% else %}
-    <div class="tab-pane fade show active" id="nav-tests" role="tabpanel" aria-labelledby="nav-tests-tab">
-    {% endif %}
-      <!-- Test stuff goes here -->
-
-      <div class="container" id="modelTestResult">
-        <div class="card">
-          <div class="card-header">
-            <h4 class="my-0 font-weight-normal">Test Corpus Selection</h4>
-          </div>
-          <div class="card-body">
-            <select class="custom-select" id="testSelectDD" aria-label="Example select with button addon" style="width: 300px">
-              <option selected disabled hidden>Select test...</option>
-              {% for test, test_date in available_tests.items() %}
-                {% if test == test_corpus %}
-                  <option selected value="{{ test }} {{ date }}">{{ test.replace('_', ' ').capitalize() }}</option>
-                {% else %}
-                  <option value="{{ test }} {{ test_date }}">{{ test.replace('_', ' ').capitalize() }}</option>
-                {% endif %}
-              {% endfor %}
-            </select>
-            <div class="d-inline-flex button-container p-2">
-              <button class="btn btn-outline-secondary" onClick="testRedirect(document.getElementById('testSelectDD'))" type="button">Load Test Results</button>
-            </div>
-          </div>
+      <div class="card">
+        <div class="card-header">
+          <h4 class="my-0 font-weight-normal">Top 10 Agents</h4>
         </div>
-        
-        <div class="card">
-          <div class="card-header">
-            <h4 class="my-0 font-weight-normal">Percentage of Tests Passed</h4>
-          </div>
-          <div class="card-body">
-            <div class="container" id="passedRatio"></div>
-          </div>
+        <div class="card-body">
+          <div class="container" id="agentDistr"></div>
         </div>
-        <div class="card">
-          <div class="card-header">
-            <h4 class="my-0 font-weight-normal">Passed and Applied Tests</h4>
-          </div>
-          <div class="card-body">
-            <div class="container" id="passedApplied"></div>
-          </div>
-        </div>
-        {{ path_card(new_applied_tests, "New Applied Tests", None, model_types, "newAppliedTests", url=test_url) }}
-        {{ path_card(new_passed_tests, "New Passed Tests", None, ["Test", "Top Path"], "newPassedTests", true, url=test_url)}}
-        {{ path_card(all_test_results, "All Test Results", None, model_types, "allTestResults", url=test_url) }}
       </div>
-
+      {{ path_card(stmts_counts, "Most Supported Statements", "stmtEvidenceTable", ["Statement", "Evidence Count"], "stmtEvidence") }}
+      <div class="card">
+        <div class="card-header">
+          <h4 class="my-0 font-weight-normal">Number of Statements over Time</h4>
+        </div>
+        <div class="card-body">
+          <div class="container" id="stmtsOverTime"></div>
+        </div>
+      </div>
+      {{ path_card(added_stmts, "New Added Statements", "addedStmtsTable", ["Statement"], "addedStmts") }}
     </div>
+
+  </div>
+  {% if tab == 'model' %}
+  <div class="tab-pane fade" id="nav-tests" role="tabpanel" aria-labelledby="nav-tests-tab">
+  {% else %}
+  <div class="tab-pane fade show active" id="nav-tests" role="tabpanel" aria-labelledby="nav-tests-tab">
+  {% endif %}
+    <!-- Test stuff goes here -->
+
+    <div class="container" id="modelTestResult">
+      <div class="card">
+        <div class="card-header">
+          <h4 class="my-0 font-weight-normal">Test Corpus Selection</h4>
+        </div>
+        <div class="card-body">
+          <select class="custom-select" id="testSelectDD" aria-label="Example select with button addon" style="width: 300px">
+            <option selected disabled hidden>Select test...</option>
+            {% for test, test_date in available_tests.items() %}
+              {% if test == test_corpus %}
+                <option selected value="{{ test }} {{ date }}">{{ test.replace('_', ' ').capitalize() }}</option>
+              {% else %}
+                <option value="{{ test }} {{ test_date }}">{{ test.replace('_', ' ').capitalize() }}</option>
+              {% endif %}
+            {% endfor %}
+          </select>
+          <div class="d-inline-flex button-container p-2">
+            <button class="btn btn-outline-secondary" onClick="testRedirect(document.getElementById('testSelectDD'))" type="button">Load Test Results</button>
+          </div>
+        </div>
+      </div>
+      
+      <div class="card">
+        <div class="card-header">
+          <h4 class="my-0 font-weight-normal">Percentage of Tests Passed</h4>
+        </div>
+        <div class="card-body">
+          <div class="container" id="passedRatio"></div>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-header">
+          <h4 class="my-0 font-weight-normal">Passed and Applied Tests</h4>
+        </div>
+        <div class="card-body">
+          <div class="container" id="passedApplied"></div>
+        </div>
+      </div>
+      {{ path_card(new_applied_tests, "New Applied Tests", None, model_types, "newAppliedTests") }}
+      {{ path_card(new_passed_tests, "New Passed Tests", None, ["Test", "Top Path"], "newPassedTests", true)}}
+      {{ path_card(all_test_results, "All Test Results", None, model_types, "allTestResults") }}
+    </div>
+
   </div>
 </div>
-<script>
-  Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, hash_val='') }}";
-  Vue.prototype.$curation_url = "{{ url_for('submit_curation_endpoint', hash_val='') }}";
-  Vue.prototype.$curation_list_url = "{{ url_for('list_curations', stmt_hash='', src_hash='') }}".slice(0, -2);
-  var app = new Vue({el: '#app'});
-</script>
 {% endblock %}

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -71,7 +71,7 @@
     <!-- Model stuff goes here -->
 
     <!-- This table displays model data -->
-    <div class="container">
+    <div class="container" id="app">
       {{ path_card(model_info_contents, "Model Info", "modelInfoTable", ["Item", "Details"], "modelInfoTableBody") }}
       <div class="card">
         <div class="card-header">
@@ -94,19 +94,14 @@
           <h4 class="my-0 font-weight-normal">Most Supported Statements</h4>
         </div>
         <div class="card-body">
-          <div id="app0">
-            {% for sh, stmt, evid in stmts_counts %}
-            <statement english="{{ stmt }}"
-                      hash="{{ sh }}"
-                      :evidence="[]"
-                      :loadable="true"
-                      :total_evidence="{{ evid }}"></statement>
-            {% endfor %}
-          </div>
-          <script>
-            Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, hash_val='') }}";
-            var app = new Vue({el: '#app0'});
-          </script>
+          {% for sh, stmt, num_evid, num_cur in stmts_counts %}
+          <statement english="{{ stmt }}"
+                    hash="{{ sh }}"
+                    :evidence="[]"
+                    :loadable="true"
+                    :total_evidence="{{ num_evid }}"
+                    :num_curations="{{ num_cur }}"></statement>
+          {% endfor %}
         </div>
       </div>
       <div class="card">
@@ -125,24 +120,39 @@
           {% if added_stmts is string %}
           <p>{{ added_stmts }}</p>
           {% else %}
-          <div id="app">
-            {% for sh, stmt, evid in added_stmts %}
-            <statement english="{{ stmt }}"
-                       hash="{{ sh }}"
-                       :evidence="[]"
-                       :loadable="true"
-                       :total_evidence="{{ evid }}"></statement>
-            {% endfor %}
-          </div>
-          <script>
-            Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, hash_val='') }}";
-            var app = new Vue({el: '#app'});
-          </script>
+          {% for sh, stmt, num_evid, num_cur in added_stmts %}  
+          <statement english="{{ stmt }}"
+                      hash="{{ sh }}"
+                      :evidence="[]"
+                      :loadable="true"
+                      :total_evidence="{{ num_evid }}"
+                      :num_curations="{{ num_cur }}"></statement>
+          {% endfor %}
           {% endif %}
         </div>
       </div>
+      <div class="card">
+        <div class="card-header">
+          <h4 class="my-0 font-weight-normal"> All Model Statements</h4>
+        </div>
+        <div class="card-body">
+          {% for sh, stmt, num_evid, num_cur in model_stmts %}
+          <statement english="{{ stmt }}"
+                      hash="{{ sh }}"
+                      :evidence="[]"
+                      :loadable="true"
+                      :total_evidence="{{ num_evid }}"
+                      :num_curations="{{ num_cur }}"></statement>
+          {% endfor %}
+        </div>
+      </div>
     </div>
-
+    <script>
+      Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, hash_val='') }}";
+      Vue.prototype.$curation_url = "{{ url_for('submit_curation_endpoint', hash_val='') }}";
+      Vue.prototype.$curation_list_url = "{{ url_for('list_curations', stmt_hash='', src_hash='') }}".slice(0, -2);
+      var app = new Vue({el: '#app'});
+    </script>
   </div>
   {% if tab == 'model' %}
   <div class="tab-pane fade" id="nav-tests" role="tabpanel" aria-labelledby="nav-tests-tab">

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -63,102 +63,104 @@
   </nav>
 </div>
 <div id="app">
-<div class="tab-content" id="nav-tabContent">
-  {% if tab == 'model' %}
-  <div class="tab-pane fade show active" id="nav-model" role="tabpanel" aria-labelledby="nav-model-tab">
-  {% else %}
-  <div class="tab-pane" id="nav-model" role="tabpanel" aria-labelledby="nav-model-tab">
-  {% endif %} 
-    <!-- Model stuff goes here -->
+  {% set model_url = url_for('get_statement_by_hash_model', model=model, hash_val='') %}
+  {% set test_url = url_for('get_tests_by_hash', test_corpus=test_corpus, hash_val='') %}
+  <div class="tab-content" id="nav-tabContent">
+    {% if tab == 'model' %}
+    <div class="tab-pane fade show active" id="nav-model" role="tabpanel" aria-labelledby="nav-model-tab">
+    {% else %}
+    <div class="tab-pane" id="nav-model" role="tabpanel" aria-labelledby="nav-model-tab">
+    {% endif %} 
+      <!-- Model stuff goes here -->
 
-    <!-- This table displays model data -->
-    <div class="container">
-      {{ path_card(model_info_contents, "Model Info", "modelInfoTable", ["Item", "Details"], "modelInfoTableBody") }}
-      <div class="card">
-        <div class="card-header">
-          <h4 class="my-0 font-weight-normal">Statement Types Distribution</h4>
-        </div>
-        <div class="card-body">
-          <div class="container" id="modelTestResultBody"></div>
-        </div>
-      </div>
-      <div class="card">
-        <div class="card-header">
-          <h4 class="my-0 font-weight-normal">Top 10 Agents</h4>
-        </div>
-        <div class="card-body">
-          <div class="container" id="agentDistr"></div>
-        </div>
-      </div>
-      {{ path_card(stmts_counts, "Most Supported Statements", "stmtEvidenceTable", ["Statement", "Evidence Count"], "stmtEvidence") }}
-      <div class="card">
-        <div class="card-header">
-          <h4 class="my-0 font-weight-normal">Number of Statements over Time</h4>
-        </div>
-        <div class="card-body">
-          <div class="container" id="stmtsOverTime"></div>
-        </div>
-      </div>
-      {{ path_card(added_stmts, "New Added Statements", "addedStmtsTable", ["Statement"], "addedStmts") }}
-      {{ path_card(model_stmts, "All Statements", "allStmtsTable", ["Statement"], "allStmts") }}
-    </div>
-
-  </div>
-  {% if tab == 'model' %}
-  <div class="tab-pane fade" id="nav-tests" role="tabpanel" aria-labelledby="nav-tests-tab">
-  {% else %}
-  <div class="tab-pane fade show active" id="nav-tests" role="tabpanel" aria-labelledby="nav-tests-tab">
-  {% endif %}
-    <!-- Test stuff goes here -->
-
-    <div class="container" id="modelTestResult">
-      <div class="card">
-        <div class="card-header">
-          <h4 class="my-0 font-weight-normal">Test Corpus Selection</h4>
-        </div>
-        <div class="card-body">
-          <select class="custom-select" id="testSelectDD" aria-label="Example select with button addon" style="width: 300px">
-            <option selected disabled hidden>Select test...</option>
-            {% for test, test_date in available_tests.items() %}
-              {% if test == test_corpus %}
-                <option selected value="{{ test }} {{ date }}">{{ test.replace('_', ' ').capitalize() }}</option>
-              {% else %}
-                <option value="{{ test }} {{ test_date }}">{{ test.replace('_', ' ').capitalize() }}</option>
-              {% endif %}
-            {% endfor %}
-          </select>
-          <div class="d-inline-flex button-container p-2">
-            <button class="btn btn-outline-secondary" onClick="testRedirect(document.getElementById('testSelectDD'))" type="button">Load Test Results</button>
+      <!-- This table displays model data -->
+      <div class="container">
+        {{ path_card(model_info_contents, "Model Info", "modelInfoTable", ["Item", "Details"], "modelInfoTableBody") }}
+        <div class="card">
+          <div class="card-header">
+            <h4 class="my-0 font-weight-normal">Statement Types Distribution</h4>
+          </div>
+          <div class="card-body">
+            <div class="container" id="modelTestResultBody"></div>
           </div>
         </div>
+        <div class="card">
+          <div class="card-header">
+            <h4 class="my-0 font-weight-normal">Top 10 Agents</h4>
+          </div>
+          <div class="card-body">
+            <div class="container" id="agentDistr"></div>
+          </div>
+        </div>
+        {{ path_card(stmts_counts, "Most Supported Statements", "stmtEvidenceTable", ["Statement"], "stmtEvidence", url=model_url) }}
+        <div class="card">
+          <div class="card-header">
+            <h4 class="my-0 font-weight-normal">Number of Statements over Time</h4>
+          </div>
+          <div class="card-body">
+            <div class="container" id="stmtsOverTime"></div>
+          </div>
+        </div>
+        {{ path_card(added_stmts, "New Added Statements", "addedStmtsTable", ["Statement"], "addedStmts", url=model_url) }}
+        {{ path_card(model_stmts, "All Statements", "allStmtsTable", ["Statement"], "allStmts", url=model_url) }}
       </div>
-      
-      <div class="card">
-        <div class="card-header">
-          <h4 class="my-0 font-weight-normal">Percentage of Tests Passed</h4>
-        </div>
-        <div class="card-body">
-          <div class="container" id="passedRatio"></div>
-        </div>
-      </div>
-      <div class="card">
-        <div class="card-header">
-          <h4 class="my-0 font-weight-normal">Passed and Applied Tests</h4>
-        </div>
-        <div class="card-body">
-          <div class="container" id="passedApplied"></div>
-        </div>
-      </div>
-      {{ path_card(new_applied_tests, "New Applied Tests", None, model_types, "newAppliedTests") }}
-      {{ path_card(new_passed_tests, "New Passed Tests", None, ["Test", "Top Path"], "newPassedTests", true)}}
-      {{ path_card(all_test_results, "All Test Results", None, model_types, "allTestResults") }}
-    </div>
 
+    </div>
+    {% if tab == 'model' %}
+    <div class="tab-pane fade" id="nav-tests" role="tabpanel" aria-labelledby="nav-tests-tab">
+    {% else %}
+    <div class="tab-pane fade show active" id="nav-tests" role="tabpanel" aria-labelledby="nav-tests-tab">
+    {% endif %}
+      <!-- Test stuff goes here -->
+
+      <div class="container" id="modelTestResult">
+        <div class="card">
+          <div class="card-header">
+            <h4 class="my-0 font-weight-normal">Test Corpus Selection</h4>
+          </div>
+          <div class="card-body">
+            <select class="custom-select" id="testSelectDD" aria-label="Example select with button addon" style="width: 300px">
+              <option selected disabled hidden>Select test...</option>
+              {% for test, test_date in available_tests.items() %}
+                {% if test == test_corpus %}
+                  <option selected value="{{ test }} {{ date }}">{{ test.replace('_', ' ').capitalize() }}</option>
+                {% else %}
+                  <option value="{{ test }} {{ test_date }}">{{ test.replace('_', ' ').capitalize() }}</option>
+                {% endif %}
+              {% endfor %}
+            </select>
+            <div class="d-inline-flex button-container p-2">
+              <button class="btn btn-outline-secondary" onClick="testRedirect(document.getElementById('testSelectDD'))" type="button">Load Test Results</button>
+            </div>
+          </div>
+        </div>
+        
+        <div class="card">
+          <div class="card-header">
+            <h4 class="my-0 font-weight-normal">Percentage of Tests Passed</h4>
+          </div>
+          <div class="card-body">
+            <div class="container" id="passedRatio"></div>
+          </div>
+        </div>
+        <div class="card">
+          <div class="card-header">
+            <h4 class="my-0 font-weight-normal">Passed and Applied Tests</h4>
+          </div>
+          <div class="card-body">
+            <div class="container" id="passedApplied"></div>
+          </div>
+        </div>
+        {{ path_card(new_applied_tests, "New Applied Tests", None, model_types, "newAppliedTests", url=test_url) }}
+        {{ path_card(new_passed_tests, "New Passed Tests", None, ["Test", "Top Path"], "newPassedTests", true)}}
+        {{ path_card(all_test_results, "All Test Results", None, model_types, "allTestResults", url=test_url) }}
+      </div>
+
+    </div>
   </div>
 </div>
-</div>
 <script>
-  Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, test_corpus=test_corpus, hash_val='') }}";
+  Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, hash_val='') }}";
   Vue.prototype.$curation_url = "{{ url_for('submit_curation_endpoint', hash_val='') }}";
   Vue.prototype.$curation_list_url = "{{ url_for('list_curations', stmt_hash='', src_hash='') }}".slice(0, -2);
   var app = new Vue({el: '#app'});

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -152,7 +152,7 @@
           </div>
         </div>
         {{ path_card(new_applied_tests, "New Applied Tests", None, model_types, "newAppliedTests", url=test_url) }}
-        {{ path_card(new_passed_tests, "New Passed Tests", None, ["Test", "Top Path"], "newPassedTests", true)}}
+        {{ path_card(new_passed_tests, "New Passed Tests", None, ["Test", "Top Path"], "newPassedTests", true, url=test_url)}}
         {{ path_card(all_test_results, "All Test Results", None, model_types, "allTestResults", url=test_url) }}
       </div>
 

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -89,7 +89,7 @@
           <div class="container" id="agentDistr"></div>
         </div>
       </div>
-      {{ path_card(stmts_counts, "Most Supported Statements", "stmtEvidenceTable", ["Statement", "Evidence Count"], "stmtEvidence") }}
+      {{ path_card(stmts_counts, "Most Supported Statements", "stmtEvidenceTable", ["Statement", "Evidence Count"], "stmtEvidence", show_all=True) }}
       <div class="card">
         <div class="card-header">
           <h4 class="my-0 font-weight-normal">Number of Statements over Time</h4>


### PR DESCRIPTION
This PR enables curation of statements via EMMAA dashboard by integrating Vue components. Any statement on the dashboard links out to a separate page where all evidences for this statement can be viewed and curated. This can be done for model statements, tests and path statements. Two new page views have been added - one to browse evidence for one statement at a time and one to browse all model statements sorted by number of evidence. Most preprocessing of the data is done on api side before rendering templates, but the links in path statements depend on the files saved on S3, so this change will be fully propagated after daily test runs. https://github.com/indralab/ui_util/pull/7 should be merged along with this PR.