### PR TITLE
Query delta

### DIFF
--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -288,10 +288,6 @@ class QueryManager(object):
                 return mm
         return load_model_manager_from_cache(model_name)
 
-    def _recreate_db(self):
-        self.db.drop_tables(force=True)
-        self.db.create_tables()
-
 
 def _detailed_page_link(domain, model_name, model_type, query_hash):
     # example:

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -303,24 +303,6 @@ class QueryManager(object):
         self.db.create_tables()
 
 
-def is_query_result_diff(new_result_json, all_result_hashes):
-    """Return True if there is a delta between results."""
-    # NOTE: this function is query-type specific so it may need to be
-    # refactored as a method of the Query class:
-
-    # Return True if this is the first result
-    if not old_result_json:
-        return True
-    # Check if there're new paths
-    return len(get_query_result_diff(new_result_json, all_result_hashes)) > 0
-
-
-def get_query_result_diff(new_result_json, all_result_hashes):
-    """Compare two result jsons and return a set of hashes of new paths."""
-    new_result_hashes = [k for k in new_result_json.keys()]
-    return set(new_result_hashes) - set(all_result_hashes)
-
-
 def _detailed_page_link(domain, model_name, model_type, query_hash):
     # example:
     # https://emmaa.indra.bio/query/aml/?model_type=pysb&query_hash

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -68,8 +68,8 @@ class QueryManager(object):
                 self.db.put_results(model_name, results_to_store)
         return {query_type: query_hashes}
 
-    def answer_registered_queries(self, model_name, find_delta=True,
-                                  use_kappa=False, bucket=EMMAA_BUCKET_NAME):
+    def answer_registered_queries(self, model_name, use_kappa=False,
+                                  bucket=EMMAA_BUCKET_NAME):
         """Retrieve and asnwer registered queries
 
         Retrieve queries registered on database for a given model,
@@ -80,10 +80,6 @@ class QueryManager(object):
         ----------
         model_name : str
             The name of the model
-        find_delta : bool
-            If True, also generate a report for the logs on what the delta
-            is for the new results compared to the previous results.
-            Default: True
         use_kappa : bool
             If True, use kappa modeling when answering the dynamic query
         bucket : str
@@ -98,14 +94,6 @@ class QueryManager(object):
                 queries, use_kappa=use_kappa, bucket=bucket)
             new_results = [(model_name, result[0], result[1], result[2], '')
                            for result in results]
-            # Optionally find delta between results
-            # NOTE: For now the report is presented in the logs. In future we
-            # can choose some other ways to keep track of result changes.
-            if find_delta:
-                reports = self.make_reports_from_results(new_results, False,
-                                                         'str')
-                for report in reports:
-                    logger.info(report)
             self.db.put_results(model_name, results)
 
     def get_registered_queries(self, user_email, query_type='path_property'):
@@ -118,13 +106,7 @@ class QueryManager(object):
         """Retrieve results from a db given a list of query-model hashes."""
         results = self.db.get_results_from_hashes(
             query_hashes, latest_order=latest_order)
-        try:
-            old_results = self.db.get_results_from_hashes(
-                query_hashes, latest_order=latest_order+1)
-        except IndexError:
-            old_results = None
-        diff = get_all_diff(results, old_results)
-        return format_results(results, diff, query_type)
+        return format_results(results, query_type)
 
     def make_reports_from_results(self, new_results, domain='emmaa.indra.bio'):
         """Make a report given latest results and queries the results are for.

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -390,4 +390,4 @@ def answer_queries_from_s3(model_name, db=None, bucket=EMMAA_BUCKET_NAME):
     """
     mm = load_model_manager_from_s3(model_name=model_name, bucket=bucket)
     qm = QueryManager(db=db, model_managers=[mm])
-    qm.answer_registered_queries(model_name, find_delta=True)
+    qm.answer_registered_queries(model_name)

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -111,7 +111,7 @@ class QueryManager(object):
     def get_registered_queries(self, user_email, query_type='path_property'):
         """Get formatted results to queries registered by user."""
         results = self.db.get_results(user_email, query_type=query_type)
-        return format_results(results, query_type)
+        return format_results(results, {}, query_type)
 
     def retrieve_results_from_hashes(
             self, query_hashes, query_type='path_property', latest_order=1):
@@ -456,7 +456,7 @@ def format_results(results, diff, query_type='path_property'):
             if isinstance(v, str):
                 response = v
             elif isinstance(v, dict):
-                if k in diff[mc_type]:
+                if diff and k in diff[mc_type]:
                     v['path'] = ('new', v['path'])
                 response.append(v)
         if query_type in ['path_property', 'open_search_query']:

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -371,7 +371,7 @@ class QueryManager(object):
         self.db.create_tables()
 
 
-def is_query_result_diff(new_result_json, old_result_json=None):
+def is_query_result_diff(new_result_json, all_result_hashes):
     """Return True if there is a delta between results."""
     # NOTE: this function is query-type specific so it may need to be
     # refactored as a method of the Query class:
@@ -380,26 +380,13 @@ def is_query_result_diff(new_result_json, old_result_json=None):
     if not old_result_json:
         return True
     # Check if there're new paths
-    return len(get_query_result_diff(new_result_json, old_result_json)) > 0
+    return len(get_query_result_diff(new_result_json, all_result_hashes)) > 0
 
 
-def get_query_result_diff(new_result_json, old_result_json):
+def get_query_result_diff(new_result_json, all_result_hashes):
     """Compare two result jsons and return a set of hashes of new paths."""
-    old_result_hashes = [k for k in old_result_json.keys()]
     new_result_hashes = [k for k in new_result_json.keys()]
-    return set(new_result_hashes) - set(old_result_hashes)
-
-
-def get_all_diff(new_results, old_results=None):
-    """Get new hashes across all model types."""
-    if not old_results:
-        return {}
-    new_results_dict = {res[2]: res[3] for res in new_results}
-    old_results_dict = {res[2]: res[3] for res in old_results}
-    diff_dict = {mc_type: get_query_result_diff(
-        new_results_dict.get(mc_type), old_results_dict.get(mc_type))
-            for mc_type in new_results_dict}
-    return diff_dict
+    return set(new_result_hashes) - set(all_result_hashes)
 
 
 def _detailed_page_link(domain, model_name, model_type, query_hash):

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -211,21 +211,6 @@ class QueryManager(object):
             logger.info(f'No query delta to report for {user_email}')
         return str_report, html_report
 
-    # def get_report_per_query(self, model_name, query, format='str'):
-    #     if format not in {'html', 'str'}:
-    #         logger.error(f'Invalid format ({format}). Must be "str" '
-    #                      f'or "html"')
-    #         return None
-    #     try:
-    #         new_results = self.db.get_results_from_query(
-    #             query, [model_name], latest_order=1)
-    #     except IndexError:
-    #         logger.info('No latest result was found.')
-    #         return None
-    #     if format == 'html':
-    #         return self.make_reports_from_results(new_results, True, 'html')
-    #     return self.make_reports_from_results(new_results, True, 'str')
-
     def make_str_report_per_user(self, static_results_delta,
                                  open_results_delta, dynamic_results_delta):
         """Produce a report for all query results per user as a string.
