### PR TITLE
Save load stmts

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -651,9 +651,32 @@ def get_model_stats(model, mode, tests=None, date=None,
             latest_file_key)
 
 
-def get_assembled_statements(model, bucket=EMMAA_BUCKET_NAME):
+def get_assembled_statements(model, date=None, bucket=EMMAA_BUCKET_NAME):
+    """Load and return a list of assembled statements.
+
+    Parameters
+    ----------
+    model : str
+        A name of a model.
+    date : str or None
+        Date in "YYYY-MM-DD" format for which to load the statements. If None,
+        loads the latest available statements.
+    bucket : str
+        Name of S3 bucket to look for a file. Defaults to 'emmaa'.
+
+    Returns
+    -------
+    stmts : list[indra.statements.Statement]
+        A list of assembled statements.
+    latest_file_key : str
+        Key of a file with statements on s3.
+    """
+    if not date:
+        prefix = f'assembled/{model}/statements_'
+    else:
+        prefix = f'assembled/{model}/statements_{date}'
     latest_file_key = find_latest_s3_file(
-        bucket, f'assembled/{model}/statements_', '.json')
+        bucket, prefix, '.json')
     if not latest_file_key:
         logger.info(f'No assembled statements found for {model}.')
         return None, None

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -675,8 +675,7 @@ def get_assembled_statements(model, date=None, bucket=EMMAA_BUCKET_NAME):
         prefix = f'assembled/{model}/statements_'
     else:
         prefix = f'assembled/{model}/statements_{date}'
-    latest_file_key = find_latest_s3_file(
-        bucket, prefix, '.json')
+    latest_file_key = find_latest_s3_file(bucket, prefix, '.json')
     if not latest_file_key:
         logger.info(f'No assembled statements found for {model}.')
         return None, None

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -22,7 +22,7 @@ from emmaa.model import EmmaaModel
 from emmaa.queries import PathProperty, DynamicProperty
 from emmaa.util import make_date_str, get_s3_client, get_class_from_name, \
     EMMAA_BUCKET_NAME, find_latest_s3_file, load_pickle_from_s3, \
-    save_pickle_to_s3, load_json_from_s3, save_json_to_s3
+    save_pickle_to_s3, load_json_from_s3, save_json_to_s3, strip_out_date
 
 
 logger = logging.getLogger(__name__)
@@ -200,6 +200,7 @@ class ModelManager(object):
 
     def _make_path_stmts(self, stmts, merge=False):
         sentences = []
+        date = strip_out_date(self.date_str, 'date')
         if merge:
             groups = group_and_sort_statements(stmts)
             for group in groups:
@@ -229,7 +230,7 @@ class ModelManager(object):
                 stmt_hashes = [gr_st.get_hash() for gr_st in group_stmts]
                 url_param = parse.urlencode(
                     {'stmt_hash': stmt_hashes, 'source': 'model_statement',
-                     'model': self.model.name}, doseq=True)
+                     'model': self.model.name, 'date': date}, doseq=True)
                 link = f'/evidence?{url_param}'
                 sentences.append((link, sentence, ''))
         else:
@@ -243,7 +244,7 @@ class ModelManager(object):
                     stmt_hashes = [stmt.get_hash()]
                     url_param = parse.urlencode(
                         {'stmt_hash': stmt_hashes, 'source': 'model_statement',
-                         'model': self.model.name}, doseq=True)
+                         'model': self.model.name, 'date': date}, doseq=True)
                     link = f'/evidence?{url_param}'
                     sentences.append((link, sentence, ''))
         return sentences

--- a/emmaa/priors/cancer_prior.py
+++ b/emmaa/priors/cancer_prior.py
@@ -201,7 +201,7 @@ class TcgaCancerPrior(object):
     @staticmethod
     def find_drugs_for_genes(node_list):
         """Return list of drugs targeting gene nodes."""
-        tas_statements = tas.process_csv().statements
+        tas_statements = tas.process_from_web().statements
         already_added = set()
         drug_terms = []
         for node in node_list:

--- a/emmaa/priors/gene_list_prior.py
+++ b/emmaa/priors/gene_list_prior.py
@@ -27,9 +27,10 @@ class GeneListPrior(object):
         self.stmts = []
         self.search_terms = []
 
-    def make_search_terms(self):
+    def make_search_terms(self, drug_gene_stmts=None):
         """Generate search terms from the gene list."""
-        tas_stmts = tas.process_csv().statements
+        if not drug_gene_stmts:
+            drug_gene_stmts = tas.process_from_web().statements
         already_added = set()
         terms = []
         for gene in self.gene_list:
@@ -42,7 +43,7 @@ class GeneListPrior(object):
             terms.append(term)
 
             # Drug search term
