### PR TITLE
Clean up grounding and use Gilda as a package

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,3 +9,4 @@ fnvhash
 sqlalchemy
 inflection
 pybel
+gilda

--- a/emmaa/queries.py
+++ b/emmaa/queries.py
@@ -1,8 +1,8 @@
 import logging
 from inflection import underscore
 from collections import OrderedDict as _o
-from .util import get_class_from_name
 import gilda
+from indra.sources import trips
 from indra.preassembler.grounding_mapper.standardize import \
     standardize_agent_name
 from indra.statements.statements import Statement, Agent, get_all_descendants,\
@@ -10,6 +10,7 @@ from indra.statements.statements import Statement, Agent, get_all_descendants,\
 from indra.assemblers.english.assembler import _assemble_agent_str, \
     EnglishAssembler
 from bioagents.tra.tra import MolecularQuantity, TemporalPattern
+from .util import get_class_from_name
 
 
 logger = logging.getLogger(__name__)
@@ -259,6 +260,8 @@ class DynamicProperty(Query):
         return f'{agent} is {pattern}.'
 
 
+# This is the general method to get a grounding agent from text but it doesn't
+# handle agent state which is required for dynamic queries
 def get_agent_from_text(ag_name):
     """Return an INDRA Agent object by grounding its entity text with Gilda."""
     matches = gilda.ground(ag_name)
@@ -270,6 +273,15 @@ def get_agent_from_text(ag_name):
     standardize_agent_name(agent, standardize_refs=True)
     return agent
 
+
+# This is the method that dynamical queries use to represent agents with
+# state
+def get_agent_from_trips(ag_text):
+    tp = trips.process_text(ag_text)
+    agent_list = tp.get_agents()
+    if agent_list:
+        return agent_list[0]
+    return None
 
 class GroundingError(Exception):
     pass

--- a/emmaa/queries.py
+++ b/emmaa/queries.py
@@ -1,5 +1,4 @@
 import logging
-import requests
 from inflection import underscore
 from collections import OrderedDict as _o
 from .util import get_class_from_name
@@ -8,11 +7,6 @@ from indra.preassembler.grounding_mapper.standardize import \
     standardize_agent_name
 from indra.statements.statements import Statement, Agent, get_all_descendants,\
     mk_str, make_hash
-from indra.databases.hgnc_client import get_hgnc_id
-from indra.databases.chebi_client import get_chebi_id_from_name
-from indra.databases.mesh_client import get_mesh_id_name
-from indra.preassembler.grounding_mapper import gm
-from indra.sources import trips
 from indra.assemblers.english.assembler import _assemble_agent_str, \
     EnglishAssembler
 from bioagents.tra.tra import MolecularQuantity, TemporalPattern

--- a/emmaa/queries.py
+++ b/emmaa/queries.py
@@ -3,6 +3,9 @@ import requests
 from inflection import underscore
 from collections import OrderedDict as _o
 from .util import get_class_from_name
+import gilda
+from indra.preassembler.grounding_mapper.standardize import \
+    standardize_agent_name
 from indra.statements.statements import Statement, Agent, get_all_descendants,\
     mk_str, make_hash
 from indra.databases.hgnc_client import get_hgnc_id
@@ -262,76 +265,16 @@ class DynamicProperty(Query):
         return f'{agent} is {pattern}.'
 
 