@@ -305,59 +290,6 @@ class QueryManager(object):
             )
         else:
             return ''
-
-    # def make_str_report_one_query(self, query_str, link, model_name, mc_type,
-    #                               include_no_diff=True):
-    #                                                   query.to_english(),
-
-    #     """Return a string message containing information about a query and any
-    #     change in the results.
-
-    #     Parameters
-    #     ----------
-    #     model_name : str
-    #         Name of model
-    #     query : emmaa.query.Query
-    #         The query object representing the query
-    #     mc_type : str
-    #         The model type
-    #     new_result_json : dict
-    #         The json containing the new results
-    #     old_result_json : dict
-    #         The json the new results are to be compared with
-    #     include_no_diff : bool
-    #         If True, also report results that haven't changed. Default: True.
-
-    #     Returns
-    #     -------
-    #     str
-    #         The string containing the report.
-    #     """
-    #     model_type_name = FORMATTED_TYPE_NAMES[mc_type] if mc_type else mc_type
-
-    #     if is_query_result_diff(new_result_json, old_result_json):
-
-    #         if not old_result_json:
-    #             msg = f'\nThis is the first result to query ' \
-    #                   f'{query.to_english()} in {model_name} with' \
-    #                   f' {model_type_name} model checker.\nThe result is:'
-    #             msg += _process_result_to_str(new_result_json, 'str')
-    #         else:
-    #             msg = f'\nA new result to query {query.to_english()}' \
-    #                   f' in {model_name} was found with {model_type_name}' \
-    #                   f' model checker. '
-    #             msg += '\nPrevious result was:'
-    #             msg += _process_result_to_str(old_result_json, 'str')
-    #             msg += '\nNew result is:'
-    #             msg += _process_result_to_str(new_result_json, 'str')
-    #     elif include_no_diff:
-    #         msg = f'\nA result to query {query.to_english()} in ' \
-    #               f'{model_name} from {model_type_name} model checker ' \
-    #               f'did not change. The result is:'
-    #         msg += _process_result_to_str(new_result_json, 'str')
-    #     else:
-    #         msg = None
-    #     return msg
 
     def get_model_manager(self, model_name):
         # Try get model manager from class attributes or load from s3.
@@ -472,22 +404,6 @@ def load_model_manager_from_cache(model_name, bucket=EMMAA_BUCKET_NAME):
         model_name=model_name, bucket=bucket)
     model_manager_cache[model_name] = model_manager
     return model_manager
-
-
-def _process_result_to_str(result_json, format='str'):
-    msg = '\n' if format == 'str' else '<br>'
-    for v in result_json.values():
-        if isinstance(v, str):
-            msg += v
-        elif isinstance(v, dict):
-            if 'path' in v.keys():
-                msg += v['path']
-                msg += '\n' if format == 'str' else '<br>'
-            else:
-                msg += f'Satisfaction rate: {v["sat_rate"]}, '
-                msg += f'Number of simulations: {v["num_sim"]}, '
-                msg += f'Suggested pattern: {v["kpat"]}.'
-    return msg
 
 
 def answer_queries_from_s3(model_name, db=None, bucket=EMMAA_BUCKET_NAME):

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -403,10 +403,8 @@ def is_query_result_diff(new_result_json, old_result_json=None):
     # Return True if this is the first result
     if not old_result_json:
         return True
