### PR TITLE
Endpoint normalization and badges customization

### DIFF
--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -413,7 +413,7 @@ def _detailed_page_link(domain, model_name, model_type, query_hash):
     # example:
     # https://emmaa.indra.bio/query/aml/?model_type=pysb&query_hash
     # =4911955502409811&order=1
-    return f'https://{domain}/query/{model_name}/?model_type=' \
+    return f'https://{domain}/query/{model_name}?model_type=' \
            f'{model_type}&query_hash={query_hash}&order=1'
 
 

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -224,7 +224,7 @@ class ModelManager(object):
                 url_param = parse.urlencode(
                     {'stmt_hash': stmt_hashes, 'source': 'model_statement',
                      'model': self.model.name}, doseq=True)
-                link = f'/evidence/?{url_param}'
+                link = f'/evidence?{url_param}'
                 sentences.append((link, sentence, ''))
         else:
             for stmt in stmts:
@@ -238,7 +238,7 @@ class ModelManager(object):
                     url_param = parse.urlencode(
                         {'stmt_hash': stmt_hashes, 'source': 'model_statement',
                          'model': self.model.name}, doseq=True)
-                    link = f'/evidence/?{url_param}'
+                    link = f'/evidence?{url_param}'
                     sentences.append((link, sentence, ''))
         return sentences
 

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -614,8 +614,9 @@ def load_model_manager_from_s3(model_name=None, key=None,
             body = obj['Body'].read()
             model_manager = pickle.loads(body)
             return model_manager
-        except Exception:
-            logger.info(f'No file found with key {key}')
+        except Exception as e:
+            logger.info('Could not load the model manager')
+            logger.info(e)
     # Now try find the latest key for given model
     if model_name:
         # Versioned

--- a/emmaa/queries.py
+++ b/emmaa/queries.py
@@ -243,7 +243,7 @@ class DynamicProperty(Query):
         return str(self)
 
     def to_english(self):
-        agent = _assemble_agent_str(self.entity)
+        agent = _assemble_agent_str(self.entity).agent_str
         agent = agent[0].upper() + agent[1:]
         if self.pattern_type == 'always_value':
             pattern = 'always'

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -249,7 +249,7 @@ def _format_table_array(tests_json, model_types, model_name, date, test_corpus):
         ev_url_par = parse.urlencode(
             {'stmt_hash': th, 'source': 'test', 'model': model_name,
              'test_corpus': test_corpus})
-        test['test'][0] = f'/evidence/?{ev_url_par}'
+        test['test'][0] = f'/evidence?{ev_url_par}'
         test['test'][2] = stmt_db_link_msg
         new_row = [(test['test'])]
         for mt in model_types:
@@ -270,14 +270,14 @@ def _format_query_results(formatted_results):
         latest_date = get_latest_available_date(
             model, _default_test(model))
         new_res = [('', res["query"], ''),
-                   (f'/dashboard/{model}/?date={latest_date}' +
+                   (f'/dashboard/{model}?date={latest_date}' +
                     f'&test_corpus={_default_test(model)}&tab=model',
                     model,
                     f'Click to see details about {model}')]
         for mt in model_types:
             url_param = parse.urlencode(
                 {'model_type': mt, 'query_hash': qh, 'order': 1})
-            new_res.append((f'/query/{model}?{url_param}', res[mt][0],
+            new_res.append((f'/query{model}?{url_param}', res[mt][0],
                             'Click to see detailed results for this query'))
         result_array.append(new_res)
     return result_array
@@ -316,7 +316,7 @@ def _new_passed_tests(model_name, test_stats_json, current_model_types, date,
             ev_url_par = parse.urlencode(
                 {'stmt_hash': th, 'source': 'test', 'model': model_name,
                  'test_corpus': test_corpus})
-            test['test'][0] = f'/evidence/?{ev_url_par}'
+            test['test'][0] = f'/evidence?{ev_url_par}'
             test['test'][2] = stmt_db_link_msg
             path_loc = test[mt][1]
             if isinstance(path_loc, list):
@@ -462,7 +462,7 @@ def get_home():
                            user_email=user.email if user else "")
 
 
-@app.route('/dashboard/<model>/')
+@app.route('/dashboard/<model>')
 @jwt_optional
 def get_model_dashboard(model):
     test_corpus = request.args.get('test_corpus', _default_test(
@@ -511,7 +511,7 @@ def get_model_dashboard(model):
     for st_hash, st_value in all_stmts.items():
         url_param = parse.urlencode(
             {'stmt_hash': st_hash, 'source': 'model_statement', 'model': model})
-        st_value[0] = f'/evidence/?{url_param}'
+        st_value[0] = f'/evidence?{url_param}'
         st_value[2] = stmt_db_link_msg
         cur = _set_curation(st_hash, correct, incorrect)
         st_value.append(cur)
@@ -553,7 +553,7 @@ def get_model_dashboard(model):
                            tab=tab)
 
 
-@app.route('/tests/<model>/')
+@app.route('/tests/<model>')
 def get_model_tests_page(model):
     model_type = request.args.get('model_type')
     test_hash = request.args.get('test_hash')
@@ -688,7 +688,7 @@ def get_query_page():
                            tab=tab)
 
 
-@app.route('/evidence/')
+@app.route('/evidence')
 def get_statement_evidence_page():
     stmt_hashes = request.args.getlist('stmt_hash')
     source = request.args.get('source')
@@ -744,7 +744,7 @@ def get_statement_evidence_page():
                            is_all_stmts=False)
 
 
-@app.route('/all_statements/<model>/')
+@app.route('/all_statements/<model>')
 def get_all_statements_page(model):
     mm = load_model_manager_from_cache(model)
     sort_by = request.args.get('sort_by', 'evidence')
@@ -819,7 +819,7 @@ def get_all_statements_page(model):
                            link=link)
 
 
-@app.route('/query/<model>/')
+@app.route('/query/<model>')
 def get_query_tests_page(model):
     model_type = request.args.get('model_type')
     query_hash = int(request.args.get('query_hash'))

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -654,7 +654,8 @@ def get_statement_evidence_page():
                         cur_count, json_link)]
             stmt_rows.append(stmt_row)
     else:
-        return jsonify(stmts[0].to_json())
+        stmt_json = json.dumps(stmts[0].to_json(), indent=1)
+        return Response(stmt_json, mimetype='application/json')
     return render_template('evidence_template.html',
                            stmt_rows=stmt_rows,
                            model=model,

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -399,7 +399,7 @@ def _get_stmt_row(stmt, source, model, cur_counts, test_corpus=None,
     if test_corpus:
         params.update({'test_corpus': test_corpus})
     url_param = parse.urlencode(params)
-    json_link = f'/evidence/?{url_param}'
+    json_link = f'/evidence?{url_param}'
     path_count = 0
     if path_counts:
         path_count = path_counts.get(stmt_hash)

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -277,7 +277,7 @@ def _format_query_results(formatted_results):
         for mt in model_types:
             url_param = parse.urlencode(
                 {'model_type': mt, 'query_hash': qh, 'order': 1})
-            new_res.append((f'/query{model}?{url_param}', res[mt][0],
+            new_res.append((f'/query/{model}?{url_param}', res[mt][0],
                             'Click to see detailed results for this query'))
         result_array.append(new_res)
     return result_array

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -384,17 +384,19 @@ def _count_curations(curations=None, **kwargs):
     return cur_counts
 
 
-def _get_stmt_row(stmt, source, model, cur_counts, path_counts=None,
-                  cur_dict=None, with_evid=False):
+def _get_stmt_row(stmt, source, model, cur_counts, test_corpus=None,
+                  path_counts=None, cur_dict=None, with_evid=False):
     stmt_hash = str(stmt.get_hash())
     english = _format_stmt_text(stmt)
     evid_count = len(stmt.evidence)
     evid = []
     if with_evid and cur_dict:
         evid = _format_evidence_text(stmt, cur_dict)[:10]
-    url_param = parse.urlencode(
-        {'stmt_hash': stmt_hash, 'source': source,
-            'model': model, 'format': 'json'})
+    params = {'stmt_hash': stmt_hash, 'source': source, 'model': model,
+              'format': 'json'}
+    if test_corpus:
+        params.update({'test_corpus': test_corpus})
+    url_param = parse.urlencode(params)
     json_link = f'/evidence/?{url_param}'
     path_count = 0
     if path_counts:
@@ -720,7 +722,8 @@ def get_statement_evidence_page():
         stmt_rows = []
         for stmt in stmts:
             stmt_row = _get_stmt_row(stmt, source, model, cur_counts,
-                                     stmt_counts_dict, cur_dict, True)
+                                     test_corpus, stmt_counts_dict,
+                                     cur_dict, True)
             stmt_rows.append(stmt_row)
     else:
         stmt_json = json.dumps(stmts[0].to_json(), indent=1)
@@ -785,8 +788,8 @@ def get_all_statements_page(model):
                     continue
     stmt_rows = []
     for stmt in stmts:
-        stmt_row = _get_stmt_row(
-            stmt, 'model_statement', model, cur_counts, stmt_counts_dict)
+        stmt_row = _get_stmt_row(stmt, 'model_statement', model, cur_counts,
+                                 None, stmt_counts_dict)
         stmt_rows.append(stmt_row)
     table_title = f'All statements in {model.upper()} model.'
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -719,7 +719,11 @@ def get_all_statements_page(model):
         sh = str(stmt.get_hash())
         english = _format_stmt_text(stmt)
         evid_count = len(stmt.evidence)
-        stmt_row = [(sh, english, [], evid_count, cur_counts[sh])]
+        url_param = parse.urlencode(
+            {'stmt_hash': sh, 'source': 'model_statement', 'model': model,
+             'format': 'json'})
+        json_link = f'/evidence/?{url_param}'
+        stmt_row = [(sh, english, [], evid_count, cur_counts[sh], json_link)]
         stmt_rows.append(stmt_row)
     table_title = f'All statements in {model.upper()} model.'
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -392,7 +392,8 @@ def _get_stmt_row(stmt, source, model, cur_counts, test_corpus=None,
     evid_count = len(stmt.evidence)
     evid = []
     if with_evid and cur_dict:
-        evid = _format_evidence_text(stmt, cur_dict)[:10]
+        evid = _format_evidence_text(
+            stmt, cur_dict, ['correct', 'act_vs_amt', 'hypothesis'])[:10]
     params = {'stmt_hash': stmt_hash, 'source': source, 'model': model,
               'format': 'json'}
     if test_corpus:
@@ -1040,7 +1041,8 @@ def get_statement_by_hash_model(model, hash_val):
     for st in mm.model.assembled_stmts:
         if str(st.get_hash()) == str(hash_val):
             st_json = st.to_json()
-            ev_list = _format_evidence_text(st, cur_dict)
+            ev_list = _format_evidence_text(
+                st, cur_dict, ['correct', 'act_vs_amt', 'hypothesis'])
             st_json['evidence'] = ev_list
     return {'statements': {hash_val: st_json}}
 
@@ -1056,7 +1058,8 @@ def get_tests_by_hash(test_corpus, hash_val):
     for test in tests:
         if str(test.stmt.get_hash()) == str(hash_val):
             st_json = test.stmt.to_json()
-            ev_list = _format_evidence_text(test.stmt, cur_dict)
+            ev_list = _format_evidence_text(
+                test.stmt, cur_dict, ['correct', 'act_vs_amt', 'hypothesis'])
             st_json['evidence'] = ev_list
     return {'statements': {hash_val: st_json}}
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -410,27 +410,28 @@ def _get_stmt_row(stmt, source, model, cur_counts, test_corpus=None,
 
 def _make_badges(evid_count, json_link, path_count, cur_counts=None):
     badges = [
-        {'label': 'evidence', 'num': evid_count, 'color': 'grey',
-         'symbol': None, 'title': 'Evidence count for this statement'},
-        {'label': 'paths', 'num': path_count, 'symbol': '\u2713',
-         'color': '#28a745', 'title': 'Number of paths with this statement'},
         {'label': 'stmt_json', 'num': 'JSON', 'color': '#b3b3ff',
-         'symbol': None, 'title': 'View statement JSON', 'href': json_link}]
+         'symbol': None, 'title': 'View statement JSON', 'href': json_link,
+         'loc': 'right'},
+        {'label': 'evidence', 'num': evid_count, 'color': 'grey',
+         'symbol': None, 'title': 'Evidence count for this statement',
+         'loc': 'right'},
+        {'label': 'paths', 'num': path_count, 'symbol': '\u2713',
+         'color': '#28a745', 'title': 'Number of paths with this statement'}]
     if cur_counts:
         badges += [
-            {'label': 'incorrect_other', 'symbol': '\u270E', 'loc': 'right',
-             'num': cur_counts['other']['incorrect'], 'color': '#ffcccc',
-             'title': 'Curated as incorrect outside of EMMAA'},
-            {'label': 'correct_other', 'num': cur_counts['other']['correct'],
-             'color': '#adebbb', 'symbol': '\u270E',
-             'title': 'Curated as correct outside of EMMAA', 'loc': 'right'},
-            {'label': 'incorrect_emmaa', 'num': cur_counts['emmaa']['incorrect'],
-             'color': '#ff8080', 'symbol': '\u270E',
-             'title': 'Curated as incorrect in EMMAA', 'loc': 'right'},
             {'label': 'correct_emmaa', 'num': cur_counts['emmaa']['correct'],
              'color': '#28a745', 'symbol':  '\u270E',
-             'title': 'Curated as correct in EMMAA', 'loc': 'right'}
-        ]
+             'title': 'Curated as correct in EMMAA'},
+            {'label': 'incorrect_emmaa', 'num': cur_counts['emmaa']['incorrect'],
+             'color': '#ff8080', 'symbol': '\u270E',
+             'title': 'Curated as incorrect in EMMAA'},
+            {'label': 'correct_other', 'num': cur_counts['other']['correct'],
+             'color': '#adebbb', 'symbol': '\u270E',
+             'title': 'Curated as correct outside of EMMAA'},
+            {'label': 'incorrect_other', 'symbol': '\u270E',
+             'num': cur_counts['other']['incorrect'], 'color': '#ffcccc',
+             'title': 'Curated as incorrect outside of EMMAA'}]
     return badges
 
 

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -164,7 +164,7 @@ function redirectSelection(ddSelect, param) {
 
 function redirectToAllStmts() {
   let model = window.location.pathname.split('/')[2]
-  window.open(`/all_statements/${model}/?sort_by=evidence&page=1&filter_curated=false`, target="_blank")
+  window.open(`/all_statements/${model}?sort_by=evidence&page=1&filter_curated=false`, target="_blank")
 }
 
 function clearTables(arrayOfTableBodies) {

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -35,12 +35,12 @@
 
   <!-- Vue scripts -->
   <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-  <!-- <script src="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-latest/IndralabVue.umd.min.js"></script> -->
-  <!-- <link href="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-latest/IndralabVue.css" rel="stylesheet"> -->
+  <script src="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-latest/IndralabVue.umd.min.js"></script>
+  <link href="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-latest/IndralabVue.css" rel="stylesheet">
   <!-- <script src="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-dev/IndralabVue.umd.min.js"></script> -->
   <!-- <link href="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-dev/IndralabVue.css" rel="stylesheet"> -->
-  <script src="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-test/IndralabVue.umd.min.js"></script>
-  <link href="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-test/IndralabVue.css" rel="stylesheet">  
+  <!-- <script src="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-test/IndralabVue.umd.min.js"></script> -->
+  <!-- <link href="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-test/IndralabVue.css" rel="stylesheet">   -->
   {% block additional_scripts %}
   {% endblock %}
 

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -35,10 +35,12 @@
 
   <!-- Vue scripts -->
   <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-  <script src="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-latest/IndralabVue.umd.min.js"></script>
-  <link href="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-latest/IndralabVue.css" rel="stylesheet">
+  <!-- <script src="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-latest/IndralabVue.umd.min.js"></script> -->
+  <!-- <link href="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-latest/IndralabVue.css" rel="stylesheet"> -->
   <!-- <script src="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-dev/IndralabVue.umd.min.js"></script> -->
   <!-- <link href="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-dev/IndralabVue.css" rel="stylesheet"> -->
+  <script src="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-test/IndralabVue.umd.min.js"></script>
+  <link href="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-test/IndralabVue.css" rel="stylesheet">  
   {% block additional_scripts %}
   {% endblock %}
 

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -35,10 +35,10 @@
 
   <!-- Vue scripts -->
   <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-  <!-- <script src="https://bigmech.s3.amazonaws.com/indra-db/IndralabVue.umd.js"></script> -->
-  <!-- <link href="https://bigmech.s3.amazonaws.com/indra-db/IndralabVue.css" rel="stylesheet"> -->
-  <script src="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-dev/IndralabVue.umd.min.js"></script>
-  <link href="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-dev/IndralabVue.css" rel="stylesheet">
+  <script src="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-latest/IndralabVue.umd.min.js"></script>
+  <link href="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-latest/IndralabVue.css" rel="stylesheet">
+  <!-- <script src="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-dev/IndralabVue.umd.min.js"></script> -->
+  <!-- <link href="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-dev/IndralabVue.css" rel="stylesheet"> -->
   {% block additional_scripts %}
   {% endblock %}
 

--- a/emmaa_service/templates/maintenance.html
+++ b/emmaa_service/templates/maintenance.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Service Maintenance</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+    }
+
+    html,
+    body {
+      height: 100%;
+    }
+
+    #wrap {
+      min-height: 100%;
+    }
+
+    #main {
+      overflow: auto;
+      padding-bottom: 180px;
+      /* must be same height as the footer */
+    }
+
+    #footer {
+      position: relative;
+      margin-top: -180px;
+      /* negative value of footer height */
+      height: 180px;
+      clear: both;
+      background-color: red;
+    }
+  </style>
+</head>
+<body>
+<div id="wrap">
+  <div id="main">
+  <h1>We're working on it</h1>
+  <p style="font-size: large">The service is currently down for maintenance,
+    please check back later today</p>
+  </div>
+</div>
+  <footer id="footer" class="footer text-muted" style="background: #F5F5F5;">
+    <div class="container">
+      <h5 class="my-0 mr-md-auto font-weight-normal">About</h5>
+      <small>
+        <p class="float-right">
+          <a href="#">Back to top</a>
+        </p>
+        <p><a href="https://indralab.github.io" target="_blank">INDRALAB</a></p>
+        <p><a href="http://hits.harvard.edu" target="_blank">Harvard Program in Therapeutic Science (HiTS)</a></p>
+        <p><b>Automating Scientific Knowledge Extraction (ASKE)</b><br>EMMAA (Ecosystem of Machine-maintained Models with Automated Assembly) is a part of the DARPA ASKE program, which is part of DARPA's broader Artificial Intelligence Exploration program with the goal of developing technologies for the "Third Wave" of AI.<br><i>The EMMAA project is funded by the Defense Advanced Research Projects Agency under award HR00111990009.</i></p>
+      </small>
+    </div>
+  </footer>
+</body>
+</html>

--- a/emmaa_service/templates/tests_template.html
+++ b/emmaa_service/templates/tests_template.html
@@ -34,7 +34,7 @@
   </select>
   <div class="input-group-append">
     <button class="btn btn-outline-secondary"
-            onClick="modelRedirect(document.getElementById('modelTypeSelectDD'), '{{ model_type }}')"
+            onClick="redirectSelection(document.getElementById('modelTypeSelectDD'), '{{ model_type }}')"
             type="button">Load Type</button>
   </div>
 </div>


### PR DESCRIPTION
This PR makes two substantial updates:

**Endpoint normalization and nginx compatibility:**
- All trailing slashes have been removed in endpoints and links
- A static "down for maintenance" html page has been added
- nginx has been set up to redirect old links that go to now extinct endpoints (outside code of PR)

**badge updates**
All statements and statement evidence pages now display the following badges:
- Evidence count
- Link to statement json
- Count of paths the statement is a part of
- Count of correct/incorrect curations in the scope and outside of the scope of current model
- Evidence level badges showing correct/incorrect curations.

This PR depends on the following PRs being merged: https://github.com/sorgerlab/indra/pull/1086, https://github.com/indralab/ui_util/pull/8, https://github.com/indralab/indralab-vue/pull/7