### PR TITLE
Get new readings from BioRxiv

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -124,9 +124,9 @@ class EmmaaModel(object):
         """
         if lit_source == 'pubmed':
             terms_to_ids = self.search_pubmed(self.search_terms, date_limit)
-        elif lit_source == 'bioarxiv':
+        elif lit_source == 'biorxiv':
             collection_id = self.reading_config.get('collection_id', '181')
-            terms_to_ids = self.search_bioarxiv(collection_id, date_limit)
+            terms_to_ids = self.search_biorxiv(collection_id, date_limit)
         elif lit_source == 'elsevier':
             terms_to_ids = self.search_elsevier(self.search_terms, date_limit)
         else:
@@ -196,8 +196,8 @@ class EmmaaModel(object):
         return terms_to_piis
 
     @staticmethod
-    def search_bioarxiv(collection_id, date_limit):
-        """Search Bioarxiv within date_limit.
+    def search_biorxiv(collection_id, date_limit):
+        """Search BioRxiv within date_limit.
 
         Parameters
         ----------
@@ -208,14 +208,14 @@ class EmmaaModel(object):
         Returns
         -------
         terms_to_dois : dict
-            A dict representing bioarxiv collection ID as key and DOIs returned
+            A dict representing biorxiv collection ID as key and DOIs returned
             by search as values.
         """
         start_date = (
             datetime.datetime.utcnow() - datetime.timedelta(days=date_limit))
         dois = biorxiv_client.get_collection_dois(collection_id, start_date)
         logger.info(f'{len(dois)} DOIs found')
-        terms_to_dois = {f'bioarxiv: {collection_id}': dois}
+        terms_to_dois = {f'biorxiv: {collection_id}': dois}
         return terms_to_dois
 
     def get_new_readings(self, date_limit=10):

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -192,6 +192,29 @@ class EmmaaModel(object):
             time.sleep(1)
         return terms_to_piis
 
+    @staticmethod
+    def search_bioarxiv(collection_id, date_limit):
+        """Search Bioarxiv within date_limit.
+
+        Parameters
+        ----------
+        date_limit : int
+            The number of days to search back from today.
+        collection_id : str
+            ID of a collection to search BioArxiv for.
+        Returns
+        -------
+        terms_to_dois : dict
+            A dict representing bioarxiv collection ID as key and DOIs returned
+            by search as values.
+        """
+        start_date = (
+            datetime.datetime.utcnow() - datetime.timedelta(days=date_limit))
+        dois = biorxiv_client.get_collection_dois(collection_id, start_date)
+        logger.info(f'{len(dois)} DOIs found')
+        terms_to_dois = {f'bioarxiv: {collection_id}': dois}
+        return terms_to_dois
+
     def get_new_readings(self, date_limit=10):
         """Search new literature, read, and add to model statements"""
         reader = self.reading_config.get('reader', 'indra_db')

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -4,7 +4,7 @@ import pickle
 import logging
 import datetime
 from indra.databases import ndex_client
-from indra.literature import pubmed_client, elsevier_client
+from indra.literature import pubmed_client, elsevier_client, biorxiv_client
 from indra.assemblers.cx import CxAssembler
 from indra.assemblers.pysb import PysbAssembler
 from indra.assemblers.pybel import PybelAssembler
@@ -15,7 +15,8 @@ from indra.tools.assemble_corpus import filter_grounded_only
 from indra_db.client.principal.curation import get_curations
 from emmaa.priors import SearchTerm
 from emmaa.readers.aws_reader import read_pmid_search_terms
-from emmaa.readers.db_client_reader import read_db_pmid_search_terms
+from emmaa.readers.db_client_reader import read_db_pmid_search_terms, \
+    read_db_doi_search_terms
 from emmaa.readers.elsevier_eidos_reader import \
     read_elsevier_eidos_search_terms
 from emmaa.util import make_date_str, find_latest_s3_file, get_s3_client, \
@@ -105,7 +106,7 @@ class EmmaaModel(object):
         if 'query' in config:
             self.query_config = config['query']
 
-    def search_literature(self, date_limit=None):
+    def search_literature(self, lit_source, date_limit=None):
         """Search for the model's search terms in the literature.
 
         Parameters
@@ -121,9 +122,11 @@ class EmmaaModel(object):
             and the search terms for which the given ID was produced as
             values.
         """
-        lit_source = self.reading_config.get('literature_source', 'pubmed')
         if lit_source == 'pubmed':
             terms_to_ids = self.search_pubmed(self.search_terms, date_limit)
+        elif lit_source == 'bioarxiv':
+            collection_id = self.reading_config.get('collection_id', '181')
+            terms_to_ids = self.search_bioarxiv(collection_id, date_limit)
         elif lit_source == 'elsevier':
             terms_to_ids = self.search_elsevier(self.search_terms, date_limit)
         else:
@@ -217,16 +220,25 @@ class EmmaaModel(object):
 
     def get_new_readings(self, date_limit=10):
         """Search new literature, read, and add to model statements"""