-    # Compare hashes of query results
-    old_result_hashes = [k for k in old_result_json.keys()]
-    new_result_hashes = [k for k in new_result_json.keys()]
-    return not set(new_result_hashes) == set(old_result_hashes)
+    # Check if there're new paths
+    return len(get_query_result_diff(new_result_json, old_result_json)) > 0
 
 
 def get_query_result_diff(new_result_json, old_result_json):

--- a/emmaa/answer_queries.py
+++ b/emmaa/answer_queries.py
@@ -135,7 +135,7 @@ class QueryManager(object):
         # If latest results are not in db, retrieve the latest stored
         else:
             order = 1
-        for model_name, query, mc_type, result_json, _, delta in new_results:
+        for model_name, query, mc_type, result_json, delta, _ in new_results:
             if (model_name, query, mc_type) in processed_query_mc:
                 continue
             if delta:
@@ -311,7 +311,7 @@ def _detailed_page_link(domain, model_name, model_type, query_hash):
            f'{model_type}&query_hash={query_hash}&order=1'
 
 
-def format_results(results, diff, query_type='path_property'):
+def format_results(results, query_type='path_property'):
     """Format db output to a standard json structure."""
     model_types = ['pysb', 'pybel', 'signed_graph', 'unsigned_graph']
     formatted_results = {}
@@ -326,12 +326,13 @@ def format_results(results, diff, query_type='path_property'):
                 'date': make_date_str(result[4])}
         mc_type = result[2]
         response_json = result[3]
+        delta = result[4]
         response = []
         for k, v in response_json.items():
             if isinstance(v, str):
                 response = v
             elif isinstance(v, dict):
-                if diff and k in diff[mc_type]:
+                if k in delta:
                     v['path'] = ('new', v['path'])
                 response.append(v)
         if query_type in ['path_property', 'open_search_query']:

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -309,14 +309,17 @@ class EmmaaDatabaseManager(object):
         logger.info(f"Found {len(results)} results.")
         return results
 
-    def get_all_result_hashes(self, qhash, mc_type):
+    def get_all_result_hashes(self, qhash, mc_type, latest_order=1):
         """Get a set of all result hashes for a given query and mc_type."""
         with self.get_session() as sess:
             q = (sess.query(Result.all_result_hashes)
                  .filter(Result.query_hash == qhash,
                          Result.mc_type == mc_type)
-                 .order_by(Result.date.desc()).limit(1))
-        return set([q[0] for q in q.all()][0])
+                 .order_by(Result.date.desc()))
+        all_sets = [q for q in q.all()]
+        if all_sets:
+            return set(all_sets[latest_order - 1][0])
+        return set()
 
     def get_results(self, user_email, latest_order=1, query_type=None):
         """Get the results for which the user has registered.

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -275,9 +275,10 @@ class EmmaaDatabaseManager(object):
         model_id : str
             The short, standard model ID.
         query_results : list of tuples
-            A list of tuples of the form (query, result_json), where
-            the query is the query object run against the model,
-            and the result_json is the json containing corresponding result.
+            A list of tuples of the form (query, mc_type, result_json), where
+            the query is the query object run against the model, mc_type is
+            the model type for the result, and the result_json is the json
+            containing corresponding result.
         """
         results = []
         for query, mc_type, result_json in query_results:
@@ -322,16 +323,16 @@ class EmmaaDatabaseManager(object):
         logger.info(f"Found {len(results)} results.")
         return results
 
-    def get_all_result_hashes(self, qhash, mc_type, latest_order=1):
+    def get_all_result_hashes(self, qhash, mc_type):
         """Get a set of all result hashes for a given query and mc_type."""
         with self.get_session() as sess:
             q = (sess.query(Result.all_result_hashes)
                  .filter(Result.query_hash == qhash,
                          Result.mc_type == mc_type)
-                 .order_by(Result.date.desc()))
+                 .order_by(Result.date.desc()).limit(1))
         all_sets = [q for q in q.all()]
         if all_sets:
-            return set(all_sets[latest_order - 1][0])
+            return set(all_sets[0][0])
         return None
 
     def get_results(self, user_email, latest_order=1, query_type=None):

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -309,7 +309,7 @@ class EmmaaDatabaseManager(object):
                     f"{query_hashes}")
         with self.get_session() as sess:
             q = (sess.query(Query.model_id, Query.json, Result.mc_type,
-                            Result.result_json, Result.date)
+                            Result.result_json, Result.delta, Result.date)
                  .filter(Result.query_hash.in_(query_hashes),
                          Query.hash == Result.query_hash)).distinct()
             results = _make_queries_in_results(q.all())
