### PR TITLE
Individual models tweets

### DIFF
--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -776,3 +776,25 @@ def generate_stats_on_s3(
     if upload_stats:
         sg.save_to_s3()
     return sg
+
+
+def _make_twitter_msg(model_name, human_readable_name, msg_type, delta,
+                      mc_type=None):
+    if msg_type == 'stmts':
+        msg = (f'{human_readable_name} model found {len(delta["added"])} new '
+               'mechanisms today. '
+               f'See https://emmaa.indra.bio/dashboard/{model_name} '
+               'for more details.')
+    elif msg_type == 'applied_tests':
+        msg = (f'{human_readable_name} model has {len(delta["added"])} new '
+               'applied tests today. See '
+               f'https://emmaa.indra.bio/dashboard/{model_name}?tab=tests '
+               'for more details.')
+    elif msg_type == 'passed_tests' and mc_type:
+        msg = (f'{human_readable_name} {FORMATTED_TYPE_NAMES[mc_type]} has '
+               f'{len(delta["added"])} new passed tests today.'
+               f' See https://emmaa.indra.bio/dashboard/{model_name}?tab=tests'
+               ' for more details.')
+    else:
+        raise TypeError(f'Invalid message type: {msg_type}.')
+    return msg

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -773,13 +773,14 @@ def _make_twitter_msg(model_name, msg_type, delta, human_readable_name=None,
                'for more details.')
     elif msg_type == 'applied_tests':
         msg = (f'{human_readable_name} model has {len(delta["added"])} new '
-               'applied tests today. See '
+               f'applied tests in {test_corpus} test corpus today. See '
                f'https://emmaa.indra.bio/dashboard/{model_name}?tab=tests'
                f'&test_corpus={test_corpus} for more details.')
     elif msg_type == 'passed_tests' and mc_type:
         msg = (f'{human_readable_name} {FORMATTED_TYPE_NAMES[mc_type]} has '
-               f'{len(delta["added"])} new passed tests today.'
-               f' See https://emmaa.indra.bio/dashboard/{model_name}?tab=tests'
+               f'{len(delta["added"])} new passed tests in {test_corpus} test '
+               'corpus today. See '
+               f'https://emmaa.indra.bio/dashboard/{model_name}?tab=tests'
                f'&test_corpus={test_corpus} for more details.')
     else:
         raise TypeError(f'Invalid message type: {msg_type}.')

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -459,7 +459,7 @@ class ModelStatsGenerator(StatsGenerator):
             if len(stmts_delta['added']) > 0:
                 logger.info(
                     f'{self.model_name.upper()} model found '
-                    f'{len(stmts_delta['added'])} new mechanisms today.\n'
+                    f'{len(stmts_delta["added"])} new mechanisms today. '
                     f'See https://emmaa.indra.bio/dashboard/{self.model_name} '
                     f'for more details.')
 
@@ -612,7 +612,7 @@ class TestStatsGenerator(StatsGenerator):
             if len(applied_delta['added']) > 0:
                 logger.info(
                     f'{self.model_name.upper()} model has '
-                    f'{len(applied_delta['added'])} new applied tests today. '
+                    f'{len(applied_delta["added"])} new applied tests today. '
                     f'See https://emmaa.indra.bio/dashboard/{self.model_name}'
                     f'?tab=tests for more details.')
 
@@ -630,7 +630,7 @@ class TestStatsGenerator(StatsGenerator):
                     logger.info(
                         f'{self.model_name.upper()} '
                         f'{FORMATTED_TYPE_NAMES[mc_type]} has '
-                        f'{len(passed_delta['added'])} new passed tests today.'
+                        f'{len(passed_delta["added"])} new passed tests today.'
                         f' See https://emmaa.indra.bio/dashboard/'
                         f'{self.model_name}?tab=tests for more details.')
         self.json_stats['tests_delta'] = tests_delta

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -759,7 +759,7 @@ def generate_stats_on_s3(
 
 
 def _make_twitter_msg(model_name, msg_type, delta, date, mc_type=None,
-                      test_corpus=None, bucket=EMMAA_BUCKET_NAME):
+                      test_corpus=None):
     if len(delta['added']) == 0:
         logger.info(f'No {msg_type} delta found')
         return

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -454,14 +454,16 @@ class ModelStatsGenerator(StatsGenerator):
                 self.previous_round, 'statements')
             self.json_stats['model_delta'] = {
                 'statements_hashes_delta': stmts_delta}
-            if self.config.get('twitter') and len(stmts_delta['added']) > 0:
+            if len(stmts_delta['added']) > 0:
                 msg = (
-                    f'{self.config['human_readable_name']} model found '
+                    f'{self.config["human_readable_name"]} model found '
                     f'{len(stmts_delta["added"])} new mechanisms today. '
                     f'See https://emmaa.indra.bio/dashboard/{self.model_name} '
                     f'for more details.')
-                twitter_cred = get_credentials(self.config['twitter'])
-                update_status(msg, twitter_cred)
+                logger.info(msg)
+                if self.config.get('twitter'):
+                    twitter_cred = get_credentials(self.config['twitter'])
+                    update_status(msg, twitter_cred)
 
     def make_changes_over_time(self):
         """Add changes to model over time to json_stats."""