-            drug_terms = get_drugs_for_gene(tas_stmts,
+            drug_terms = get_drugs_for_gene(drug_gene_stmts,
                                             agent.db_refs['HGNC'])
             for drug_term in drug_terms:
                 if drug_term.name not in already_added:

--- a/emmaa/priors/reactome_prior.py
+++ b/emmaa/priors/reactome_prior.py
@@ -78,7 +78,7 @@ def make_prior_from_genes(gene_list):
     return sorted(gene_terms, key=lambda x: x.name)
 
 
-def find_drugs_for_genes(search_terms):
+def find_drugs_for_genes(search_terms, drug_gene_stmts=None):
     """Return list of drugs targeting at least one gene from a list of genes
 
     Parameters
@@ -91,13 +91,14 @@ def find_drugs_for_genes(search_terms):
     drug_terms : list of :py:class:`emmaa.priors.SearchTerm`
         List of search terms of drugs targeting at least one of the input genes
     """
-    tas_statements = tas.process_csv().statements
+    if not drug_gene_stmts:
+        drug_gene_stmts = tas.process_from_web().statements
     drug_terms = []
     already_added = set()
     for search_term in search_terms:
         if search_term.type == 'gene':
             hgnc_id = search_term.db_refs['HGNC']
-            drugs = get_drugs_for_gene(tas_statements, hgnc_id)
+            drugs = get_drugs_for_gene(drug_gene_stmts, hgnc_id)
             for drug in drugs:
                 if drug.name not in already_added:
                     drug_terms.append(drug)

--- a/emmaa/readers/aws_reader.py
+++ b/emmaa/readers/aws_reader.py
@@ -2,7 +2,8 @@ import datetime
 from indra.sources import reach
 from indra.literature.s3_client import get_reader_json_str, get_full_text
 from indra_reading.scripts.submit_reading_pipeline import \
-    submit_reading, BatchMonitor
+    submit_reading
+from indra_reading.batch.monitor import BatchMonitor
 from emmaa.statements import EmmaaStatement
 
 

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -24,11 +24,13 @@ test_response = {
         'edge_list': [
             {'edge': 'BRAF → MAP2K1',
              'stmts': [
-                 ['/evidence?stmt_hash=-23078353002754841&source=model_statement&model=test',
+                 ['/evidence?stmt_hash=-23078353002754841&source='
+                  'model_statement&model=test&date=2020-01-01',
                   'BRAF activates MAP2K1.', '']]},
             {'edge': 'MAP2K1 → MAPK1',
              'stmts': [
-                 ['/evidence?stmt_hash=-34603994586320440&source=model_statement&model=test',
+                 ['/evidence?stmt_hash=-34603994586320440&source='
+                  'model_statement&model=test&date=2020-01-01',
                   'Active MAP2K1 activates MAPK1.', '']]}]}}
 query_not_appl = {'2413475507': 'Query is not applicable for this model'}
 fail_response = {'521653329': 'No path found that satisfies the test statement'}
@@ -36,6 +38,7 @@ fail_response = {'521653329': 'No path found that satisfies the test statement'}
 # on S3 version
 test_model = create_model()
 test_mm = ModelManager(test_model)
+test_mm.date_str = '2020-01-01-00-00-00'
 test_email = 'tester@test.com'
 
 

--- a/emmaa/tests/test_gene_list_prior.py
+++ b/emmaa/tests/test_gene_list_prior.py
@@ -1,14 +1,19 @@
 from emmaa.priors import SearchTerm
 from emmaa.priors.gene_list_prior import GeneListPrior
 
+from indra.statements import Inhibition, Agent
+
 
 def test_get_search_terms():
     gp = GeneListPrior(['BRAF'], 'braf', 'BRAF model')
     assert gp.name == 'braf'
     assert gp.human_readable_name == 'BRAF model'
-    st = gp.make_search_terms()
+    st = gp.make_search_terms(
+        [Inhibition(Agent('vemurafenib', db_refs={'CHEBI': 'CHEBI:63637'}),
+                    Agent('BRAF', db_refs={'HGNC': '1097', 'UP': 'P15056'}))])
     assert st
     assert all([isinstance(s, SearchTerm) for s in st])
     assert st[0].type == 'gene'
     assert st[0].search_term == '"BRAF"'
     assert st[1].type == 'drug'
+    assert st[1].search_term == '"vemurafenib"', st[1].search_term

--- a/emmaa/tests/test_lambda.py
+++ b/emmaa/tests/test_lambda.py
@@ -1,7 +1,7 @@
 import boto3
 import pickle
 import unittest
-from indra_reading.scripts.submit_reading_pipeline import BatchMonitor
+from indra_reading.batch.monitor import BatchMonitor
 
 from emmaa.aws_lambda_functions.model_tests import lambda_handler, QUEUE
 from emmaa.util import make_date_str, get_s3_client

--- a/emmaa/tests/test_reactome_prior.py
+++ b/emmaa/tests/test_reactome_prior.py
@@ -6,6 +6,7 @@ from emmaa.priors.reactome_prior import find_drugs_for_genes
 from emmaa.priors.reactome_prior import make_prior_from_genes
 from emmaa.priors.reactome_prior import get_pathways_containing_gene
 from emmaa.priors.reactome_prior import get_genes_contained_in_pathway
+from indra.statements import Inhibition, Agent
 
 
 def test_rx_id_from_up_id():
@@ -72,7 +73,12 @@ def test_find_drugs_for_genes():
     SRC = SearchTerm(type='gene', name='SRC', search_term='"SRC"',
                      db_refs={'HGNC': '11283'})
     # drugs targeting KRAS
-    drug_terms = find_drugs_for_genes([SRC])
+    drug_terms = find_drugs_for_genes(
+        [SRC],
+        [Inhibition(Agent('Dasatinib', db_refs={'CHEBI': 'CHEBI:49375'}),
+                    Agent('SRC', db_refs={'HGNC': '11283'})),
+         Inhibition(Agent('Ponatinib', db_refs={'CHEBI': 'CHEBI:78543'}),
+                    Agent('SRC', db_refs={'HGNC': '11283'}))])
 
     # make sure there are results
     assert drug_terms
@@ -80,10 +86,6 @@ def test_find_drugs_for_genes():
     # make sure the result is a list of search terms
     assert all(isinstance(term, SearchTerm) for term in drug_terms)
 
-    # something is wrong if there are fewer than 10 drugs
-    assert len(drug_terms) > 10
-
     # test that some example drugs are included
     drug_names = set(term.name for term in drug_terms)
-    example_drugs = set(['Dasatinib', 'Tozasertib', 'Ponatinib'])
-    assert example_drugs <= drug_names
+    assert drug_names == set(['Dasatinib', 'Ponatinib'])

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -268,7 +268,7 @@ def _format_table_array(tests_json, model_types, model_name, date, test_corpus):
     for th, test in tests_json:
         ev_url_par = parse.urlencode(
             {'stmt_hash': th, 'source': 'test', 'model': model_name,
-             'test_corpus': test_corpus})
+             'test_corpus': test_corpus, 'date': date})
         test['test'][0] = f'/evidence?{ev_url_par}'
         test['test'][2] = stmt_db_link_msg
         new_row = [(test['test'])]