@@ -347,13 +347,13 @@ class EmmaaDatabaseManager(object):
         -------
         results : list[tuple]
             A list of tuples, each of the form: (model_id, query, mc_type,
-            result_json, date) representing the result of a query run on a
-            model on a given date.
+            result_json, delta, date) representing the result of a query run
+            on a model on a given date.
         """
         logger.info(f"Got request for results for {user_email}")
         with self.get_session() as sess:
             q = (sess.query(Query.model_id, Query.json, Result.mc_type,
-                            Result.result_json, Result.date)
+                            Result.result_json, Result.delta, Result.date)
                  .filter(Query.hash == Result.query_hash,
                          Query.hash == UserQuery.query_hash,
                          UserQuery.user_id == User.id,
@@ -482,7 +482,8 @@ class EmmaaDatabaseManager(object):
 
 
 def _weed_results(result_iter, latest_order=1):
-    # Each element of result_iter: (model_id, query(object), result_json, date)
+    # Each element of result_iter:
+    # (model_id, query(object), result_json, delta, date)
     result_dict = defaultdict(list)
     for res in result_iter:
         result_dict[(res[1].get_hash_with_model(res[0]), res[2])].append(
@@ -494,12 +495,13 @@ def _weed_results(result_iter, latest_order=1):
 
 
 def _make_queries_in_results(result_iter):
-    # Each element of result_iter: (model_id, query_json, result_json, date)
+    # Each element of result_iter:
+    # (model_id, query_json, result_json, delta, date)
     # Replace query_json with Query object
     results = []
     for res in result_iter:
         query = QueryObject._from_json(res[1])
-        results.append((res[0], query, res[2], res[3], res[4]))
+        results.append((res[0], query, res[2], res[3], res[4], res[5]))
     return results
 
 

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -309,6 +309,15 @@ class EmmaaDatabaseManager(object):
         logger.info(f"Found {len(results)} results.")
         return results
 
+    def get_all_result_hashes(self, qhash, mc_type):
+        """Get a set of all result hashes for a given query and mc_type."""
+        with self.get_session() as sess:
+            q = (sess.query(Result.all_result_hashes)
+                 .filter(Result.query_hash == qhash,
+                         Result.mc_type == mc_type)
+                 .order_by(Result.date.desc()).limit(1))
+        return set([q[0] for q in q.all()][0])
+
     def get_results(self, user_email, latest_order=1, query_type=None):
         """Get the results for which the user has registered.
 

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -285,6 +285,10 @@ class EmmaaDatabaseManager(object):
             all_result_hashes = self.get_all_result_hashes(query_hash, mc_type)
             delta = set(result_json.keys()) - all_result_hashes
             new_all_hashes = all_result_hashes.union(delta)
+            if delta:
+                logger.info('New results:')
+                for key in delta:
+                    logger.info(result_json[key])
             results.append(Result(query_hash=query_hash,
                                   mc_type=mc_type,
                                   result_json=result_json,

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -282,9 +282,13 @@ class EmmaaDatabaseManager(object):
         results = []
         for query, mc_type, result_json in query_results:
             query_hash = query.get_hash_with_model(model_id)
+            all_result_hashes = self.get_all_result_hashes(query_hash, mc_type)
+            delta = set(result_json.keys()) - all_result_hashes
+            new_all_hashes = all_result_hashes.union(delta)
             results.append(Result(query_hash=query_hash,
                                   mc_type=mc_type,
-                                  result_json=result_json))
+                                  result_json=result_json,
+                                  all_result_hashes=new_all_hashes))
 
         with self.get_session() as sess:
             sess.add_all(results)

--- a/emmaa/db/schema.py
+++ b/emmaa/db/schema.py
@@ -63,7 +63,7 @@ class User(Base, EmmaaTable):
 
 
 class Query(Base, EmmaaTable):
-    """Queries run on each model: ``Query(_hash_, model_id, json)``
+    """Queries run on each model: ``Query(_hash_, model_id, json, qtype)``
 
     The hash column is a hash generated from the json and model_id columns
     that can be derived from the
@@ -90,7 +90,7 @@ class Query(Base, EmmaaTable):
 class UserQuery(Base, EmmaaTable):
     """A table linking users to queries:
 
-    ``UserQuery(_id_, user_id, query_hash, date, subscription)``
+    ``UserQuery(_id_, user_id, query_hash, date, subscription, count)``
 
     Parameters
     ----------
@@ -123,7 +123,8 @@ class UserQuery(Base, EmmaaTable):
 class Result(Base, EmmaaTable):
     """Results of queries to models:
 
-    ``Result(_id_, query_hash, date, result_json)``
+    ``Result(_id_, query_hash, date, result_json, mc_type, all_result_hashes,
+    delta)``
 
     Parameters
     ----------

--- a/emmaa/db/schema.py
+++ b/emmaa/db/schema.py
@@ -147,3 +147,4 @@ class Result(Base, EmmaaTable):
     result_json = Column(JSONB, nullable=False)
     mc_type = Column(String(20), default='pysb')
     all_result_hashes = Column(ARRAY(String), default=[])
+    delta = Column(ARRAY(String), default=[])