@@ -610,14 +612,16 @@ class TestStatsGenerator(StatsGenerator):
                 self.previous_round, 'applied_tests')
             tests_delta = {
                 'applied_hashes_delta': applied_delta}
-            if self.config.get('twitter') and len(applied_delta['added']) > 0:
+            if len(applied_delta['added']) > 0:
                 msg = (
-                    f'{self.config['human_readable_name']} model has '
+                    f'{self.config["human_readable_name"]} model has '
                     f'{len(applied_delta["added"])} new applied tests today. '
                     f'See https://emmaa.indra.bio/dashboard/{self.model_name}'
                     f'?tab=tests for more details.')
-                twitter_cred = get_credentials(self.config['twitter'])
-                update_status(msg, twitter_cred)
+                logger.info(msg)
+                if self.config.get('twitter'):
+                    twitter_cred = get_credentials(self.config['twitter'])
+                    update_status(msg, twitter_cred)
 
         for mc_type in self.latest_round.mc_types_results:
             if not self.previous_round or mc_type not in \
@@ -629,19 +633,21 @@ class TestStatsGenerator(StatsGenerator):
                     self.previous_round, 'passed_tests', mc_type=mc_type)
                 tests_delta[mc_type] = {
                     'passed_hashes_delta': passed_delta}
-                if self.config.get('twitter') and \
-                        len(passed_delta['added']) > 0:
+                if len(passed_delta['added']) > 0:
                     msg = (
-                        f'{self.config['human_readable_name']} '
+                        f'{self.config["human_readable_name"]} '
                         f'{FORMATTED_TYPE_NAMES[mc_type]} has '
                         f'{len(passed_delta["added"])} new passed tests today.'
                         f' See https://emmaa.indra.bio/dashboard/'
                         f'{self.model_name}?tab=tests for more details.')
-                    # We can have the credentials already if there were new
-                    # applied or passed tests with other model type
-                    if not twitter_cred:
-                        twitter_cred = get_credentials(self.config['twitter'])
-                    update_status(msg, twitter_cred)
+                    logger.info(msg)
+                    if self.config.get('twitter'):
+                        # We can have the credentials already if there were new
+                        # applied or passed tests with other model type
+                        if not twitter_cred:
+                            twitter_cred = get_credentials(
+                                self.config['twitter'])
+                        update_status(msg, twitter_cred)
         self.json_stats['tests_delta'] = tests_delta
 
     def make_changes_over_time(self):

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -602,7 +602,7 @@ class TestStatsGenerator(StatsGenerator):
         test_name = None
         test_data = self.latest_round.json_results[0].get('test_data')
         if test_data:
-            test_name = test_data.get('test_name')
+            test_name = test_data.get('name')
         if not self.previous_round:
             tests_delta = {
                 'applied_hashes_delta': {'added': [], 'removed': []}}
@@ -819,7 +819,7 @@ def tweet_deltas(model_name, test_corpora, date, bucket=EMMAA_BUCKET_NAME):
         test_name = None
         test_data = test_stats['test_round_summary'].get('test_data')
         if test_data:
-            test_name = test_data.get('test_name')
+            test_name = test_data.get('name')
         for k, v in test_stats['tests_delta'].items():
             if k == 'applied_hashes_delta':
                 applied_delta = v

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -597,7 +597,7 @@ class TestStatsGenerator(StatsGenerator):
     def make_tests_delta(self):
         """Add tests delta between two latest test rounds to json_stats."""
         logger.info(f'Generating tests delta for {self.model_name}.')
-        config = load_config_from_s3(self.model_name)
+        config = load_config_from_s3(self.model_name, self.bucket)
         human_readable_name = config['human_readable_name']
         if not self.previous_round:
             tests_delta = {
@@ -759,12 +759,12 @@ def generate_stats_on_s3(
 
 
 def _make_twitter_msg(model_name, msg_type, delta, human_readable_name=None,
-                      mc_type=None, test_corpus=None):
+                      mc_type=None, test_corpus=None, bucket=EMMAA_BUCKET_NAME):
     if len(delta['added']) == 0:
         logger.info(f'No {msg_type} delta found')
         return
     if not human_readable_name:
-        config = load_config_from_s3(model_name)
+        config = load_config_from_s3(model_name, bucket)
         human_readable_name = config['human_readable_name']
     if msg_type == 'stmts':
         msg = (f'{human_readable_name} model found {len(delta["added"])} new '
@@ -786,7 +786,7 @@ def _make_twitter_msg(model_name, msg_type, delta, human_readable_name=None,
     return msg
 
 
-def tweet_deltas(model_name, test_corpora, date):
+def tweet_deltas(model_name, test_corpora, date, bucket=EMMAA_BUCKET_NAME):
     model_stats, _ = get_model_stats(model_name, 'model', date=date)
     test_stats_by_corpus = {}
     for test_corpus in test_corpora:
@@ -798,7 +798,7 @@ def tweet_deltas(model_name, test_corpora, date):
     if not model_stats or not test_stats_by_corpus:
         logger.warning('Stats are not found, not tweeting')
         return
-    config = load_config_from_s3(model_name)
+    config = load_config_from_s3(model_name, bucket)
     human_readable_name = config['human_readable_name']
     twitter_key = config.get('twitter')
     twitter_cred = get_credentials(twitter_key)

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -608,7 +608,8 @@ class TestStatsGenerator(StatsGenerator):
             tests_delta = {
                 'applied_hashes_delta': applied_delta}
             msg = _make_twitter_msg(self.model_name, 'applied_tests',
-                                    applied_delta, human_readable_name)
+                                    applied_delta, human_readable_name,
+                                    test_corpus=self.test_corpus)
             if msg:
                 logger.info(msg)
 
@@ -624,7 +625,7 @@ class TestStatsGenerator(StatsGenerator):
                     'passed_hashes_delta': passed_delta}
                 msg = _make_twitter_msg(
                     self.model_name, 'passed_tests', passed_delta,
-                    human_readable_name, mc_type)
+                    human_readable_name, mc_type, test_corpus=self.test_corpus)
                 if msg:
                     logger.info(msg)
         self.json_stats['tests_delta'] = tests_delta