@@ -335,7 +335,7 @@ def _new_passed_tests(model_name, test_stats_json, current_model_types, date,
             test = all_test_results[th]
             ev_url_par = parse.urlencode(
                 {'stmt_hash': th, 'source': 'test', 'model': model_name,
-                 'test_corpus': test_corpus})
+                 'test_corpus': test_corpus, 'date': date})
             test['test'][0] = f'/evidence?{ev_url_par}'
             test['test'][2] = stmt_db_link_msg
             path_loc = test[mt][1]
@@ -405,7 +405,7 @@ def _count_curations(curations, stmts_by_hash):
     return cur_counts
 
 
-def _get_stmt_row(stmt, source, model, cur_counts, test_corpus=None,
+def _get_stmt_row(stmt, source, model, cur_counts, date, test_corpus=None,
                   path_counts=None, cur_dict=None, with_evid=False):
     stmt_hash = str(stmt.get_hash())
     english = _format_stmt_text(stmt)
@@ -415,7 +415,7 @@ def _get_stmt_row(stmt, source, model, cur_counts, test_corpus=None,
         evid = _format_evidence_text(
             stmt, cur_dict, ['correct', 'act_vs_amt', 'hypothesis'])[:10]
     params = {'stmt_hash': stmt_hash, 'source': source, 'model': model,
-              'format': 'json'}
+              'format': 'json', 'date': date}
     if test_corpus:
         params.update({'test_corpus': test_corpus})
     url_param = parse.urlencode(params)
@@ -540,7 +540,8 @@ def get_model_dashboard(model):
     all_stmts = model_stats['model_summary']['all_stmts']
     for st_hash, st_value in all_stmts.items():
         url_param = parse.urlencode(
-            {'stmt_hash': st_hash, 'source': 'model_statement', 'model': model})
+            {'stmt_hash': st_hash, 'source': 'model_statement', 'model': model,
+             'date': date})
         st_value[0] = f'/evidence?{url_param}'
         st_value[2] = stmt_db_link_msg
         cur = _set_curation(st_hash, correct, incorrect)