--- a/emmaa/db/schema.py
+++ b/emmaa/db/schema.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, UniqueConstraint, ForeignKey, \
     Boolean, DateTime, func, BigInteger
 from sqlalchemy.orm import relationship
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, ARRAY
 
 
 logger = logging.getLogger(__name__)
@@ -146,3 +146,4 @@ class Result(Base, EmmaaTable):
     date = Column(DateTime, default=func.now())
     result_json = Column(JSONB, nullable=False)
     mc_type = Column(String(20), default='pysb')
+    all_result_hashes = Column(ARRAY(String), default=[])

--- a/emmaa/tests/README.md
+++ b/emmaa/tests/README.md
@@ -35,5 +35,20 @@ Change `peer` or `md5` in the `METHOD` section to be `trust`. This will allow
 you to access the test databases without a password. *Note that you should
 **not** do this when the database could be exposed to the outside or multiple
 users may be using the same machine*. After changing the file, you will need to
-reboot your computer. After this is done, you should be all set to run the
-tests.
+reboot your computer. After this is done, you can try running the tests.
+
+You should not be prompted to enter a password to run the tests. If so, revisit
+the changes made to the `pg_hba.conf` file, and again make sure you rebooted
+after making the changes. You can then test that the database works as expected
+by entering
+
+```bash		
+psql -U postgres		
+```		
+At which point you should see a prompt like this:		
+```		
+psql (10.9 (Ubuntu 10.9-1.pgdg16.04+1), server 9.6.14)		
+Type "help" for help.		
+ postgres=# 		
+ ```		
+Enter `\q` to exit the prompt, and you should be all set to run the tests.

--- a/emmaa/tests/README.md
+++ b/emmaa/tests/README.md
@@ -6,23 +6,14 @@ files and functions.
 
 ## Test Database
 Some tests require access to a database to test the part of the EMMAA framework
-that relies on postgres database storage. To set this database up locally, you
-must first install postgres and then create a database called `emmaadb_test`.
+that relies on postgres database storage. Nosetests fixtures are used to
+create this database and drop it when needed. To enable this on your local
+computer, you must first install postgres.
 
 ### Instructions for Mac
 On Mac, download and install the postgres app:
 https://postgresapp.com/downloads.html, then launch the app, and click
-Initialize. Make sure you open a new terminal and run `createdb emmaadb_test`
-to create the test database. If you get `bash: createdb: command not found`
-error, try running the command using the absolute path:
-
-```bash
-/Applications/Postgres.app/Contents/Versions/latest/bin/createdb emmaadb_test
-```
-
-or export the `$PATH` variable in you `.bash_profile` file and then run 
-`createdb emmaadb_test` in the new terminal.
-After this is done, you should be able to run the tests.
+Initialize. After this is done, you should be able to run the tests.
 
 ### Instructions for Linux
 On Linux, start by installing postgres:
@@ -44,25 +35,5 @@ Change `peer` or `md5` in the `METHOD` section to be `trust`. This will allow
 you to access the test databases without a password. *Note that you should
 **not** do this when the database could be exposed to the outside or multiple
 users may be using the same machine*. After changing the file, you will need to
-reboot your computer.
-
-Once that is done, you can create the test database that EMMAA uses:
-`emmaadb_test` by entering the following command:
-```bash
-sudo -u postgres createdb emmaadb_test
-```
-You should not be prompted to enter a password. If so, revisit the changes made
-to the `pg_hba.conf` file, and again make sure you rebooted after making the
-changes. You can then test that the database works as expected by entering
-```bash
-psql -U postgres
-```
-At which point you should see a prompt like this:
-```
-psql (10.9 (Ubuntu 10.9-1.pgdg16.04+1), server 9.6.14)
-Type "help" for help.
-
-postgres=# 
-
-```
-Enter `\q` to exit the prompt, and you should be all set to run the tests.
+reboot your computer. After this is done, you should be all set to run the
+tests.