@@ -758,7 +759,7 @@ def generate_stats_on_s3(
 
 
 def _make_twitter_msg(model_name, msg_type, delta, human_readable_name=None,
-                      mc_type=None):
+                      mc_type=None, test_corpus=None):
     if len(delta['added']) == 0:
         logger.info(f'No {msg_type} delta found')
         return
@@ -773,13 +774,13 @@ def _make_twitter_msg(model_name, msg_type, delta, human_readable_name=None,
     elif msg_type == 'applied_tests':
         msg = (f'{human_readable_name} model has {len(delta["added"])} new '
                'applied tests today. See '
-               f'https://emmaa.indra.bio/dashboard/{model_name}?tab=tests '
-               'for more details.')
+               f'https://emmaa.indra.bio/dashboard/{model_name}?tab=tests'
+               f'&test_corpus={test_corpus} for more details.')
     elif msg_type == 'passed_tests' and mc_type:
         msg = (f'{human_readable_name} {FORMATTED_TYPE_NAMES[mc_type]} has '
                f'{len(delta["added"])} new passed tests today.'
                f' See https://emmaa.indra.bio/dashboard/{model_name}?tab=tests'
-               ' for more details.')
+               f'&test_corpus={test_corpus} for more details.')
     else:
         raise TypeError(f'Invalid message type: {msg_type}.')
     return msg
@@ -818,7 +819,7 @@ def tweet_deltas(model_name, test_corpora, date, twitter_key):
                 applied_delta = v
                 applied_msg = _make_twitter_msg(
                     model_name, 'applied_tests', applied_delta,
-                    human_readable_name)
+                    human_readable_name, test_corpus=test_corpus)
                 if applied_msg:
                     logger.info(applied_msg)
                     if twitter_cred:
@@ -828,7 +829,7 @@ def tweet_deltas(model_name, test_corpora, date, twitter_key):
                 passed_delta = v['passed_hashes_delta']
                 passed_msg = _make_twitter_msg(
                     model_name, 'passed_tests', passed_delta,
-                    human_readable_name, mc_type)
+                    human_readable_name, mc_type, test_corpus=test_corpus)
                 if passed_msg:
                     logger.info(passed_msg)
                     if twitter_cred:

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -4,7 +4,8 @@ from collections import defaultdict
 from emmaa.model import _default_test
 from emmaa.model_tests import load_model_manager_from_s3
 from emmaa.util import find_latest_s3_file, find_nth_latest_s3_file, \
-    strip_out_date, EMMAA_BUCKET_NAME, load_json_from_s3, save_json_to_s3
+    strip_out_date, EMMAA_BUCKET_NAME, load_json_from_s3, save_json_to_s3, \
+    FORMATTED_TYPE_NAMES
 from indra.statements.statements import Statement
 from indra.assemblers.english.assembler import EnglishAssembler
 from indra.sources.indra_db_rest.api import get_statement_queries
@@ -18,12 +19,6 @@ CONTENT_TYPE_FUNCTION_MAPPING = {
     'applied_tests': 'get_applied_test_hashes',
     'passed_tests': 'get_passed_test_hashes',
     'paths': 'get_passed_test_hashes'}
