### PR TITLE
Assembled statements

### DIFF
--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -449,11 +449,17 @@ class ModelManager(object):
     def save_assembled_statements(self, bucket=EMMAA_BUCKET_NAME):
         """Upload assembled statements jsons to S3 bucket."""
         stmt_jsons = self.assembled_stmts_to_json()
-        key = f'assembled/{self.model.name}/statements_{self.date_str}.json'
+        # Save a timestapmed version and a generic latest version of files
+        key1 = f'assembled/{self.model.name}/statements_{self.date_str}.json'
+        key2 = f'assembled/{self.model.name}/' \
+               f'latest_statements_{self.model.name}.json'
         json_str = json.dumps(stmt_jsons, indent=1)
         client = get_s3_client(unsigned=False)
-        logger.info(f'Uploading assembled statements to {key}')
-        client.put_object(Bucket=bucket, Key=key,
+        logger.info(f'Uploading assembled statements to {key1}')
+        client.put_object(Bucket=bucket, Key=key1,
+                          Body=json_str.encode('utf8'))
+        logger.info(f'Uploading assembled statements to {key2}')
+        client.put_object(Bucket=bucket, Key=key2,
                           Body=json_str.encode('utf8'))
 
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -803,7 +803,11 @@ def get_all_statements_page(model):
         stmt_rows.append(stmt_row)
     table_title = f'All statements in {model.upper()} model.'
 
-    if does_exist(EMMAA_BUCKET_NAME, f'assembled/{model}/statements_'):
+    if does_exist(EMMAA_BUCKET_NAME,
+                  f'assembled/{model}/latest_statements_{model}'):
+        fkey = f'assembled/{model}/latest_statements_{model}.json'
+        link = f'https://{EMMAA_BUCKET_NAME}.s3.amazonaws.com/{fkey}'
+    elif does_exist(EMMAA_BUCKET_NAME, f'assembled/{model}/statements_'):
         fkey = find_latest_s3_file(
             EMMAA_BUCKET_NAME, f'assembled/{model}/statements_', '.json')
         link = f'https://{EMMAA_BUCKET_NAME}.s3.amazonaws.com/{fkey}'


### PR DESCRIPTION
This PR makes it easier to get latest assembled statements of a given model in multiple ways:

- At assembly time, the assembled statements will be dumped into a constantly updated 'latest_statements_{model_name}.json' file to be found easily (first file in S3 directory) and a timestamped file for keeping track of changes
- Download statements button on all statements page will download (if available) the file called 'latest_statements_{model_name}.json' instead of time-stamped one
- New endpoint ('/latest_statements/<model>') allows to get statement jsons and the link to latest file programmatically through API request
