### PR TITLE
Path constraint in EMMAA tests

### DIFF
--- a/emmaa/filter_functions.py
+++ b/emmaa/filter_functions.py
@@ -18,6 +18,4 @@ def register_filter(function):
 @register_filter
 def filter_chem_mesh_go(agent):
     gr = agent.get_grounding()
-    if gr[0] in ['MESH', 'CHEBI', 'GO']:
-        return False
-    return True
+    return gr[0] not in {'MESH', 'CHEBI', 'GO', None}

--- a/emmaa/filter_functions.py
+++ b/emmaa/filter_functions.py
@@ -1,0 +1,23 @@
+from indra.tools import assemble_corpus as ac
+
+
+filter_functions = {}
+
+
+def register_filter(function):
+    """
+    Decorator to register a function as a filter for tests.
+
+    A function should take an agent as an argument and return True if the agent
+    is allowed to be in a path and False otherwise.
+    """
+    filter_functions[function.__name__] = function
+    return function
+
+
+@register_filter
+def filter_chem_mesh_go(agent):
+    gr = agent.get_grounding()
+    if gr[0] in ['MESH', 'CHEBI', 'GO']:
+        return False
+    return True

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -126,9 +126,11 @@ class ModelManager(object):
         """Add a result to a list of results."""
         self.mc_types[mc_type]['test_results'].append(result)
 
-    def run_all_tests(self, filter_func=None):
+    def run_all_tests(self):
         """Run all applicable tests with all available ModelCheckers."""
         max_path_length, max_paths = self._get_test_configs()
+        # TODO get the filter function from model config
+        filter_func = None
         for mc_type in self.mc_types:
             self.run_tests_per_mc(mc_type, max_path_length, max_paths,
                                   filter_func)

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -114,6 +114,8 @@ class ModelManager(object):
             mc.model_stmts = self.model.assembled_stmts
             mc.get_graph(prune_im=True, prune_im_degrade=True,
                          add_namespaces=add_ns)
+        if mc_type in ('signed_graph', 'unsigned_graph'):
+            mc.nodes_to_agents = {ag.name: ag for ag in self.entities}
         return mc
 
     def add_test(self, test):
@@ -124,19 +126,22 @@ class ModelManager(object):
         """Add a result to a list of results."""
         self.mc_types[mc_type]['test_results'].append(result)
 
-    def run_all_tests(self):
+    def run_all_tests(self, filter_func=None):
         """Run all applicable tests with all available ModelCheckers."""
         max_path_length, max_paths = self._get_test_configs()
         for mc_type in self.mc_types:
-            self.run_tests_per_mc(mc_type, max_path_length, max_paths)
+            self.run_tests_per_mc(mc_type, max_path_length, max_paths,
+                                  filter_func)
 
-    def run_tests_per_mc(self, mc_type, max_path_length, max_paths):
+    def run_tests_per_mc(self, mc_type, max_path_length, max_paths,
+                         filter_func):
         """Run all applicable tests with one ModelChecker."""
         mc = self.get_updated_mc(
             mc_type, [test.stmt for test in self.applicable_tests])
         logger.info(f'Running the tests with {mc_type} ModelChecker.')
         results = mc.check_model(
-            max_path_length=max_path_length, max_paths=max_paths)
+            max_path_length=max_path_length, max_paths=max_paths,
+            agent_filter_func=filter_func)
         for (stmt, result) in results:
             self.add_result(mc_type, result)
 


### PR DESCRIPTION
This PR integrates changes proposed in https://github.com/sorgerlab/indra/pull/1179 into EMMAA model testing pipeline. To add constraints to a specific model+test corpus combination, the function has to be defined as a filter function and its name has to be added to model config file. A sample function is defined as a part of this PR, that filters out nodes grounded to CHEBI, MESH and GO.