-
-
-FORMATTED_TYPE_NAMES = {'pysb': 'PySB model',
-                        'pybel': 'PyBEL model',
-                        'signed_graph': 'Signed Graph',
-                        'unsigned_graph': 'Unsigned Graph'}
 
 
 class Round(object):

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -786,7 +786,7 @@ def _make_twitter_msg(model_name, msg_type, delta, human_readable_name=None,
     return msg
 
 
-def tweet_deltas(model_name, test_corpora, date, twitter_key):
+def tweet_deltas(model_name, test_corpora, date):
     model_stats, _ = get_model_stats(model_name, 'model', date=date)
     test_stats_by_corpus = {}
     for test_corpus in test_corpora:
@@ -800,6 +800,7 @@ def tweet_deltas(model_name, test_corpora, date, twitter_key):
         return
     config = load_config_from_s3(model_name)
     human_readable_name = config['human_readable_name']
+    twitter_key = config.get('twitter')
     twitter_cred = get_credentials(twitter_key)
     if not twitter_cred:
         logger.warning('Twitter credentials are not found, not tweeting')

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -775,12 +775,12 @@ def _make_twitter_msg(model_name, msg_type, delta, date, mc_type=None,
                f'?tab=model&date={date} for more details.')
     elif msg_type == 'applied_tests':
         msg = (f'Today I applied {len(delta["added"])} new tests in the '
-               f'{test_name} test corpus. See '
+               f'{test_name}. See '
                f'https://emmaa.indra.bio/dashboard/{model_name}?tab=tests'
                f'&test_corpus={test_corpus}&date={date} for more details.')
     elif msg_type == 'passed_tests' and mc_type:
         msg = (f'Today I explained {len(delta["added"])} new observations in '
-               f'the {test_name} test corpus with my '
+               f'the {test_name} with my '
                f'{FORMATTED_TYPE_NAMES[mc_type]} model. See '
                f'https://emmaa.indra.bio/dashboard/{model_name}?tab=tests'
                f'&test_corpus={test_corpus}&date={date} for more details.')

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -20,6 +20,12 @@ CONTENT_TYPE_FUNCTION_MAPPING = {
     'paths': 'get_passed_test_hashes'}
 
 
+FORMATTED_TYPE_NAMES = {'pysb': 'PySB model',
+                        'pybel': 'PyBEL model',
+                        'signed_graph': 'Signed Graph',
+                        'unsigned_graph': 'Unsigned Graph'}
+
+
 class Round(object):
     """Parent class for classes analyzing one round of something (model or
     tests).
@@ -446,9 +452,16 @@ class ModelStatsGenerator(StatsGenerator):
             self.json_stats['model_delta'] = {
                 'statements_hashes_delta': {'added': [], 'removed': []}}
         else:
+            stmts_delta = self.latest_round.find_delta_hashes(
+                self.previous_round, 'statements')
             self.json_stats['model_delta'] = {
-                'statements_hashes_delta': self.latest_round.find_delta_hashes(
-                    self.previous_round, 'statements')}
+                'statements_hashes_delta': stmts_delta}
+            if len(stmts_delta['added']) > 0:
+                logger.info(
+                    f'{self.model_name.upper()} model found '
+                    f'{len(stmts_delta['added'])} new mechanisms today.\n'
+                    f'See https://emmaa.indra.bio/dashboard/{self.model_name} '
+                    f'for more details.')
 
     def make_changes_over_time(self):
         """Add changes to model over time to json_stats."""
@@ -592,9 +605,16 @@ class TestStatsGenerator(StatsGenerator):
             tests_delta = {
                 'applied_hashes_delta': {'added': [], 'removed': []}}
         else:
+            applied_delta = self.latest_round.find_delta_hashes(
+                self.previous_round, 'applied_tests')
             tests_delta = {
-                'applied_hashes_delta': self.latest_round.find_delta_hashes(
-                    self.previous_round, 'applied_tests')}
+                'applied_hashes_delta': applied_delta}
+            if len(applied_delta['added']) > 0:
+                logger.info(
+                    f'{self.model_name.upper()} model has '
+                    f'{len(applied_delta['added'])} new applied tests today. '
+                    f'See https://emmaa.indra.bio/dashboard/{self.model_name}'
+                    f'?tab=tests for more details.')
 
         for mc_type in self.latest_round.mc_types_results:
             if not self.previous_round or mc_type not in \
@@ -602,9 +622,17 @@ class TestStatsGenerator(StatsGenerator):
                 tests_delta[mc_type] = {
                     'passed_hashes_delta': {'added': [], 'removed': []}}
             else:
+                passed_delta = self.latest_round.find_delta_hashes(
+                    self.previous_round, 'passed_tests', mc_type=mc_type)
                 tests_delta[mc_type] = {
-                    'passed_hashes_delta': self.latest_round.find_delta_hashes(
-                        self.previous_round, 'passed_tests', mc_type=mc_type)}
+                    'passed_hashes_delta': passed_delta}
+                if len(passed_delta['added']) > 0:
+                    logger.info(
+                        f'{self.model_name.upper()} '
+                        f'{FORMATTED_TYPE_NAMES[mc_type]} has '
+                        f'{len(passed_delta['added'])} new passed tests today.'
+                        f' See https://emmaa.indra.bio/dashboard/'
+                        f'{self.model_name}?tab=tests for more details.')
         self.json_stats['tests_delta'] = tests_delta
 
     def make_changes_over_time(self):

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -1,7 +1,7 @@
 import logging
 import jsonpickle
 from collections import defaultdict
-from emmaa.model import _default_test
+from emmaa.model import _default_test, load_config_from_s3
 from emmaa.model_tests import load_model_manager_from_s3
 from emmaa.util import find_latest_s3_file, find_nth_latest_s3_file, \
     strip_out_date, EMMAA_BUCKET_NAME, load_json_from_s3, save_json_to_s3, \
@@ -327,6 +327,8 @@ class StatsGenerator(object):
     ----------
     json_stats : dict
         A JSON-formatted dictionary containing model or test statistics.
+    config : dict
+        Model specific configurations.
     """
 
     def __init__(self, model_name, latest_round=None, previous_round=None,
@@ -347,6 +349,7 @@ class StatsGenerator(object):
         else:
             self.previous_round = previous_round
         self.json_stats = {}
+        self.config = load_config_from_s3(model_name, bucket)
 
     def make_changes_over_time(self):
         """Add changes to model and tests over time to json_stats."""
@@ -453,7 +456,7 @@ class ModelStatsGenerator(StatsGenerator):
                 'statements_hashes_delta': stmts_delta}
             if len(stmts_delta['added']) > 0:
                 logger.info(
-                    f'{self.model_name.upper()} model found '
+                    f'{self.config['human_readable_name']} model found '
                     f'{len(stmts_delta["added"])} new mechanisms today. '
                     f'See https://emmaa.indra.bio/dashboard/{self.model_name} '
                     f'for more details.')
@@ -606,7 +609,7 @@ class TestStatsGenerator(StatsGenerator):
                 'applied_hashes_delta': applied_delta}
             if len(applied_delta['added']) > 0:
                 logger.info(
-                    f'{self.model_name.upper()} model has '
+                    f'{self.config['human_readable_name']} model has '
                     f'{len(applied_delta["added"])} new applied tests today. '
                     f'See https://emmaa.indra.bio/dashboard/{self.model_name}'
                     f'?tab=tests for more details.')
