### PR TITLE
Save paths and fix issues

### DIFF
--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -242,12 +242,12 @@ class QueryManager(object):
         # Make text report
         str_report = self.make_str_report_per_user(results,
                                                    include_no_diff=False)
-        str_report = '\n'.join(str_report[:10]) if str_report else None
+        str_report = '\n'.join(str_report) if str_report else None
 
         # Make html report
         html_report = self.make_html_report_per_user(results, user_email,
                                                      domain=domain,
-                                                     limit=10)
+                                                     limit=None)
         html_report = html_report if html_report else None
 
         if html_report:

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -141,9 +141,12 @@ class ModelManager(object):
 
     def make_path_json(self, mc_type, result_paths):
         paths = []
+        json_lines = []
         for path in result_paths:
             path_nodes = []
             edge_list = []
+            path_node_list = []
+            hashes = []
             report_function = self.mc_mapping[mc_type][2]
             model = self.mc_types[mc_type]['model']
             stmts = self.model.assembled_stmts
@@ -170,9 +173,13 @@ class ModelManager(object):
                     edge_nodes.append(source.name)
                     edge_nodes.append(u"\u2192")
                     edge_nodes.append(target.name)
+                    hashes.append(['not a statement'])
                 else:
+                    step_hashes = []
                     for stmt in step:
                         self.path_stmt_counts[stmt.get_hash()] += 1
+                        step_hashes.append(stmt.get_hash())
+                    hashes.append(step_hashes)
                     agents = [ag.name if ag is not None else None
                               for ag in step[0].agent_list()]
                     # For complexes make sure that the agent from the
@@ -193,17 +200,23 @@ class ModelManager(object):
                 if i == 0:
                     for n in edge_nodes:
                         path_nodes.append(n)
+                    path_node_list.append(edge_nodes[0])
+                    path_node_list.append(edge_nodes[-1])
                 else:
                     for n in edge_nodes[1:]:
                         path_nodes.append(n)
+                    path_node_list.append(edge_nodes[-1])
                 step_sentences = self._make_path_stmts(step, merge=merge)
                 edge_dict = {'edge': ' '.join(edge_nodes),
                              'stmts': step_sentences}
                 edge_list.append(edge_dict)
             path_json = {'path': ' '.join(path_nodes),
                          'edge_list': edge_list}
+            one_line_path_json = {'nodes': path_node_list, 'edges': hashes,
+                                  'graph_type': mc_type}
             paths.append(path_json)
-        return paths
+            json_lines.append(one_line_path_json)
+        return paths, json_lines
 
     def _make_path_stmts(self, stmts, merge=False):
         sentences = []

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -575,13 +575,15 @@ class ModelManager(object):
             obj_key = latest_key + ext
             logger.info(f'Uploading assembled statements to {obj_key}')
             client.upload_file(fname, bucket, obj_key)
+        logger.info(f'Uploading assembled statements to {dated_key}.jsonl')
+        client.upload_file(
+            'assembled_stmts.jsonl', bucket, f'{dated_key}.jsonl')
+        os.remove('assembled_stmts.jsonl')
         with ZipFile('assembled_stmts.zip', mode='w') as zipf:
             zipf.write('assembled_stmts.json')
         logger.info(f'Uploading assembled statements to {dated_key}.zip')
         client.upload_file('assembled_stmts.zip', bucket, f'{dated_key}.zip')
-        logger.info(f'Uploading assembled statements to {dated_key}.jsonl')
-        client.upload_file(
-            'assembled_stmts.jsonl', bucket, f'{dated_key}.jsonl')
+        os.remove('assembled_stmts.json')
 
 
 class TestManager(object):

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -433,7 +433,8 @@ class ModelManager(object):
         if applicable_open_queries:
             for mc_type in self.mc_types:
                 max_path_length, max_paths = self._get_test_configs(
-                    mode='query', mc_type=mc_type, default_paths=5)
+                    mode='query', mc_type=mc_type, default_paths=50,
+                    default_length=2)
                 mc = self.get_updated_mc(mc_type, applicable_open_stmts, True)
                 for query in applicable_open_queries:
                     res = self.open_query_per_mc(

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -557,10 +557,13 @@ class ModelManager(object):
                       f'{test_corpus}_{self.date_str}.json')
         paths_key = (f'paths/{self.model.name}/paths_{test_corpus}_'
                      f'{self.date_str}.jsonl')
+        latest_paths_key = (f'paths/{self.model.name}/{test_corpus}'
+                            '_latest_paths.jsonl')
         logger.info(f'Uploading test results to {result_key}')
         save_json_to_s3(json_dict, bucket, result_key)
         logger.info(f'Uploading test paths to {paths_key}')
         save_json_to_s3(json_lines, bucket, paths_key, save_format='jsonl')
+        save_json_to_s3(json_lines, bucket, latest_paths_key, 'jsonl')
 
     def save_assembled_statements(self, bucket=EMMAA_BUCKET_NAME):
         """Upload assembled statements jsons to S3 bucket."""

--- a/emmaa/readers/db_client_reader.py
+++ b/emmaa/readers/db_client_reader.py
@@ -1,7 +1,7 @@
 import datetime
 from indra_db.client.principal.raw_statements import \
     get_raw_stmt_jsons_from_papers