-        reader = self.reading_config.get('reader', 'indra_db')
-        ids_to_terms = self.search_literature(date_limit=date_limit)
-        if reader == 'aws':
-            estmts = read_pmid_search_terms(ids_to_terms)
-        elif reader == 'indra_db':
-            estmts = read_db_pmid_search_terms(ids_to_terms)
-        elif reader == 'elsevier_eidos':
-            estmts = read_elsevier_eidos_search_terms(ids_to_terms)
-        else:
-            raise ValueError('Unknown reader: %s' % reader)
+        readers = self.reading_config.get('reader', ['indra_db_pmid'])
+        lit_sources = self.reading_config.get('literature_source', ['pubmed'])
+        if isinstance(lit_sources, str):
+            lit_sources = [lit_sources]
+        if isinstance(readers, str):
+            readers = [readers]
+        estmts = []
+        for lit_source, reader in zip(lit_sources, readers):
+            ids_to_terms = self.search_literature(lit_source, date_limit)
+            if reader == 'aws':
+                estmts += read_pmid_search_terms(ids_to_terms)
+            elif reader == 'indra_db_pmid':
+                estmts += read_db_pmid_search_terms(ids_to_terms)
+            elif reader == 'indra_db_doi':
+                estmts += read_db_doi_search_terms(ids_to_terms)
+            elif reader == 'elsevier_eidos':
+                estmts += read_elsevier_eidos_search_terms(ids_to_terms)
+            else:
+                raise ValueError('Unknown reader: %s' % reader)
         logger.info('Got a total of %d new EMMAA Statements from reading' %
                     len(estmts))
         self.extend_unique(estmts)

--- a/emmaa/readers/db_client_reader.py
+++ b/emmaa/readers/db_client_reader.py
@@ -4,6 +4,34 @@ from indra_db.util import get_primary_db
 from emmaa.statements import EmmaaStatement
 
 
+def read_db_ids_search_terms(id_search_terms, id_type):
+    """Return extracted EmmaaStatements from INDRA database given an
+    ID-search term dict.
+
+    Parameters
+    ----------
+    id_search_terms : dict
+        A dict representing a set of IDs pointing to search terms that
+        produced them.
+
+    Returns
+    -------
+    list[:py:class:`emmaa.model.EmmaaStatement`]
+        A list of EmmaaStatements extracted from the given IDs.
+    """
+    ids = list(id_search_terms.keys())
+    date = datetime.datetime.utcnow()
+    db = get_primary_db()
+    id_stmts = get_statements_by_paper(ids, id_type=id_type, db=db,
+                                       preassembled=False)
+    estmts = []
+    for _id, stmts in id_stmts.items():
+        for stmt in stmts:
+            es = EmmaaStatement(stmt, date, id_search_terms[_id])
+            estmts.append(es)
+    return estmts
+
+
 def read_db_pmid_search_terms(pmid_search_terms):
     """Return extracted EmmaaStatements from INDRA database given a
     PMID-search term dict.
@@ -19,14 +47,22 @@ def read_db_pmid_search_terms(pmid_search_terms):
     list[:py:class:`emmaa.model.EmmaaStatement`]
         A list of EmmaaStatements extracted from the given PMIDs.
     """
-    pmids = list(pmid_search_terms.keys())
-    date = datetime.datetime.utcnow()
-    db = get_primary_db()
-    pmid_stmts = get_statements_by_paper(pmids, id_type='pmid', db=db,
-                                         preassembled=False)
-    estmts = []
-    for pmid, stmts in pmid_stmts.items():
-        for stmt in stmts:
-            es = EmmaaStatement(stmt, date, pmid_search_terms[pmid])
-            estmts.append(es)
-    return estmts
+    return read_db_ids_search_terms(pmid_search_terms, 'pmid')
+
+
+def read_db_doi_search_terms(doi_search_terms):
+    """Return extracted EmmaaStatements from INDRA database given a
+    DOI-search term dict.
+
+    Parameters
+    ----------
+    doi_search_terms : dict
+        A dict representing a set of DOIs pointing to search terms that
+        produced them.
+
+    Returns
+    -------
+    list[:py:class:`emmaa.model.EmmaaStatement`]
+        A list of EmmaaStatements extracted from the given DOIs.
+    """
+    return read_db_ids_search_terms(doi_search_terms, 'doi')

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -24,11 +24,11 @@ test_response = {
         'edge_list': [
             {'edge': 'BRAF → MAP2K1',
              'stmts': [
-                 ['/evidence/?stmt_hash=-23078353002754841&source=model_statement&model=test',
+                 ['/evidence?stmt_hash=-23078353002754841&source=model_statement&model=test',
                   'BRAF activates MAP2K1.', '']]},
             {'edge': 'MAP2K1 → MAPK1',
              'stmts': [
-                 ['/evidence/?stmt_hash=-34603994586320440&source=model_statement&model=test',
+                 ['/evidence?stmt_hash=-34603994586320440&source=model_statement&model=test',
                   'Active MAP2K1 activates MAPK1.', '']]}]}}
 query_not_appl = {'2413475507': 'Query is not applicable for this model'}
 fail_response = {'521653329': 'No path found that satisfies the test statement'}


### PR DESCRIPTION
This PR allows EMMAA models to get extended with statements from BioRxiv and get new statements from more than one literature source. Since both PMID and DOI based statements are sourced from INDRA DB, the generalized function is created for getting statements from INDRA DB and ID specific functions call it with different parameters. To get statements from multiple literature sources, a list of sources and a corresponding list of users need to be provided in model config, e.g. 
`config['reading'] = {'literature_source': ['pubmed', 'biorxiv'], 'reader': ['indra_db_pmid', 'indra_db_doi']}`