### PR TITLE
Fixing ModelManager pickling

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -679,7 +679,7 @@ def get_assembled_statements(model, date=None, bucket=EMMAA_BUCKET_NAME):
     if not latest_file_key:
         logger.info(f'No assembled statements found for {model}.')
         return None, None
-    logger.info(f'Loading assembled statements for {model} from S3.')
+    logger.info(f'Loading assembled statements for {model} from {latest_file_key}.')
     stmt_jsons = load_json_from_s3(bucket, latest_file_key)
     stmts = stmts_from_json(stmt_jsons)
     return stmts, latest_file_key

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -20,7 +20,8 @@ from emmaa.readers.elsevier_eidos_reader import \
     read_elsevier_eidos_search_terms
 from emmaa.util import make_date_str, find_latest_s3_file, strip_out_date, \
     EMMAA_BUCKET_NAME, find_nth_latest_s3_file, load_pickle_from_s3, \
-    save_pickle_to_s3, load_json_from_s3, save_json_to_s3
+    save_pickle_to_s3, load_json_from_s3, save_json_to_s3, \
+    load_zip_json_from_s3
 from emmaa.statements import to_emmaa_stmts
 
 
@@ -675,12 +676,19 @@ def get_assembled_statements(model, date=None, bucket=EMMAA_BUCKET_NAME):
         prefix = f'assembled/{model}/statements_'
     else:
         prefix = f'assembled/{model}/statements_{date}'
-    latest_file_key = find_latest_s3_file(bucket, prefix, '.json')
-    if not latest_file_key:
-        logger.info(f'No assembled statements found for {model}.')
-        return None, None
-    logger.info(f'Loading assembled statements for {model} from {latest_file_key}.')
-    stmt_jsons = load_json_from_s3(bucket, latest_file_key)
+    # Try loading zip file
+    latest_file_key = find_latest_s3_file(bucket, prefix, '.zip')
+    if latest_file_key:
+        stmt_jsons = load_zip_json_from_s3(bucket, latest_file_key)
+    else:
+        # Try loading json file
+        latest_file_key = find_latest_s3_file(bucket, prefix, '.json')
+        if latest_file_key:
+            stmt_jsons = load_json_from_s3(bucket, latest_file_key)
+        # Didn't get zip or json
+        else:
+            logger.info(f'No assembled statements found for {model}.')
+            return None, None
     stmts = stmts_from_json(stmt_jsons)
     return stmts, latest_file_key
 

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -3,6 +3,7 @@ import logging
 import itertools
 import jsonpickle
 import os
+import pickle
 import sys
 from collections import defaultdict
 from fnvhash import fnv1a_32
@@ -602,8 +603,13 @@ def save_model_manager_to_s3(model_name, model_manager,
                              bucket=EMMAA_BUCKET_NAME):
     logger.info(f'Saving a model manager for {model_name} model to S3.')
     date_str = model_manager.date_str