-def get_agent_from_text(ag_name, use_grouding_service=True):
-    """Return an INDRA Agent object."""
-    grounding_url = "http://grounding.indra.bio/ground"
-    if use_grouding_service:
-        try:
-            agent = get_agent_from_grounding_service(ag_name, grounding_url)
-        except Exception as e:
-            logger.warning('Could not get agent from grounding service: %s' % e)
-            agent = get_agent_from_local_grounding(ag_name)
-    else:
-        agent = get_agent_from_local_grounding(ag_name)
-    return agent
-
-
-def get_grounding_from_name(name):
-    """Return grounding given an agent name."""
-    # See if it's a gene name
-    hgnc_id = get_hgnc_id(name)
-    if hgnc_id:
-        return ('HGNC', hgnc_id)
-
-    # Check if it's in the grounding map
-    try:
-        refs = gm[name]
-        if isinstance(refs, dict):
-            for dbn, dbi in refs.items():
-                if dbn != 'TEXT':
-                    return (dbn, dbi)
-    # If not, search by text
-    except KeyError:
-        pass
-
-    chebi_id = get_chebi_id_from_name(name)
-    if chebi_id:
-        return ('CHEBI', f'CHEBI:{chebi_id}')
-
-    mesh_id, _ = get_mesh_id_name(name)
-    if mesh_id:
-        return ('MESH', mesh_id)
-
-    return None
-
-
-def get_agent_from_local_grounding(ag_name):
-    grounding = get_grounding_from_name(ag_name)
-    if not grounding:
-        grounding = get_grounding_from_name(ag_name.upper())
-        ag_name = ag_name.upper()
-    if not grounding:
+def get_agent_from_text(ag_name):
+    """Return an INDRA Agent object by grounding its entity text with Gilda."""
+    matches = gilda.ground(ag_name)
+    if not matches:
         raise GroundingError(f"Could not find grounding for {ag_name}.")
-    agent = Agent(ag_name, db_refs={grounding[0]: grounding[1]})
+    agent = Agent(ag_name,
+                  db_refs={'TEXT': ag_name,
+                           matches[0].term.db: matches[0].term.id})
+    standardize_agent_name(agent, standardize_refs=True)
     return agent
-
-
-def get_agent_from_grounding_service(ag_name, url):
-    res = requests.post(url, json={'text': ag_name})
-    rj = res.json()
-    if not rj:
-        raise GroundingError(f"Could not find grounding for {ag_name}.")
-    agent = Agent(name=rj[0]['term']['entry_name'],
-                  db_refs={rj[0]['term']['db']: rj[0]['term']['id']})
-    return agent
-
-
-def get_agent_from_trips(ag_text):
-    tp = trips.process_text(ag_text)
-    agent_list = tp.get_agents()
-    if agent_list:
-        return agent_list[0]
-    return None
 
 
 class GroundingError(Exception):

--- a/emmaa/tests/test_queries.py
+++ b/emmaa/tests/test_queries.py
@@ -2,7 +2,7 @@ import json
 from os.path import abspath, dirname, join
 from indra.statements import Phosphorylation, Agent, ModCondition
 from emmaa.queries import Query, PathProperty, DynamicProperty, \
-    get_agent_from_text
+    get_agent_from_text, get_agent_from_trips
 
 
 def test_path_property_from_json():
@@ -123,3 +123,12 @@ def test_grounding():
     assert isinstance(agent, Agent)
     assert agent.name == 'BRAF'
     assert agent.db_refs == {'HGNC': '1097'}
+
+
+def test_agent_from_trips():
+    ag = get_agent_from_trips('MAP2K1')
+    assert isinstance(ag, Agent)
+    assert ag.name == 'MAP2K1'
+    assert not ag.mods
+    ag_phos = get_agent_from_trips('phosphorylated MAP2K1')
+    assert ag_phos.mods

--- a/emmaa/tests/test_queries.py
+++ b/emmaa/tests/test_queries.py
@@ -112,17 +112,20 @@ def test_grounding():
     agent = get_agent_from_text('MAPK1')
     assert isinstance(agent, Agent)
     assert agent.name == 'MAPK1'
-    assert agent.db_refs == {'HGNC': '6871'}
+    assert agent.db_refs == {'TEXT': 'MAPK1',
+                             'HGNC': '6871', 'UP': 'P28482'}, agent.db_refs
     # test with lower case
     agent = get_agent_from_text('mapk1')
     assert isinstance(agent, Agent)
     assert agent.name == 'MAPK1'
-    assert agent.db_refs == {'HGNC': '6871'}
+    assert agent.db_refs == {'TEXT': 'mapk1',
+                             'HGNC': '6871', 'UP': 'P28482'}, agent.db_refs
     # other agent
     agent = get_agent_from_text('BRAF')
     assert isinstance(agent, Agent)
     assert agent.name == 'BRAF'