-from indra_db.util import get_primary_db
+from indra_db.util import get_db
 from indra.statements import stmts_from_json
 from emmaa.statements import EmmaaStatement
 
@@ -23,7 +23,7 @@ def read_db_ids_search_terms(id_search_terms, id_type):
     """
     ids = list(id_search_terms.keys())
     date = datetime.datetime.utcnow()
-    db = get_primary_db()
+    db = get_db('primary')
     id_stmts = get_raw_stmt_jsons_from_papers(ids, id_type=id_type, db=db)
     estmts = []
     for _id, stmt_jsons in id_stmts.items():

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -331,7 +331,7 @@ class EmailHtmlBody(object):
         html
             An html string rendered from the associated jinja2 template
         """
-        if not static_query_deltas and open_query_deltas and \
+        if not static_query_deltas and not open_query_deltas and \
                 not dynamic_query_deltas:
             raise ValueError('No query deltas provided')
         # Todo consider generating unsubscribe link here, will probably have

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -4,6 +4,7 @@ import boto3
 import logging
 import json
 import pickle
+import zlib
 from flask import Flask
 from pathlib import Path
 from datetime import datetime, timedelta
@@ -13,6 +14,7 @@ from inflection import camelize
 from zipfile import ZipFile
 from indra.util.aws import get_s3_file_tree, get_date_from_str
 from indra.statements import get_all_descendants
+from indra.literature.s3_client import gzip_string
 from emmaa.subscription.email_service import email_bucket
 
 FORMAT = '%Y-%m-%d-%H-%M-%S'
@@ -282,21 +284,43 @@ def load_json_from_s3(bucket, key):
 
 def save_json_to_s3(obj, bucket, key, save_format='json'):
     client = get_s3_client(unsigned=False)
-    if save_format == 'json':
-        json_str = json.dumps(obj, indent=1).encode('utf8')
-    elif save_format == 'jsonl':
-        json_str = '\n'.join([json.dumps(item) for item in obj]).encode('utf8')
-    client.put_object(Body=json_str,
+    json_str = _get_json_str(obj, save_format=save_format)
+    client.put_object(Body=json_str.encode('utf8'),
                       Bucket=bucket, Key=key)
 
 
 def load_zip_json_from_s3(bucket, key):
     client = get_s3_client()
-    logger.info(f'Loading zipfile from {key}')
-    client.download_file(bucket, key, 'temp.zip')
-    with ZipFile('temp.zip', 'r') as zipf:
-        content = json.loads(zipf.read(zipf.namelist()[0]))
+    # Newer files are zipped with gzip while older with zipfile
+    try:
+        logger.info(f'Loading zipped object from {key}')
+        gz_obj = client.get_object(Bucket=bucket, Key=key)
+        content = json.loads(zlib.decompress(
+            gz_obj['Body'].read(), 16+zlib.MAX_WBITS).decode('utf8'))
+    except Exception as e:
+        logger.info(e)
+        logger.info('Could not load with gzip, using zipfile')
+        logger.info(f'Loading zipfile from {key}')
+        client.download_file(bucket, key, 'temp.zip')
+        with ZipFile('temp.zip', 'r') as zipf:
+            content = json.loads(zipf.read(zipf.namelist()[0]))
     return content
+
+
+def save_zip_json_to_s3(obj, bucket, key, save_format='json'):
+    client = get_s3_client(unsigned=False)
+    json_str = _get_json_str(obj, save_format=save_format)
+    gz_str = gzip_string(json_str, f'assembled_stmts.{save_format}')
+    client.put_object(Body=gz_str, Bucket=bucket, Key=key)
+
+
+def _get_json_str(json_obj, save_format='json'):
+    if save_format == 'json':
+        json_str = json.dumps(json_obj, indent=1)
+    elif save_format == 'jsonl':
+        json_str = '\n'.join(
+            [json.dumps(item) for item in json_obj])
+    return json_str
 
 
 class EmailHtmlBody(object):

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -280,9 +280,13 @@ def load_json_from_s3(bucket, key):
     return content
 
 
-def save_json_to_s3(obj, bucket, key):
+def save_json_to_s3(obj, bucket, key, save_format='json'):
     client = get_s3_client(unsigned=False)
-    client.put_object(Body=json.dumps(obj, indent=1).encode('utf8'),
+    if save_format == 'json':
+        json_str = json.dumps(obj, indent=1).encode('utf8')
+    elif save_format == 'jsonl':
+        json_str = '\n'.join([json.dumps(item) for item in obj]).encode('utf8')
+    client.put_object(Body=json_str,
                       Bucket=bucket, Key=key)
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,5 @@ setup(name='emmaa',
       install_requires=['indra', 'boto3', 'jsonpickle', 'kappy==4.0.0rc1',
                         'pygraphviz', 'fnvhash', 'sqlalchemy', 'inflection',
                         'pybel', 'flask_jwt_extended', 'gilda'],
-      extras_require={'test': ['nose', 'coverage', 'moto']}
+      extras_require={'test': ['nose', 'coverage', 'moto[iam]']}
       )


### PR DESCRIPTION
This PR adds the following changes:
- Saving paths information in JSONL format at each test run
- Fixing a few email notification and query configuration bugs
- Changing the way assembled statements are zipped/saved/loaded in the manner that doesn't require writing to disc