@@ -762,7 +763,7 @@ def get_statement_evidence_page():
                 {'error_type': cur.tag})
         cur_counts = _count_curations(curations, stmts_by_hash)
         for stmt in stmts:
-            stmt_row = _get_stmt_row(stmt, source, model, cur_counts,
+            stmt_row = _get_stmt_row(stmt, source, model, cur_counts, date,
                                      test_corpus, stmt_counts_dict,
                                      cur_dict, True)
             stmt_rows.append(stmt_row)
@@ -776,7 +777,8 @@ def get_statement_evidence_page():
                            test_corpus=test_corpus if test_corpus else None,
                            table_title='Statement Evidence and Curation',
                            msg=None,
-                           is_all_stmts=False)
+                           is_all_stmts=False,
+                           date=date)
 
 
 @app.route('/all_statements/<model>')
@@ -830,7 +832,7 @@ def get_all_statements_page(model):
     stmt_rows = []
     for stmt in stmts:
         stmt_row = _get_stmt_row(stmt, 'model_statement', model, cur_counts,
-                                 None, stmt_counts_dict)
+                                 date, None, stmt_counts_dict)
         stmt_rows.append(stmt_row)
     table_title = f'All statements in {model.upper()} model.'
 
@@ -855,7 +857,8 @@ def get_all_statements_page(model):
                            next=next_page,
                            filter_curated=filter_curated,
                            sort_by=sort_by,
-                           link=link)
+                           link=link,
+                           date=date)
 
 
 @app.route('/query/<model>')

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -162,10 +162,6 @@ function redirectSelection(ddSelect, param) {
   redirectOneArgument(newValue, param);
 }
 
-function redirectToAllStmts() {
-  let model = window.location.pathname.split('/')[2]
-  window.open(`/all_statements/${model}?sort_by=evidence&page=1&filter_curated=false`, target="_blank")
-}
 
 function clearTables(arrayOfTableBodies) {
   for (let tableBody of arrayOfTableBodies) {

--- a/emmaa_service/static/emmaaFunctions.js
+++ b/emmaa_service/static/emmaaFunctions.js
@@ -327,6 +327,7 @@ function populateTestResultTable(tableBody, model_json, test_json) {
 
   let agentChart = generateBar(agDist, agentDataParams, top_agents_array, '');
 
+  var sourceChart = NaN;
   if (model_json.model_summary.sources) {
     // Source APIs bar graph
     let sources_array = [];
@@ -344,7 +345,7 @@ function populateTestResultTable(tableBody, model_json, test_json) {
       type: 'bar'
     };
 
-    let sourceChart = generateBar(sources, sourceDataParams, sources_array, '');
+    var sourceChart = generateBar(sources, sourceDataParams, sources_array, '');
   }
   // Statements over Time line graph
   let stmtsOverTime = model_json.changes_over_time.number_of_statements;

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -77,7 +77,7 @@
 {% endif %}
 <div class="container" id="app">
   {% if source == 'model_statement' %}
-  {% set url = url_for('get_statement_by_hash_model', model=model, hash_val='') %}
+  {% set url = url_for('get_statement_by_hash_model', model=model, hash_val='', date=date) %}
   {% else %}
   {% set url = url_for('get_tests_by_hash', test_corpus=test_corpus, hash_val='') %}
   {% endif %}

--- a/emmaa_service/templates/model_template.html
+++ b/emmaa_service/templates/model_template.html
@@ -99,7 +99,8 @@
         </div>
       </div>
       {% endif %}
-      {{ path_card(stmts_counts, "Most Supported Statements", "stmtEvidenceTable", ["Statement", "Evidence Count"], "stmtEvidence", show_all=True) }}
+      {% set show_all = url_for('get_all_statements_page', model=model, sort_by='evidence', page=1, filter_curated=false, date=date) %}
+      {{ path_card(stmts_counts, "Most Supported Statements", "stmtEvidenceTable", ["Statement", "Evidence Count"], "stmtEvidence", show_all=show_all) }}
       <div class="card">
         <div class="card-header">
           <h4 class="my-0 font-weight-normal">Number of Statements over Time</h4>


### PR DESCRIPTION
This PR introduces several changes:
-`get_assembled_statements` function is parameterized to take `date` argument to allow loading statements for different date
- Evidence page and all statements page URLs also include date parameter which determines which state of the model to load
- This allows browsing evidences for statements that were removed from the model
- Assembled statements are saved in two formats: JSON and JSONL
- To fix some failing tests, the code requiring loading statements from TAS was also updated here (in gene_list_prior, reactome_prior and cancer_prior and corresponding tests)

This PR should be merged together with https://github.com/indralab/ui_util/pull/10