-    save_pickle_to_s3(model_manager, bucket,
-                      f'results/{model_name}/model_manager_{date_str}.pkl')
+    logger.info('Pickling a model manager')
+    with open('mm.pkl', 'wb') as fh:
+        pickle.dump(model_manager, fh)
+    logger.info('Uploading a model manager')
+    client = get_s3_client(unsigned=False)
+    client.upload_file(
+        'mm.pkl', bucket, f'results/{model_name}/model_manager_{date_str}.pkl')
 
 
 def load_model_manager_from_s3(model_name=None, key=None,

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -603,13 +603,8 @@ def save_model_manager_to_s3(model_name, model_manager,
                              bucket=EMMAA_BUCKET_NAME):
     logger.info(f'Saving a model manager for {model_name} model to S3.')
     date_str = model_manager.date_str
-    logger.info('Pickling a model manager')
-    with open('mm.pkl', 'wb') as fh:
-        pickle.dump(model_manager, fh, protocol=pickle.HIGHEST_PROTOCOL)
-    logger.info('Uploading a model manager')
-    client = get_s3_client(unsigned=False)
-    client.upload_file(
-        'mm.pkl', bucket, f'results/{model_name}/model_manager_{date_str}.pkl')
+    save_pickle_to_s3(model_manager, bucket,
+                      f'results/{model_name}/model_manager_{date_str}.pkl')
 
 
 def load_model_manager_from_s3(model_name=None, key=None,

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -603,6 +603,7 @@ def save_model_manager_to_s3(model_name, model_manager,
                              bucket=EMMAA_BUCKET_NAME):
     logger.info(f'Saving a model manager for {model_name} model to S3.')
     date_str = model_manager.date_str
+    model_manager.model.stmts = None
     save_pickle_to_s3(model_manager, bucket,
                       f'results/{model_name}/model_manager_{date_str}.pkl')
 

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from fnvhash import fnv1a_32
 from urllib import parse
 from copy import deepcopy
+from zipfile import ZipFile
 from indra.explanation.model_checker import PysbModelChecker, \
     PybelModelChecker, SignedGraphModelChecker, UnsignedGraphModelChecker
 from indra.explanation.reporting import stmts_from_pysb_path, \
@@ -451,12 +452,18 @@ class ModelManager(object):
         dated_key = f'assembled/{self.model.name}/statements_{self.date_str}'
         latest_key = f'assembled/{self.model.name}/' \
                      f'latest_statements_{self.model.name}'
-        for key in (dated_key, latest_key):
-            for ext in ('.json', '.jsonl'):
-                fname = 'assembled_stmts' + ext
-                obj_key = key + ext
-                logger.info(f'Uploading assembled statements to {obj_key}')
-                client.upload_file(fname, bucket, obj_key)
+        for ext in ('.json', '.jsonl'):
+            fname = 'assembled_stmts' + ext
+            obj_key = latest_key + ext
+            logger.info(f'Uploading assembled statements to {obj_key}')
+            client.upload_file(fname, bucket, obj_key)
+        with ZipFile('assembled_stmts.zip', mode='w') as zipf:
+            zipf.write('assembled_stmts.json')
+        logger.info(f'Uploading assembled statements to {dated_key}.zip')
+        client.upload_file('assembled_stmts.zip', bucket, f'{dated_key}.zip')
+        logger.info(f'Uploading assembled statements to {dated_key}.jsonl')
+        client.upload_file(
+            'assembled_stmts.jsonl', bucket, f'{dated_key}.jsonl')
 
 
 class TestManager(object):

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -605,7 +605,7 @@ def save_model_manager_to_s3(model_name, model_manager,
     date_str = model_manager.date_str
     logger.info('Pickling a model manager')
     with open('mm.pkl', 'wb') as fh:
-        pickle.dump(model_manager, fh)
+        pickle.dump(model_manager, fh, protocol=pickle.HIGHEST_PROTOCOL)
     logger.info('Uploading a model manager')
     client = get_s3_client(unsigned=False)
     client.upload_file(

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -618,7 +618,8 @@ def load_model_manager_from_s3(model_name=None, key=None,
             if not model_manager.model.assembled_stmts:
                 stmts, _ = get_assembled_statements(
                     model_manager.model.name,
-                    strip_out_date(model_manager.date_str, 'date'))
+                    strip_out_date(model_manager.date_str, 'date'),
+                    bucket=bucket)
                 model_manager.model.assembled_stmts = stmts
             return model_manager
         except Exception as e:

--- a/emmaa/tests/test_s3.py
+++ b/emmaa/tests/test_s3.py
@@ -71,8 +71,8 @@ def setup_bucket(
             emmaa_model = create_model()
         mm = ModelManager(emmaa_model)
         mm.date_str = date_str
-        save_model_manager_to_s3('test', mm, bucket=TEST_BUCKET_NAME)
         mm.save_assembled_statements(bucket=TEST_BUCKET_NAME)
+        save_model_manager_to_s3('test', mm, bucket=TEST_BUCKET_NAME)
     if add_tests:
         tests = [StatementCheckingTest(
             Activation(Agent('BRAF'), Agent('MAPK1')))]
@@ -199,7 +199,7 @@ def test_get_assembled_stmts():
     from emmaa.model import get_assembled_statements
     client = setup_bucket(add_mm=True)
     stmts, fkey = get_assembled_statements('test', bucket=TEST_BUCKET_NAME)
-    assert len(stmts) == 2
+    assert len(stmts) == 2, stmts
     assert all([isinstance(stmt, Activation) for stmt in stmts])
 
 

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -258,7 +258,7 @@ def load_pickle_from_s3(bucket, key):
         content = pickle.loads(obj['Body'].read())
         return content
     except Exception as e:
-        logger.info('Could not load the pickle from s3')
+        logger.info(f'Could not load the pickle from {key}')
         logger.info(e)
 
 

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -264,7 +264,10 @@ def load_pickle_from_s3(bucket, key):
 
 def save_pickle_to_s3(obj, bucket, key):
     client = get_s3_client(unsigned=False)
-    client.put_object(Body=pickle.dumps(obj), Bucket=bucket, Key=key)
+    logger.info('Pickling object')
+    obj_str = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
+    logger.info(f'Saving object to {key}')
+    client.put_object(Body=obj_str, Bucket=bucket, Key=key)
 
 
 def load_json_from_s3(bucket, key):


### PR DESCRIPTION
This PR fixes a problem with pickling large models by removing both raw and assembled statements from ModelManager object before pickling and upgrading the pickle protocol to highest available.