@@ -623,7 +626,7 @@ class TestStatsGenerator(StatsGenerator):
                     'passed_hashes_delta': passed_delta}
                 if len(passed_delta['added']) > 0:
                     logger.info(
-                        f'{self.model_name.upper()} '
+                        f'{self.config['human_readable_name']} '
                         f'{FORMATTED_TYPE_NAMES[mc_type]} has '
                         f'{len(passed_delta["added"])} new passed tests today.'
                         f' See https://emmaa.indra.bio/dashboard/'

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -1,7 +1,7 @@
 import logging
 import jsonpickle
 from collections import defaultdict
-from emmaa.model import _default_test, load_config_from_s3
+from emmaa.model import _default_test, load_config_from_s3, get_model_stats
 from emmaa.model_tests import load_model_manager_from_s3
 from emmaa.util import find_latest_s3_file, find_nth_latest_s3_file, \
     strip_out_date, EMMAA_BUCKET_NAME, load_json_from_s3, save_json_to_s3, \
@@ -621,7 +621,7 @@ class TestStatsGenerator(StatsGenerator):
                     self.previous_round, 'passed_tests', mc_type=mc_type)
                 tests_delta[mc_type] = {
                     'passed_hashes_delta': passed_delta}
-                    msg = _make_twitter_msg(
+                msg = _make_twitter_msg(
                     self.model_name, 'passed_tests', passed_delta, mc_type)
                 if msg:
                     logger.info(msg)
@@ -780,6 +780,49 @@ def _make_twitter_msg(model_name, msg_type, delta, mc_type=None):
         raise TypeError(f'Invalid message type: {msg_type}.')
     return msg
 
-                if self.config.get('twitter'):
-                    twitter_cred = get_credentials(self.config['twitter'])
-                    update_status(msg, twitter_cred)
+
+def tweet_deltas(model_name, test_corpora, date, twitter_key):
+    model_stats, _ = get_model_stats(model_name, 'model', date=date)
+    test_stats_by_corpus = {}
+    for test_corpus in test_corpora:
+        test_stats, _ = get_model_stats(model_name, 'test', tests=test_corpus,
+                                        date=date)
+        if not test_stats:
+            logger.info(f'Could not find test stats for {test_corpus}')
+        test_stats_by_corpus[test_corpus] = test_stats
+    if not model_stats or not test_stats_by_corpus:
+        logger.warning('Stats are not found, not tweeting')
+        return
+    twitter_cred = get_credentials(twitter_key)
+    if not twitter_cred:
+        logger.warning('Twitter credentials are not found, not tweeting')
+    # Model message
+    stmts_delta = model_stats['model_delta']['statements_hashes_delta']
+    stmts_msg = _make_twitter_msg(model_name, 'stmts', stmts_delta)
+    if stmts_msg:
+        logger.info(stmts_msg)
+        if twitter_cred:
+            update_status(stmts_msg, twitter_cred)
+
+    # Tests messages
+    for test_corpus, test_stats in test_stats_by_corpus.items():
+        for k, v in test_stats['tests_delta'].items():
+            if k == 'applied_hashes_delta':
+                applied_delta = v
+                applied_msg = _make_twitter_msg(model_name, 'applied_tests',
+                                                applied_delta)
+                if applied_msg:
+                    logger.info(applied_msg)
+                    if twitter_cred:
+                        update_status(applied_msg, twitter_cred)
+            else:
+                mc_type = k
+                passed_delta = v['passed_hashes_delta']
+                passed_msg = _make_twitter_msg(
+                    model_name, 'passed_tests', passed_delta, mc_type)
+                if passed_msg:
+                    logger.info(passed_msg)
+                    if twitter_cred:
+                        update_status(passed_msg, twitter_cred)
+
+    logger.info('Done tweeting')

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -597,7 +597,7 @@ class TestStatsGenerator(StatsGenerator):
     def make_tests_delta(self):
         """Add tests delta between two latest test rounds to json_stats."""
         logger.info(f'Generating tests delta for {self.model_name}.')
-        config = load_config_from_s3(model_name)
+        config = load_config_from_s3(self.model_name)
         human_readable_name = config['human_readable_name']
         if not self.previous_round:
             tests_delta = {

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from emmaa.model_tests import load_model_manager_from_s3
 from emmaa.db import get_db
 from emmaa.util import make_date_str, find_latest_s3_file, EmailHtmlBody, \
-    EMMAA_BUCKET_NAME
+    EMMAA_BUCKET_NAME, FORMATTED_TYPE_NAMES
 from emmaa.subscription.email_util import generate_unsubscribe_link
 
 
@@ -13,10 +13,7 @@ logger = logging.getLogger(__name__)
 
 model_manager_cache = {}
 
-FORMATTED_TYPE_NAMES = {'pysb': 'PySB',
-                        'pybel': 'PyBEL',
-                        'signed_graph': 'Signed Graph',
-                        'unsigned_graph': 'Unsigned Graph'}
+
 email_html = EmailHtmlBody()
 
 

--- a/emmaa/aws_lambda_functions/after_update.py
+++ b/emmaa/aws_lambda_functions/after_update.py
@@ -11,6 +11,7 @@ in this directory.
 
 import boto3
 import json
+from datetime import datetime
 
 
 batch = boto3.client('batch')
@@ -18,7 +19,7 @@ JOB_DEF = 'emmaa_jobdef'
 QUEUE = 'emmaa-models-update-test'
 PROJECT = 'aske'
 BRANCH = 'origin/master'
-now_str = datetime.now().strftime('%Y%m%d')
+now_str = datetime.utcnow().strftime('%Y%m%d_%H%M%S')
 
 
 def submit_batch_job(script_command, purpose, job_name, wait_for=None):
@@ -103,7 +104,7 @@ def lambda_handler(event, context):
             tests = [tests]
 
         # For each test run the test and test stats
-        for test in tests:
+        for test_corpus in tests:
             test_command = (' python scripts/run_model_tests_from_s3.py'
                             f' --model {model_name} --tests {test_corpus}')
             test_id = submit_batch_job(

--- a/emmaa/tests/test_stats.py
+++ b/emmaa/tests/test_stats.py
@@ -95,7 +95,6 @@ def test_model_stats_generator():
     sg = ModelStatsGenerator('test', latest_round=latest_round,
                              previous_round=previous_round,
                              previous_json_stats=previous_model_stats)
-    sg.config = {'human_readable_name': 'test'}
     sg.make_stats()
     assert sg.json_stats
     model_summary = sg.json_stats['model_summary']
@@ -122,7 +121,6 @@ def test_test_stats_generator():
     sg = TestStatsGenerator('test', latest_round=latest_round,
                             previous_round=previous_round,
                             previous_json_stats=previous_test_stats)
-    sg.config = {'human_readable_name': 'test'}
     sg.make_stats()
     assert sg.json_stats
     test_round_summary = sg.json_stats['test_round_summary']

--- a/emmaa/tests/test_stats.py
+++ b/emmaa/tests/test_stats.py
@@ -166,17 +166,17 @@ def test_twitter_msg():
     # New applied tests message
     msg = _make_twitter_msg('test', 'applied_tests', {'added': [1234, 2345]},
                             '2020-01-01', test_corpus='simple_tests',
-                            test_name='Simple Tests')
-    assert msg == ('Today I applied 2 new tests in the Simple Tests test '
-                   'corpus. See https://emmaa.indra.bio/dashboard/test?'
+                            test_name='Simple tests corpus')
+    assert msg == ('Today I applied 2 new tests in the Simple tests corpus. '
+                   'See https://emmaa.indra.bio/dashboard/test?'
                    'tab=tests&test_corpus=simple_tests&date=2020-01-01 '
                    'for more details.'), msg
     # New passed tests message
     msg = _make_twitter_msg('test', 'passed_tests', {'added': [1234, 2345]},
                             '2020-01-01', 'pysb', test_corpus='simple_tests',
-                            test_name='Simple Tests')
-    assert msg == ('Today I explained 2 new observations in the Simple Tests '
-                   'test corpus with my PySB model. See '
+                            test_name='Simple tests corpus')
+    assert msg == ('Today I explained 2 new observations in the Simple tests '
+                   'corpus with my PySB model. See '
                    'https://emmaa.indra.bio/dashboard/test?tab=tests'
                    '&test_corpus=simple_tests&date=2020-01-01 '
                    'for more details.'), msg

--- a/emmaa/tests/test_stats.py
+++ b/emmaa/tests/test_stats.py
@@ -95,6 +95,7 @@ def test_model_stats_generator():
     sg = ModelStatsGenerator('test', latest_round=latest_round,
                              previous_round=previous_round,
                              previous_json_stats=previous_model_stats)
+    sg.config = {'human_readable_name': 'test'}
     sg.make_stats()
     assert sg.json_stats
     model_summary = sg.json_stats['model_summary']
@@ -121,6 +122,7 @@ def test_test_stats_generator():
     sg = TestStatsGenerator('test', latest_round=latest_round,
                             previous_round=previous_round,
                             previous_json_stats=previous_test_stats)
+    sg.config = {'human_readable_name': 'test'}
     sg.make_stats()
     assert sg.json_stats
     test_round_summary = sg.json_stats['test_round_summary']

--- a/emmaa/tests/test_stats.py
+++ b/emmaa/tests/test_stats.py
@@ -165,15 +165,17 @@ def test_twitter_msg():
                    '2020-01-01 for more details.'), msg
     # New applied tests message
     msg = _make_twitter_msg('test', 'applied_tests', {'added': [1234, 2345]},
-                            '2020-01-01', test_corpus='simple_tests')
-    assert msg == ('Today I applied 2 new tests in simple_tests test corpus. '
-                   'See https://emmaa.indra.bio/dashboard/test?tab=tests'
-                   '&test_corpus=simple_tests&date=2020-01-01 '
+                            '2020-01-01', test_corpus='simple_tests',
+                            test_name='Simple Tests')
+    assert msg == ('Today I applied 2 new tests in the Simple Tests test '
+                   'corpus. See https://emmaa.indra.bio/dashboard/test?'
+                   'tab=tests&test_corpus=simple_tests&date=2020-01-01 '
                    'for more details.'), msg
     # New passed tests message
     msg = _make_twitter_msg('test', 'passed_tests', {'added': [1234, 2345]},
-                            '2020-01-01', 'pysb', test_corpus='simple_tests')
-    assert msg == ('Today I explained 2 new observations in simple_tests '
+                            '2020-01-01', 'pysb', test_corpus='simple_tests',
+                            test_name='Simple Tests')
+    assert msg == ('Today I explained 2 new observations in the Simple Tests '
                    'test corpus with my PySB model. See '
                    'https://emmaa.indra.bio/dashboard/test?tab=tests'
                    '&test_corpus=simple_tests&date=2020-01-01 '

--- a/emmaa/tests/test_stats.py
+++ b/emmaa/tests/test_stats.py
@@ -3,7 +3,7 @@ import json
 from indra.statements import Activation, ActivityCondition, Phosphorylation, \
     Agent, Evidence
 from emmaa.analyze_tests_results import ModelRound, TestRound, \
-    ModelStatsGenerator, TestStatsGenerator
+    ModelStatsGenerator, TestStatsGenerator, _make_twitter_msg
 
 
 TestRound.__test__ = False
@@ -151,3 +151,30 @@ def test_test_stats_generator():
     assert changes['signed_graph']['passed_ratio'] == [1, 1]
     assert changes['unsigned_graph']['number_passed_tests'] == [1, 2]
     assert changes['unsigned_graph']['passed_ratio'] == [1, 1]
+
+
+def test_twitter_msg():
+    # No message when no delta
+    msg = _make_twitter_msg('test', 'stmts', {'added': []}, '2020-01-01')
+    assert not msg
+    # New statements message
+    msg = _make_twitter_msg('test', 'stmts', {'added': [1234, 2345]},
+                            '2020-01-01')
+    assert msg == ('Today I learned 2 new mechanisms. See '
+                   'https://emmaa.indra.bio/dashboard/test?tab=model&date='
+                   '2020-01-01 for more details.'), msg
+    # New applied tests message
+    msg = _make_twitter_msg('test', 'applied_tests', {'added': [1234, 2345]},
+                            '2020-01-01', test_corpus='simple_tests')
+    assert msg == ('Today I applied 2 new tests in simple_tests test corpus. '
+                   'See https://emmaa.indra.bio/dashboard/test?tab=tests'
+                   '&test_corpus=simple_tests&date=2020-01-01 '
+                   'for more details.'), msg
+    # New passed tests message
+    msg = _make_twitter_msg('test', 'passed_tests', {'added': [1234, 2345]},
+                            '2020-01-01', 'pysb', test_corpus='simple_tests')
+    assert msg == ('Today I explained 2 new observations in simple_tests '
+                   'test corpus with my PySB model. See '
+                   'https://emmaa.indra.bio/dashboard/test?tab=tests'
+                   '&test_corpus=simple_tests&date=2020-01-01 '
+                   'for more details.'), msg

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -382,6 +382,18 @@ class NotAClassName(Exception):
     pass
 
 
+def get_credentials(key):
+    client = boto3.client('ssm')
+    auth_dict = {}
+    for par in ['consumer_token', 'consumer_secret', 'access_token',
+                'access_secret']:
+        name = f'/twitter/{key}/{par}'
+        response = client.get_parameter(Name=name, WithDecryption=True)
+        val = response['Parameter']['Value']
+        auth_dict[par] = val
+    return auth_dict
+
+
 def get_oauth_dict(auth_dict):
     oauth = tweepy.OAuthHandler(auth_dict.get('consumer_token'),
                                 auth_dict.get('consumer_secret'))

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -5,6 +5,7 @@ import logging
 import json
 import pickle
 import zlib
+import tweepy
 from flask import Flask
 from pathlib import Path
 from datetime import datetime, timedelta
@@ -373,3 +374,19 @@ class EmailHtmlBody(object):
 
 class NotAClassName(Exception):
     pass
+
+
+def get_oauth_dict(auth_dict):
+    oauth = tweepy.OAuthHandler(auth_dict.get('consumer_token'),
+                                auth_dict.get('consumer_secret'))
+    oauth.set_access_token(auth_dict.get('access_token'),
+                           auth_dict.get('access_secret'))
+    return oauth
+
+
+def update_status(msg, twitter_cred):
+    twitter_auth = get_oauth_dict(twitter_cred)
+    if twitter_auth is None:
+        return
+    twitter_api = tweepy.API(twitter_auth)
+    twitter_api.update_status(msg)

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -25,6 +25,12 @@ EMMAA_BUCKET_NAME = 'emmaa'
 logger = logging.getLogger(__name__)
 
 
+FORMATTED_TYPE_NAMES = {'pysb': 'PySB',
+                        'pybel': 'PyBEL',
+                        'signed_graph': 'Signed Graph',
+                        'unsigned_graph': 'Unsigned Graph'}
+
+
 def strip_out_date(keystring, date_format='datetime'):
     """Strips out datestring of selected date_format from a keystring"""
     if date_format == 'datetime':

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -388,9 +388,13 @@ def get_credentials(key):
     for par in ['consumer_token', 'consumer_secret', 'access_token',
                 'access_secret']:
         name = f'/twitter/{key}/{par}'
-        response = client.get_parameter(Name=name, WithDecryption=True)
-        val = response['Parameter']['Value']
-        auth_dict[par] = val
+        try:
+            response = client.get_parameter(Name=name, WithDecryption=True)
+            val = response['Parameter']['Value']
+            auth_dict[par] = val
+        except Exception as e:
+            print(e)
+            break
     return auth_dict
 
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -20,12 +20,11 @@ from indra_db.client.principal.curation import get_curations, submit_curation
 
 from emmaa.util import find_latest_s3_file, strip_out_date, does_exist, \
     EMMAA_BUCKET_NAME, list_s3_files, find_index_of_s3_file, \
-    find_number_of_files_on_s3, load_json_from_s3
+    find_number_of_files_on_s3, load_json_from_s3, FORMATTED_TYPE_NAMES
 from emmaa.model import load_config_from_s3, last_updated_date, \
     get_model_stats, _default_test, get_assembled_statements
 from emmaa.model_tests import load_tests_from_s3
-from emmaa.answer_queries import QueryManager, load_model_manager_from_cache, \
-    FORMATTED_TYPE_NAMES
+from emmaa.answer_queries import QueryManager, load_model_manager_from_cache
 from emmaa.subscription.email_util import verify_email_signature,\
     register_email_unsubscribe, get_email_subscriptions
 from emmaa.queries import PathProperty, get_agent_from_text, GroundingError, \

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -540,8 +540,8 @@ def get_model_dashboard(model):
     test_data = test_stats['test_round_summary'].get('test_data')
     test_info_contents = None
     if test_data:
-        test_info_contents = [[('', k.capitalize(), ''), ('', v, '')]
-                              for k, v in test_data.items()]
+        test_info_contents = [[('', ' '.join(k.split('_')).capitalize(), ''),
+                               ('', v, '')] for k, v in test_data.items()]
     current_model_types = [mt for mt in ALL_MODEL_TYPES if mt in
                            test_stats['test_round_summary']]
     # Get correct and incorrect curation hashes to pass it per stmt

--- a/scripts/tweet_deltas.py
+++ b/scripts/tweet_deltas.py
@@ -1,0 +1,16 @@
+import argparse
+from emmaa.analyze_tests_results import tweet_deltas
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Script to tweet about model and test deltas.')
+    parser.add_argument('-m', '--model', help='Model name', required=True)
+    parser.add_argument('-tc', '--test_corpora', nargs='+',
+                        help='List of test corpora names', required=True)
+    parser.add_argument('-d', '--date', help='Date in format YYYY-mm-dd',
+                        required=True)
+    args = parser.parse_args()
+
+    tweet_deltas(model_name=args.model, test_corpora=args.test_corpora,
+                 date=args.date)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(name='emmaa',
       packages=find_packages(),
       install_requires=['indra', 'boto3', 'jsonpickle', 'kappy==4.0.0rc1',
                         'pygraphviz', 'fnvhash', 'sqlalchemy', 'inflection',
-                        'pybel', 'flask_jwt_extended', 'gilda'],
+                        'pybel', 'flask_jwt_extended', 'gilda', 'tweepy'],
       extras_require={'test': ['nose', 'coverage', 'moto[iam]']}
       )


### PR DESCRIPTION
This PR enables tweeting of EMMAA model updates. There are currently three possible tweet messages: about number of new statements, number of new applied tests, and number of new passed tests (per specific model type). The tweet message  is going to be logged in model stats and test stats logs for all models if there's delta detected. To switch on the tweeting for a model, 'twitter' parameter has to be added to the config. Credentials should be stored as SSM parameters. Some code from Indra twitter_client.py was moved to this PR. 