### PR TITLE
Load assembled statements for evidence browsing

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -656,10 +656,10 @@ def get_assembled_statements(model, bucket=EMMAA_BUCKET_NAME):
         bucket, f'assembled/{model}/statements_', '.json')
     if not latest_file_key:
         logger.info(f'No assembled statements found for {model}.')
-        return
+        return None, None
     stmt_jsons = load_json_from_s3(bucket, latest_file_key)
     stmts = stmts_from_json(stmt_jsons)
-    return stmts
+    return stmts, latest_file_key
 
 
 @register_pipeline

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -657,6 +657,7 @@ def get_assembled_statements(model, bucket=EMMAA_BUCKET_NAME):
     if not latest_file_key:
         logger.info(f'No assembled statements found for {model}.')
         return None, None
+    logger.info(f'Loading assembled statements for {model} from S3.')
     stmt_jsons = load_json_from_s3(bucket, latest_file_key)
     stmts = stmts_from_json(stmt_jsons)
     return stmts, latest_file_key

--- a/emmaa/tests/test_s3.py
+++ b/emmaa/tests/test_s3.py
@@ -198,7 +198,7 @@ def test_get_assembled_stmts():
     # Local imports are recommended when using moto
     from emmaa.model import get_assembled_statements
     client = setup_bucket(add_mm=True)
-    stmts = get_assembled_statements('test', bucket=TEST_BUCKET_NAME)
+    stmts, fkey = get_assembled_statements('test', bucket=TEST_BUCKET_NAME)
     assert len(stmts) == 2
     assert all([isinstance(stmt, Activation) for stmt in stmts])
 

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -253,9 +253,13 @@ def _get_flask_app():
 
 def load_pickle_from_s3(bucket, key):
     client = get_s3_client()
-    obj = client.get_object(Bucket=bucket, Key=key)
-    content = pickle.loads(obj['Body'].read())
-    return content
+    try:
+        obj = client.get_object(Bucket=bucket, Key=key)
+        content = pickle.loads(obj['Body'].read())
+        return content
+    except Exception as e:
+        logger.info('Could not load the pickle from s3')
+        logger.info(e)
 
 
 def save_pickle_to_s3(obj, bucket, key):

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -141,6 +141,8 @@ def _load_tests_from_cache(test_corpus):
         if isinstance(tests, dict):
             tests = tests['tests']
         tests_cache[test_corpus] = (tests, file_key)
+    else:
+        logger.info(f'Loaded {test_corpus} from cache.')
     return tests
 
 
@@ -151,6 +153,8 @@ def _load_stmts_from_cache(model):
     if file_key != latest_on_s3:
         stmts, file_key = get_assembled_statements(model, EMMAA_BUCKET_NAME)
         stmts_cache[model] = (stmts, file_key)
+    else:
+        logger.info(f'Loaded assembled stmts for {model} from cache.')
     return stmts
 
 


### PR DESCRIPTION
This PR replaces loading the model manager pickles with loading assembled stmts jsons when displaying statement evidence on model page and all statements page. These files are smaller and faster to load.