--- a/emmaa/tests/db_setup.py
+++ b/emmaa/tests/db_setup.py
@@ -1,0 +1,24 @@
+from sqlalchemy_utils import create_database, drop_database, database_exists
+from emmaa.db import EmmaaDatabaseManager
+
+
+db_url = 'postgresql://postgres:@localhost/emmaadb_test'
+
+
+def _get_test_db(db_name='emmaadb_test'):
+    db = EmmaaDatabaseManager(db_url)
+    return db
+
+
+def setup_function():
+    print('setup')
+    if database_exists(db_url):
+        drop_database(db_url)
+    create_database(db_url)
+    db = _get_test_db()
+    db.create_tables()
+
+
+def teardown_function():
+    print('tear')
+    drop_database(db_url)

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -20,9 +20,9 @@ query_object = Query._from_json(test_query)
 dyn_ag = get_agent_from_trips('active MAP2K1')
 dyn_query = DynamicProperty(dyn_ag, 'eventual_value', 'high')
 open_qj = {'type': 'open_search_query',
-            'entity': {'type': 'Agent', 'name': 'BRAF',
-                       'db_refs': {'HGNC': '1097'}},
-            'entity_role': 'subject', 'stmt_type': 'Activation'}
+           'entity': {'type': 'Agent', 'name': 'BRAF',
+                      'db_refs': {'HGNC': '1097'}},
+           'entity_role': 'subject', 'stmt_type': 'Activation'}
 open_query = Query._from_json(open_qj)
 test_response = {
     '3801854542': {
@@ -54,7 +54,7 @@ def test_format_results():
     results = [('test', query_object, 'pysb', test_response, date),
                ('test', query_object, 'signed_graph', fail_response, date),
                ('test', query_object, 'unsigned_graph', test_response, date)]
-    formatted_results = format_results(results)
+    formatted_results = format_results(results, {})
     assert len(formatted_results) == 1
     qh = query_object.get_hash_with_model('test')
     assert qh in formatted_results

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from nose.plugins.attrib import attr
-from emmaa.answer_queries import QueryManager, format_results
+from emmaa.answer_queries import QueryManager, format_results, \
+    make_reports_from_results, make_str_report_per_user, \
+    make_html_report_per_user
 from emmaa.queries import Query, DynamicProperty, get_agent_from_trips
 from emmaa.model_tests import ModelManager
 from emmaa.tests.test_model import create_model
@@ -210,3 +212,31 @@ def test_user_query_delta():
     assert '</body>' in html_rep
     assert 'pysb' in html_rep
     assert 'unsubscribe' in html_rep
+
+
+def test_make_reports():
+    date = datetime.now()
+    results = [
+        ('test', query_object, 'pysb', test_response, {'3801854542'}, date),
+        ('test', query_object, 'signed_graph', fail_response, {}, date),
+        ('test', query_object, 'unsigned_graph', test_response, {}, date),
+        ('test', open_query, 'pysb', test_response, {'3801854542'}, date),
+        ('test', dyn_query, 'pysb', query_not_appl, {'2413475507'}, date)]
+    static_rep, open_rep, dyn_rep = make_reports_from_results(results)
+    assert static_rep
+    assert open_rep
+    assert dyn_rep
+    str_rep = make_str_report_per_user(static_rep, open_rep, dyn_rep)
+    assert str_rep
+    assert 'Updates to your static queries:' in str_rep
+    assert 'Updates to your open queries:' in str_rep
+    assert 'Updates to your dynamic queries:' in str_rep
+    html_rep = make_html_report_per_user(static_rep, open_rep, dyn_rep,
+                                         test_email)
+    assert html_rep
+    assert ('Updates to your <a href="https://emmaa.indra.bio/query?'
+            'tab=static">static') in html_rep
+    assert ('Updates to your <a href="https://emmaa.indra.bio/query?'
+            'tab=open">open') in html_rep
+    assert ('Updates to your <a href="https://emmaa.indra.bio/query?'
+            'tab=dynamic">dynamic') in html_rep

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -214,6 +214,7 @@ def test_user_query_delta():
     assert 'unsubscribe' in html_rep
 
 
+@attr('nonpublic')
 def test_make_reports():
     date = datetime.now()
     results = [

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -1,8 +1,9 @@
 from os.path import abspath, dirname, join
 from datetime import datetime
+from copy import deepcopy
 from nose.plugins.attrib import attr
 from emmaa.answer_queries import QueryManager, format_results, \
-    is_query_result_diff
+    is_query_result_diff, get_query_result_diff
 from emmaa.queries import Query, DynamicProperty, get_agent_from_trips
 from emmaa.model_tests import ModelManager
 from emmaa.tests.test_db import _get_test_db
@@ -186,6 +187,19 @@ def test_answer_get_registered_queries():
 def test_is_diff():
     assert not is_query_result_diff(query_not_appl, query_not_appl)
     assert is_query_result_diff(test_response, query_not_appl)
+    new_response = deepcopy(test_response)
+    new_response.update(query_not_appl)
+    # Show diff if there are new paths
+    assert is_query_result_diff(new_response, test_response)
+    # Show no diff if path is removed
+    assert not is_query_result_diff(test_response, new_response)
+
+
+def test_get_diff():
+    new_response = deepcopy(test_response)
+    new_response.update(query_not_appl)
+    assert get_query_result_diff(new_response, test_response) == {'2413475507'}
+    assert get_query_result_diff(test_response, new_response) == set()
 
 
 @attr('nonpublic')

--- a/emmaa/tests/test_db.py
+++ b/emmaa/tests/test_db.py
@@ -2,9 +2,12 @@ import time
 import random
 
 from nose.plugins.attrib import attr
+from nose.tools import with_setup
 
-from emmaa.db import Query, Result, EmmaaDatabaseManager
+from emmaa.db import Query, Result
 from emmaa.queries import Query as QueryObject, PathProperty
+from emmaa.tests.db_setup import _get_test_db, setup_function, \
+    teardown_function
 
 
 test_query_jsons = [{'type': 'path_property', 'path': {'type': 'Activation',
@@ -18,13 +21,7 @@ test_query_jsons = [{'type': 'path_property', 'path': {'type': 'Activation',
 test_queries = [QueryObject._from_json(qj) for qj in test_query_jsons]
 
 
-def _get_test_db():
-    db = EmmaaDatabaseManager('postgresql://postgres:@localhost/emmaadb_test')
-    db.drop_tables(force=True)
-    db.create_tables()
-    return db
-
-
+@with_setup(setup_function, teardown_function)
 @attr('nonpublic')
 def test_instantiation():
     db = _get_test_db()
@@ -32,6 +29,7 @@ def test_instantiation():
     return
 
 
+@with_setup(setup_function, teardown_function)
 @attr('nonpublic')
 def test_put_queries():
     db = _get_test_db()
@@ -41,6 +39,7 @@ def test_put_queries():
     assert len(queries) == 2, len(queries)
 
 
+@with_setup(setup_function, teardown_function)
 @attr('nonpublic')
 def test_get_queries():
     db = _get_test_db()
@@ -61,6 +60,7 @@ def _get_random_result():
         [{'12': [['This is fine.', '']]}, {'34': [['This is not ok.', '']]}])
 
 
+@with_setup(setup_function, teardown_function)
 @attr('nonpublic')
 def test_put_results():
     db = _get_test_db()
@@ -74,6 +74,7 @@ def test_put_results():
     assert len(db_results) == len(results)
 
 
+@with_setup(setup_function, teardown_function)
 @attr('nonpublic')
 def test_get_results():
     db = _get_test_db()
@@ -88,7 +89,7 @@ def test_get_results():
 
     # Try to get the results.
     results = db.get_results('joshua')
-    assert len(results) == len(test_queries)*len(models), len(results)
+    assert len(results) == len(test_queries)*len(models)
     assert all(isinstance(result, tuple) for result in results)
     assert all(result[0] in models for result in results)
     assert any(results[0][1].matches(q) for q in test_queries)
@@ -96,6 +97,7 @@ def test_get_results():
     assert all(isinstance(result[3], dict) for result in results)
 
 
+@with_setup(setup_function, teardown_function)
 @attr('nonpublic')
 def test_get_latest_results():
     db = _get_test_db()

--- a/emmaa/tests/test_db.py
+++ b/emmaa/tests/test_db.py
@@ -4,7 +4,7 @@ import random
 from nose.plugins.attrib import attr
 from nose.tools import with_setup
 
-from emmaa.db import Query, Result
+from emmaa.db import Query, Result, User, UserQuery
 from emmaa.queries import Query as QueryObject, PathProperty
 from emmaa.tests.db_setup import _get_test_db, setup_function, \
     teardown_function
@@ -37,6 +37,11 @@ def test_put_queries():
     with db.get_session() as sess:
         queries = sess.query(Query).all()
     assert len(queries) == 2, len(queries)
+    # Not logged in user
+    db.put_queries(None, None, test_queries[1], ['aml'])
+    with db.get_session() as sess:
+        queries = sess.query(Query).all()
+    assert len(queries) == 3, len(queries)
 
 
 @with_setup(setup_function, teardown_function)
@@ -124,3 +129,86 @@ def test_get_latest_results():
     assert any(results[0][1].matches(q) for q in test_queries)
     assert all(isinstance(result[2], str) for result in results)
     assert all(isinstance(result[3], dict) for result in results)
+
+
+@with_setup(setup_function, teardown_function)
+@attr('nonpublic')
+def test_get_subscribed_queries():
+    db = _get_test_db()
+    db.put_queries('test@test.com', 1, test_queries[0], ['aml'], True)
+    db.put_queries('test@test.com', 1, test_queries[1], ['aml'], False)
+    # Only return queries for which subscription is True
+    queries = db.get_subscribed_queries('test@test.com')
+    assert len(queries) == 1
+    assert queries[0][2] == test_queries[0].get_hash_with_model('aml')
+
+
+@with_setup(setup_function, teardown_function)
+@attr('nonpublic')
+def test_get_subscribed_users():
+    db = _get_test_db()
+    db.put_queries('test1@test.com', 1, test_queries[0], ['aml'], True)
+    db.put_queries('test2@test.com', 2, test_queries[1], ['aml'], False)
+    # Only return users that subscribed for something
+    emails = db.get_subscribed_users()
+    assert len(emails) == 1
+    assert emails[0] == 'test1@test.com'
+
+
+@with_setup(setup_function, teardown_function)
+@attr('nonpublic')
+def test_update_email_subscription():
+    db = _get_test_db()
+    db.put_queries('test1@test.com', 1, test_queries[0], ['aml'], True)
+    qh = test_queries[0].get_hash_with_model('aml')
+    with db.get_session() as sess:
+        q = sess.query(UserQuery.subscription).filter(
+            UserQuery.user_id == 1, UserQuery.query_hash == qh)
+    assert [q[0] for q in q.all()][0]  # True
+    db.update_email_subscription('test1@test.com', [qh], False)
+    with db.get_session() as sess:
+        q = sess.query(UserQuery.subscription).filter(
+            UserQuery.user_id == 1,
+            UserQuery.query_hash == test_queries[0].get_hash_with_model('aml'))
+    assert not [q[0] for q in q.all()][0]  # new subscription status is False
+
+
+@with_setup(setup_function, teardown_function)
+@attr('nonpublic')
+def test_get_number_results():
+    db = _get_test_db()
+    db.put_queries('test@test.com', 1, test_queries[0], ['aml'])
+    db.put_results('aml', [(test_queries[0], 'pysb', _get_random_result())])
+    time.sleep(1)
+    db.put_results('aml', [(test_queries[0], 'pysb', _get_random_result())])
+    time.sleep(1)
+    db.put_results('aml', [(test_queries[0], 'pysb', _get_random_result())])
+    qh = test_queries[0].get_hash_with_model('aml')
+    assert db.get_number_of_results(qh, 'pysb') == 3
+
+
+@with_setup(setup_function, teardown_function)
+@attr('nonpublic')
+def test_get_all_result_hashes_and_delta():
+    db = _get_test_db()
+    db.put_queries('test@test.com', 1, test_queries[0], ['aml'])
+    qh = test_queries[0].get_hash_with_model('aml')
+    # If there are no older results, all hashes is None
+    assert db.get_all_result_hashes(qh, 'pysb') is None
+    db.put_results('aml', [(test_queries[0], 'pysb', {'1234': 'result'})])
+    assert db.get_all_result_hashes(qh, 'pysb') == {'1234'}
+    # First result is not delta
+    results = db.get_results_from_hashes([qh])
+    assert results[0][4] == [], results[0]
+    # All hashes keeps growing
+    time.sleep(1)
+    db.put_results('aml', [(test_queries[0], 'pysb', {'345': 'other'})])
+    assert db.get_all_result_hashes(qh, 'pysb') == {'1234', '345'}
+    results = db.get_results_from_hashes([qh])
+    assert results[0][4] == ['345'], results[0]
+    # When we go to previous result, it's not delta
+    time.sleep(1)
+    db.put_results('aml', [(test_queries[0], 'pysb', {'1234': 'result'})])
+    assert db.get_all_result_hashes(qh, 'pysb') == {'1234', '345'}
+    results = db.get_results_from_hashes([qh])
+    assert results[0][4] == [], results[0]

--- a/emmaa/tests/test_s3.py
+++ b/emmaa/tests/test_s3.py
@@ -6,6 +6,7 @@ import re
 import time
 from moto import mock_s3
 from nose.plugins.attrib import attr
+from nose.tools import with_setup
 
 from indra.statements import Activation, Agent
 from emmaa.priors import SearchTerm
@@ -13,10 +14,10 @@ from emmaa.statements import EmmaaStatement
 from emmaa.tests.test_model import create_model
 from emmaa.tests.test_stats import previous_results, new_results, \
     previous_test_stats, previous_model_stats
-from emmaa.tests.test_db import _get_test_db
 from emmaa.tests.test_answer_queries import query_object
 from emmaa.util import make_date_str, RE_DATETIMEFORMAT, RE_DATEFORMAT
-
+from emmaa.tests.db_setup import _get_test_db, setup_function, \
+    teardown_function
 
 TEST_BUCKET_NAME = 'test_bucket'
 
@@ -331,6 +332,7 @@ def test_generate_stats_on_s3():
         TEST_BUCKET_NAME, 'stats/test/test_stats_') == 2
 
 
+@with_setup(setup_function, teardown_function)
 @mock_s3
 def test_answer_queries_from_s3():
     # Local imports are recommended when using moto

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(name='emmaa',
       packages=find_packages(),
       install_requires=['indra', 'boto3', 'jsonpickle', 'kappy==4.0.94',
                         'pygraphviz', 'fnvhash', 'sqlalchemy', 'inflection',
-                        'pybel', 'flask_jwt_extended', 'gilda', 'tweepy'],
+                        'pybel', 'flask_jwt_extended', 'gilda', 'tweepy',
+                        'sqlalchemy_utils'],
       extras_require={'test': ['nose', 'coverage', 'moto[iam]']}
       )

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='emmaa',
       packages=find_packages(),
       install_requires=['indra', 'boto3', 'jsonpickle', 'kappy==4.0.94',
                         'pygraphviz', 'fnvhash', 'sqlalchemy', 'inflection',
-                        'pybel', 'flask_jwt_extended', 'gilda', 'tweepy',
-                        'sqlalchemy_utils'],
-      extras_require={'test': ['nose', 'coverage', 'moto[iam]']}
+                        'pybel', 'flask_jwt_extended', 'gilda', 'tweepy'],
+      extras_require={'test': ['nose', 'coverage', 'moto[iam]',
+                               'sqlalchemy_utils']}
       )


### PR DESCRIPTION
This PR updates query delta related code. Major changes:
- Removing old unused code, simplifying, refactoring, cleaning, updating code in `answer_queries.py`
- Moving the step of deriving data to database manager from query manager.
- Switching from "delta between last two results" to "new result never seen before".
- Adding two more columns in database Result to keep a set of all hashes of previous result and delta.
- Utilizing nosetests fixtures in a new setup for tests using database - creating/dropping test database.
- Adding more tests in test_answer_queries and test_db for new and old untested code.
- Propagating query delta information to front end for highlighting (works with https://github.com/indralab/ui_util/pull/11)