### PR TITLE
Show knowledge sources

### DIFF
--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -159,6 +159,15 @@ class ModelRound(Round):
                 self.get_english_statement(stmt))
         return stmts_by_hash
 
+    def get_sources_distribution(self):
+        logger.info('Finding distribution of sources of statement evidences.')
+        sources_count = defaultdict(int)
+        for stmt in self.statements:
+            for evid in stmt.evidence:
+                if evid.source_api:
+                    sources_count[evid.source_api] += 1
+        return sorted(sources_count.items(), key=lambda x: x[1], reverse=True)
+
 
 class TestRound(Round):
     """Analyzes the results of one test round.
@@ -426,6 +435,7 @@ class ModelStatsGenerator(StatsGenerator):
             'stmts_type_distr': self.latest_round.get_statement_types(),
             'agent_distr': self.latest_round.get_agent_distribution(),
             'stmts_by_evidence': self.latest_round.get_statements_by_evidence(),
+            'sources': self.latest_round.get_sources_distribution(),
             'all_stmts': self.latest_round.get_english_statements_by_hash()
         }
 

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -331,24 +331,25 @@ function populateTestResultTable(tableBody, model_json, test_json) {
 
   let agentChart = generateBar(agDist, agentDataParams, top_agents_array, '');
 
-  // Source APIs bar graph
-  let sources_array = [];
-  let source_freq_array = ['Evidence count']
+  if (model_json.model_summary.sources) {
+    // Source APIs bar graph
+    let sources_array = [];
+    let source_freq_array = ['Evidence count']
 
-  for (let pair of model_json.model_summary.sources) {
-    sources_array.push(pair[0]);
-    source_freq_array.push(pair[1]);
+    for (let pair of model_json.model_summary.sources) {
+      sources_array.push(pair[0]);
+      source_freq_array.push(pair[1]);
+    }
+
+    let sourceDataParams = {
+      columns: [
+        source_freq_array
+      ],
+      type: 'bar'
+    };
+
+    let sourceChart = generateBar(sources, sourceDataParams, sources_array, '');
   }
-
-  let sourceDataParams = {
-    columns: [
-      source_freq_array
-    ],
-    type: 'bar'
-  };
-
-  let sourceChart = generateBar(sources, sourceDataParams, sources_array, '');
-
   // Statements over Time line graph
   let stmtsOverTime = model_json.changes_over_time.number_of_statements;
   stmtsOverTime.unshift('Statements');

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -275,6 +275,7 @@ function populateTestResultTable(tableBody, model_json, test_json) {
   let pasAppId = '#passedApplied';
   let agDist = '#agentDistr';
   let stmtTime = '#stmtsOverTime';
+  let sources = '#sourceDistr';
 
   // Dates
   model_dates = model_json.changes_over_time.dates;
@@ -295,7 +296,7 @@ function populateTestResultTable(tableBody, model_json, test_json) {
 
   // Stmt type distribution bar graph 
   let stmt_type_array = [];
-  let stmt_freq_array = ['count'];
+  let stmt_freq_array = ['Statements count'];
 
   for (let pair of model_json.model_summary.stmts_type_distr) {
     stmt_type_array.push(pair[0]);
@@ -314,7 +315,7 @@ function populateTestResultTable(tableBody, model_json, test_json) {
 
   // Top agents bar graph
   let top_agents_array = [];
-  let agent_freq_array = ['count'];
+  let agent_freq_array = ['Agent count'];
 
   for (let pair of model_json.model_summary.agent_distr.slice(0, 10)) {
     top_agents_array.push(pair[0]);
@@ -329,6 +330,24 @@ function populateTestResultTable(tableBody, model_json, test_json) {
   };
 
   let agentChart = generateBar(agDist, agentDataParams, top_agents_array, '');
+
+  // Source APIs bar graph
+  let sources_array = [];
+  let source_freq_array = ['Evidence count']
+
+  for (let pair of model_json.model_summary.sources) {
+    sources_array.push(pair[0]);
+    source_freq_array.push(pair[1]);
+  }
+
+  let sourceDataParams = {
+    columns: [
+      source_freq_array
+    ],
+    type: 'bar'
+  };
+
+  let sourceChart = generateBar(sources, sourceDataParams, sources_array, '');
 
   // Statements over Time line graph
   let stmtsOverTime = model_json.changes_over_time.number_of_statements;
@@ -406,6 +425,7 @@ function populateTestResultTable(tableBody, model_json, test_json) {
   $('a[data-toggle=tab]').on('shown.bs.tab', function() { // This will trigger when tab is clicked
     stmtTypeChart.flush();
     agentChart.flush();
+    sourceChart.flush();
     stmtsCountChart.flush();
     lineChart.flush();
     areaChart.flush();

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -89,6 +89,7 @@
           <div class="container" id="agentDistr"></div>
         </div>
       </div>
+      {% if 'sources' in model_stats_json['model_summary'] %}
       <div class="card">
         <div class="card-header">
           <h4 class="my-0 font-weight-normal">Knowledge Sources</h4>
@@ -97,6 +98,7 @@
           <div class="container" id="sourceDistr"></div>
         </div>
       </div>
+      {% endif %}
       {{ path_card(stmts_counts, "Most Supported Statements", "stmtEvidenceTable", ["Statement", "Evidence Count"], "stmtEvidence", show_all=True) }}
       <div class="card">
         <div class="card-header">

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -89,6 +89,14 @@
           <div class="container" id="agentDistr"></div>
         </div>
       </div>
+      <div class="card">
+        <div class="card-header">
+          <h4 class="my-0 font-weight-normal">Knowledge Sources</h4>
+        </div>
+        <div class="card-body">
+          <div class="container" id="sourceDistr"></div>
+        </div>
+      </div>
       {{ path_card(stmts_counts, "Most Supported Statements", "stmtEvidenceTable", ["Statement", "Evidence Count"], "stmtEvidence", show_all=True) }}
       <div class="card">
         <div class="card-header">


### PR DESCRIPTION
This PR adds the bar chart displaying the distribution of evidence counts in model statements by knowledge source. The counts are stored in stats model summary. New statistics will be displayed after daily stats jobs are run, but the service can be updated any time (front end is backward compatible).