-    assert agent.db_refs == {'HGNC': '1097'}
+    assert agent.db_refs == {'TEXT': 'BRAF',
+                             'HGNC': '1097', 'UP': 'P15056'}, agent.db_refs
 
 
 def test_agent_from_trips():

--- a/emmaa/tests/test_queries.py
+++ b/emmaa/tests/test_queries.py
@@ -1,11 +1,8 @@
 import json
-import os
 from os.path import abspath, dirname, join
-from nose.plugins.attrib import attr
 from indra.statements import Phosphorylation, Agent, ModCondition
 from emmaa.queries import Query, PathProperty, DynamicProperty, \
-    get_agent_from_local_grounding, get_agent_from_grounding_service, \
-    get_grounding_from_name, get_agent_from_text, get_agent_from_trips
+    get_agent_from_text
 
 
 def test_path_property_from_json():
@@ -111,44 +108,18 @@ def test_dynamic_property_to_english():
     assert query.to_english() == 'Phosphorylated EGFR is eventually low.'
 
 
-def test_grounding_from_name():
-    assert get_grounding_from_name('MAPK1') == ('HGNC', '6871')
-    assert get_grounding_from_name('BRAF') == ('HGNC', '1097')
-
-
-def test_local_grounding():
-    agent = get_agent_from_local_grounding('MAPK1')
+def test_grounding():
+    agent = get_agent_from_text('MAPK1')
     assert isinstance(agent, Agent)
     assert agent.name == 'MAPK1'
     assert agent.db_refs == {'HGNC': '6871'}
     # test with lower case
-    agent = get_agent_from_local_grounding('mapk1')
+    agent = get_agent_from_text('mapk1')
     assert isinstance(agent, Agent)
     assert agent.name == 'MAPK1'
     assert agent.db_refs == {'HGNC': '6871'}
     # other agent
-    agent = get_agent_from_local_grounding('BRAF')
+    agent = get_agent_from_text('BRAF')
     assert isinstance(agent, Agent)
     assert agent.name == 'BRAF'
     assert agent.db_refs == {'HGNC': '1097'}
-
-
-@attr('nonpublic')
-def test_grounding_service():
-    agent = get_agent_from_text('MAPK1', use_grouding_service=True)
-    assert isinstance(agent, Agent)
-    assert agent.name == 'MAPK1'
-    assert agent.db_refs == {'HGNC': '6871'}
-    agent = get_agent_from_text('BRAF', use_grouding_service=True)
-    assert isinstance(agent, Agent)
-    assert agent.name == 'BRAF'
-    assert agent.db_refs == {'HGNC': '1097'}
-
-
-def test_agent_from_trips():
-    ag = get_agent_from_trips('MAP2K1')
-    assert isinstance(ag, Agent)
-    assert ag.name == 'MAP2K1'
-    assert not ag.mods
-    ag_phos = get_agent_from_trips('phosphorylated MAP2K1')
-    assert ag_phos.mods

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -203,14 +203,14 @@ def get_queryable_stmt_types():
     return stmt_types
 
 
-def _make_query(query_dict, use_grouding_service=True):
+def _make_query(query_dict):
     if 'typeSelection' in query_dict.keys():
         stmt_type = query_dict['typeSelection']
         stmt_class = get_statement_by_name(stmt_type)
         subj = get_agent_from_text(
-            query_dict['subjectSelection'], use_grouding_service)
+            query_dict['subjectSelection'])
         obj = get_agent_from_text(
-            query_dict['objectSelection'], use_grouding_service)
+            query_dict['objectSelection'])
         stmt = stmt_class(subj, obj)
         query = PathProperty(path_stmt=stmt)
         tab = 'static'

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(name='emmaa',
       packages=find_packages(),
       install_requires=['indra', 'boto3', 'jsonpickle', 'kappy',
                         'pygraphviz', 'fnvhash', 'sqlalchemy', 'inflection',
-                        'pybel', 'flask_jwt_extended'],
+                        'pybel', 'flask_jwt_extended', 'gilda'],
       extras_require={'test': ['nose', 'coverage', 'moto']}
       )


### PR DESCRIPTION
This PR removes some of the deprecated grounding approaches in the code and replaces them with using `gilda` assuming it is installed as a Python package (i.e., not used as a web service). 