### PR TITLE
Paper data

### DIFF
--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -528,7 +528,14 @@ class ModelStatsGenerator(StatsGenerator):
         """Add latest paper summary to json_stats."""
         logger.info(f'Generating model summary for {self.model_name}.')
         self.json_stats['paper_summary'] = {
-            'number_of_raw_papers': self.latest_round.get_number_raw_papers()
+            'raw_paper_ids': self.latest_round.get_all_raw_paper_ids(),
+            'number_of_raw_papers': self.latest_round.get_number_raw_papers(),
+            'assembled_paper_ids': (
+                self.latest_round.get_all_assembled_paper_ids()),
+            'number_of_assembled_papers': (
+                self.latest_round.get_number_assembled_papers()),
+            'stmts_by_paper': self.latest_round.stmts_by_papers,
+            'paper_distr': self.latest_round.get_papers_distribution()
         }
 
     def make_paper_delta(self):
@@ -536,12 +543,19 @@ class ModelStatsGenerator(StatsGenerator):
         logger.info(f'Generating paper delta for {self.model_name}.')
         if not self.previous_round or not self.previous_round.paper_ids:
             self.json_stats['paper_delta'] = {
-                'paper_ids_delta': {'added': [], 'removed': []}}
+                'raw_paper_ids_delta': {'added': [], 'removed': []},
+                'assembled_paper_ids_delta': {'added': [], 'removed': []}}
         else:
-            paper_delta = self.latest_round.find_delta_hashes(
-                self.previous_round, 'papers')
-            self.json_stats['paper_delta'] = {'paper_ids_delta': paper_delta}
-            logger.info(f'Read {len(paper_delta["added"])} new papers.')
+            raw_paper_delta = self.latest_round.find_delta_hashes(
+                self.previous_round, 'raw_papers')
+            assembled_paper_delta = self.latest_round.find_delta_hashes(
+                self.previous_round, 'assembled_papers')
+            self.json_stats['paper_delta'] = {
+                'raw_paper_ids_delta': raw_paper_delta
+                'assembled_paper_ids_delta': assembled_paper_delta}
+            logger.info(f'Read {len(raw_paper_delta["added"])} new papers.')
+            logger.info(f'Got assembled statements from '
+                        f'{len(assembled_paper_delta["added"])} new papers.')
 
     def make_changes_over_time(self):
         """Add changes to model over time to json_stats."""

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -117,7 +117,7 @@ class ModelRound(Round):
                  paper_id_type='TRID'):
         super().__init__(date_str)
         self.statements = statements
-        self.paper_ids = paper_ids if paper_ids else set()
+        self.paper_ids = paper_ids if paper_ids else []
         self.stmts_by_papers = self.get_assembled_stmts_by_paper(paper_id_type)
 
     @classmethod

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -219,7 +219,7 @@ class ModelRound(Round):
         return stmts_by_papers
 
     def get_all_assembled_paper_ids(self):
-        return self.stmts_by_papers.keys()
+        return list(self.stmts_by_papers.keys())
 
     def get_number_assembled_papers(self):
         if not self.stmts_by_papers:

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -213,7 +213,7 @@ class ModelRound(Round):
                     if paper_id in stmts_by_papers:
                         stmts_by_papers[paper_id].add(stmt.get_hash())
                     else:
-                        stmts_by_papers[paper_id] = set()
+                        stmts_by_papers[paper_id] = {stmt.get_hash()}
         return stmts_by_papers
 
     def get_all_assembled_paper_ids(self):

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -195,6 +195,9 @@ class ModelRound(Round):
             return self.paper_data.keys()
         return [k for (k, v) in paper_data.items() if len(v) > 0]
 
+    def get_number_papers(self, include_no_stmts=True):
+        return len(self.get_all_paper_ids)
+
 
 class TestRound(Round):
     """Analyzes the results of one test round.
@@ -483,6 +486,25 @@ class ModelStatsGenerator(StatsGenerator):
                                     self.latest_round.date_str[:10])
             if msg:
                 logger.info(msg)
+
+    def make_paper_summary(self):
+        """Add latest paper summary to json_stats."""
+        logger.info(f'Generating model summary for {self.model_name}.')
+        self.json_stats['paper_summary'] = {
+            'number_of_papers': self.latest_round.get_number_papers()
+        }
+
+    def make_paper_delta(self):
+        """Add paper delta between two latest model states to json_stats."""
+        logger.info(f'Generating paper delta for {self.model_name}.')
+        if not self.previous_round or not self.previous_round.paper_data:
+            self.json_stats['paper_delta'] = {
+                'paper_ids_delta': {'added': [], 'removed': []}}
+        else:
+            paper_delta = self.latest_round.find_delta_hashes(
+                self.previous_round, 'papers')
+            self.json_stats['paper_delta'] = {'paper_ids_delta': paper_delta}
+            logger.info(f'Read {len(paper_delta['added'])} new papers.')
 
     def make_changes_over_time(self):
         """Add changes to model over time to json_stats."""

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -193,10 +193,10 @@ class ModelRound(Round):
         """
         if include_no_stmts:
             return self.paper_data.keys()
-        return [k for (k, v) in paper_data.items() if len(v) > 0]
+        return [k for (k, v) in self.paper_data.items() if len(v) > 0]
 
     def get_number_papers(self, include_no_stmts=True):
-        return len(self.get_all_paper_ids)
+        return len(self.get_all_paper_ids(include_no_stmts))
 
 
 class TestRound(Round):
@@ -456,6 +456,8 @@ class ModelStatsGenerator(StatsGenerator):
         logger.info(f'Generating stats for {self.model_name}.')
         self.make_model_summary()
         self.make_model_delta()
+        self.make_paper_summary()
+        self.make_paper_delta()
         self.make_changes_over_time()
 
     def make_model_summary(self):
@@ -504,7 +506,7 @@ class ModelStatsGenerator(StatsGenerator):
             paper_delta = self.latest_round.find_delta_hashes(
                 self.previous_round, 'papers')
             self.json_stats['paper_delta'] = {'paper_ids_delta': paper_delta}
-            logger.info(f'Read {len(paper_delta['added'])} new papers.')
+            logger.info(f'Read {len(paper_delta["added"])} new papers.')
 
     def make_changes_over_time(self):
         """Add changes to model over time to json_stats."""
@@ -512,6 +514,8 @@ class ModelStatsGenerator(StatsGenerator):
         self.json_stats['changes_over_time'] = {
             'number_of_statements': self.get_over_time(
                 'model_summary', 'number_of_statements'),
+            'number_of_papers': self.get_over_time(
+                'paper_summary', 'number_of_papers'),
             'dates': self.get_dates()}
 
     def get_over_time(self, section, metrics, mc_type='pysb'):
@@ -522,7 +526,7 @@ class ModelStatsGenerator(StatsGenerator):
             previous_data = []
         else:
             previous_data = (
-                self.previous_json_stats['changes_over_time'][metrics])
+                self.previous_json_stats['changes_over_time'].get(metrics, []))
         previous_data.append(self.json_stats[section][metrics])
         return previous_data
 

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -229,7 +229,7 @@ class ModelRound(Round):
         of unique statements extracted from that paper."""
         logger.info('Finding paper distribution')
         paper_stmt_count = {paper_id: len(stmts) for (paper_id, stmts) in
-                            self.stmts_by_papers}
+                            self.stmts_by_papers.items()}
         return sorted(paper_stmt_count.items(), key=lambda x: x[1],
                       reverse=True)
 
@@ -551,7 +551,7 @@ class ModelStatsGenerator(StatsGenerator):
             assembled_paper_delta = self.latest_round.find_delta_hashes(
                 self.previous_round, 'assembled_papers')
             self.json_stats['paper_delta'] = {
-                'raw_paper_ids_delta': raw_paper_delta
+                'raw_paper_ids_delta': raw_paper_delta,
                 'assembled_paper_ids_delta': assembled_paper_delta}
             logger.info(f'Read {len(raw_paper_delta["added"])} new papers.')
             logger.info(f'Got assembled statements from '
@@ -563,8 +563,10 @@ class ModelStatsGenerator(StatsGenerator):
         self.json_stats['changes_over_time'] = {
             'number_of_statements': self.get_over_time(
                 'model_summary', 'number_of_statements'),
-            'number_of_papers': self.get_over_time(
-                'paper_summary', 'number_of_papers'),
+            'number_of_raw_papers': self.get_over_time(
+                'paper_summary', 'number_of_raw_papers'),
+            'number_of_assembled_papers': self.get_over_time(
+                'paper_summary', 'number_of_assembled_papers'),
             'dates': self.get_dates()}
 
     def get_over_time(self, section, metrics, mc_type='pysb'):

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -102,8 +102,8 @@ class ModelRound(Round):
         A list of INDRA Statements used to assemble a model.
     date_str : str
         Time when ModelManager responsible for this round was created.
-    paper_ids : set(str)
-        A set of paper IDs used to get raw statements for this round.
+    paper_ids : list(str)
+        A list of paper IDs used to get raw statements for this round.
     paper_id_type : str
         Type of paper ID used.
 
@@ -128,7 +128,7 @@ class ModelRound(Round):
         statements = mm.model.assembled_stmts
         date_str = mm.date_str
         try:
-            paper_ids = mm.model.paper_ids
+            paper_ids = list(mm.model.paper_ids)
         except AttributeError:
             paper_ids = None
         paper_id_type = mm.model.reading_config.get('main_id_type', 'TRID')
@@ -204,16 +204,18 @@ class ModelRound(Round):
         logger.info('Mapping papers to statements')
         stmts_by_papers = {}
         for stmt in self.statements:
+            stmt_hash = stmt.get_hash()
             for evid in stmt.evidence:
                 if id_type == 'pii':
                     paper_id = evid.annotations.get('pii')
                 if evid.text_refs:
                     paper_id = evid.text_refs.get(id_type)
                 if paper_id:
-                    if paper_id in stmts_by_papers:
-                        stmts_by_papers[paper_id].add(stmt.get_hash())
+                    if paper_id in stmts_by_papers and stmt_hash not in \
+                            stmts_by_papers[paper_id]:
+                        stmts_by_papers[paper_id].append(stmt_hash)
                     else:
-                        stmts_by_papers[paper_id] = {stmt.get_hash()}
+                        stmts_by_papers[paper_id] = [stmt_hash]
         return stmts_by_papers
 
     def get_all_assembled_paper_ids(self):

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -102,11 +102,22 @@ class ModelRound(Round):
         A list of INDRA Statements used to assemble a model.
     date_str : str
         Time when ModelManager responsible for this round was created.
+    paper_ids : set(str)
+        A set of paper IDs used to get raw statements for this round.
+    paper_id_type : str
+        Type of paper ID used.
+
+    Attributes
+    ----------
+    stmts_by_papers : dict
+        A dictionary mapping the paper IDs to sets of hashes of assembled
+        statements with evidences retrieved from these papers.
     """
-    def __init__(self, statements, paper_ids, date_str, paper_id_type='TRID'):
+    def __init__(self, statements, date_str, paper_ids=None,
+                 paper_id_type='TRID'):
         super().__init__(date_str)
         self.statements = statements
-        self.paper_ids = paper_ids
+        self.paper_ids = paper_ids if paper_ids else set()
         self.stmts_by_papers = self.get_assembled_stmts_by_paper(paper_id_type)
 
     @classmethod
@@ -119,8 +130,9 @@ class ModelRound(Round):
         try:
             paper_ids = mm.model.paper_ids
         except AttributeError:
-            paper_ids = {}
-        return cls(statements, paper_ids, date_str)
+            paper_ids = None
+        paper_id_type = mm.model.reading_config.get('main_id_type', 'TRID')
+        return cls(statements, date_str, paper_ids, paper_id_type)
 
     def get_total_statements(self):
         """Return a total number of statements in a model."""

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -40,11 +40,13 @@ class EmmaaModel(object):
         The name of the model.
     config : dict
         A configuration dict that is typically loaded from a YAML file.
+    paper_ids : set(str) or None
+        A set of paper IDs used to get statements for the current state of the
+        model. With new reading results, new paper IDs will be added. If not
+        provided, initial set will be derived from existing statements.
 
     Attributes
     ----------
-    name : str
-        A string containing the name of the model
     stmts : list[emmaa.EmmaaStatement]
         A list of EmmaaStatement objects representing the model
     assembly_config : dict
@@ -53,6 +55,8 @@ class EmmaaModel(object):
         Configurations for running tests on the model.
     reading_config : dict
         Configurations for reading the content.
+    query_config : dict
+        Configurations for running queries on the model.
     search_terms : list[emmaa.priors.SearchTerm]
         A list of SearchTerm objects containing the search terms used in the
         model.

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -314,9 +314,12 @@ class EmmaaModel(object):
             self.paper_ids.update(set(initial_ids))
         else:
             db = get_db('primary')
-            paper_ids = set([
-                _get_trids(db, paper_id, id_type) for paper_id in initial_ids])
-            self.paper_ids.update(paper_ids)
+            new_paper_ids = set()
+            for paper_id in initial_ids:
+                trids = _get_trids(db, paper_id, id_type)
+                # Some papers might be not in the database yet
+                if trids:
+                    self.paper_ids.add(trids[0])
 
     def get_paper_ids_from_stmts(self, stmts):
         """Get initial set of paper IDs from a list of statements.

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -295,8 +295,9 @@ class EmmaaModel(object):
             file_stmts = load_pickle_from_s3('indra-covid19', fname)
             logger.info(f'Loaded {len(file_stmts)} statements from {fname}.')
             other_stmts += file_stmts
-        new_stmts = make_model_stmts(current_stmts, other_stmts)
+        new_stmts, paper_ids = make_model_stmts(current_stmts, other_stmts)
         self.stmts = to_emmaa_stmts(new_stmts, datetime.datetime.now(), [])
+        self.add_paper_ids(paper_ids, 'TRID')
 
     def add_paper_ids(self, initial_ids, id_type='pmid'):
         """Convert if needed and save paper IDs.
@@ -309,7 +310,7 @@ class EmmaaModel(object):
             What type the given IDs are (e.g. pmid, doi, pii). All IDs except
             for PIIs will be converted into TextRef IDs before saving.
         """
-        if id_type == 'pii':
+        if id_type in {'pii', 'TRID'}:
             self.paper_ids.update(set(initial_ids))
         else:
             db = get_db('primary')

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -324,7 +324,7 @@ class EmmaaModel(object):
         ids_to_stmt_hashes = {}
         for estmt in stmts:
             stmt_hash = estmt.stmt.get_hash(refresh=True)
-            for evid in stmt.evidence:
+            for evid in estmt.stmt.evidence:
                 if evid.pmid:
                     if evid.pmid in ids_to_stmt_hashes:
                         ids_to_stmt_hashes[evid.pmid].add(stmt_hash)

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -59,7 +59,7 @@ class EmmaaModel(object):
     assembled_stmts : list[indra.statements.Statement]
         A list of assembled INDRA Statements
     """
-    def __init__(self, name, config):
+    def __init__(self, name, config, ids_to_stmt_hashes=None):
         self.name = name
         self.stmts = []
         self.assembly_config = {}
@@ -71,6 +71,10 @@ class EmmaaModel(object):
         self.human_readable_name = None
         self._load_config(config)
         self.assembled_stmts = []
+        if ids_to_stmt_hashes:
+            self.ids_to_stmt_hashes = ids_to_stmt_hashes
+        else:
+            ids_to_stmt_hashes = {}
 
     def add_statements(self, stmts):
         """"Add a set of EMMAA Statements to the model

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -41,7 +41,7 @@ class EmmaaModel(object):
     config : dict
         A configuration dict that is typically loaded from a YAML file.
     paper_ids : list(str) or None
-        A set of paper IDs used to get statements for the current state of the
+        A list of paper IDs used to get statements for the current state of the
         model. With new reading results, new paper IDs will be added. If not
         provided, initial set will be derived from existing statements.
 

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -395,7 +395,7 @@ class EmmaaModel(object):
         save_json_to_s3(self.stmts, bucket, key=fname+'.json')
         # Save ids to stmt hashes mapping as json
         id_fname = f'papers/{self.name}/paper_ids_{date_str}.json'
-        save_json_to_s3(self.ids_to_stmt_hashes, bucket, key=id_fname)
+        save_json_to_s3(self.paper_ids, bucket, key=id_fname)
 
     @classmethod
     def load_from_s3(klass, model_name, bucket=EMMAA_BUCKET_NAME):

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -310,11 +310,11 @@ class EmmaaModel(object):
             What type the given IDs are (e.g. pmid, doi, pii). All IDs except
             for PIIs will be converted into TextRef IDs before saving.
         """
+        logger.info(f'Adding new paper IDs from {len(initial_ids)} {id_type}s')
         if id_type in {'pii', 'TRID'}:
             self.paper_ids.update(set(initial_ids))
         else:
             db = get_db('primary')
-            new_paper_ids = set()
             for paper_id in initial_ids:
                 trids = _get_trids(db, paper_id, id_type)
                 # Some papers might be not in the database yet
@@ -330,6 +330,7 @@ class EmmaaModel(object):
             A list of EMMAA statements to create the mappings from.
         """
         main_id_type = self.reading_config.get('main_id_type', 'TRID')
+        logger.info(f'Extracting {main_id_type}s from statements')
         paper_ids = set()
         for estmt in stmts:
             for evid in estmt.stmt.evidence:
@@ -342,6 +343,7 @@ class EmmaaModel(object):
                         paper_id = evid.text_refs.get(main_id_type.lower())
                 if paper_id:
                     paper_ids.add(paper_id)
+        logger.info(f'Got {len(paper_ids)} {main_id_type}s from statements')
         return paper_ids
 
     def eliminate_copies(self):

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -40,7 +40,7 @@ class EmmaaModel(object):
         The name of the model.
     config : dict
         A configuration dict that is typically loaded from a YAML file.
-    paper_ids : set(str) or None
+    paper_ids : list(str) or None
         A set of paper IDs used to get statements for the current state of the
         model. With new reading results, new paper IDs will be added. If not
         provided, initial set will be derived from existing statements.
@@ -78,7 +78,7 @@ class EmmaaModel(object):
         self._load_config(config)
         self.assembled_stmts = []
         if paper_ids:
-            self.paper_ids = paper_ids
+            self.paper_ids = set(paper_ids)
         else:
             self.paper_ids = set()
 
@@ -395,7 +395,7 @@ class EmmaaModel(object):
         save_json_to_s3(self.stmts, bucket, key=fname+'.json')
         # Save ids to stmt hashes mapping as json
         id_fname = f'papers/{self.name}/paper_ids_{date_str}.json'
-        save_json_to_s3(self.paper_ids, bucket, key=id_fname)
+        save_json_to_s3(list(self.paper_ids), bucket, key=id_fname)
 
     @classmethod
     def load_from_s3(klass, model_name, bucket=EMMAA_BUCKET_NAME):

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -74,9 +74,6 @@ class EmmaaModel(object):
         self.assembled_stmts = []
         if ids_to_stmt_hashes:
             self.ids_to_stmt_hashes = ids_to_stmt_hashes
-        elif self.stmts:
-            self.ids_to_stmt_hashes = self.get_ids_to_hashes_from_stmts(
-                self.stmts)
         else:
             self.ids_to_stmt_hashes = {}
 
@@ -321,12 +318,12 @@ class EmmaaModel(object):
 
         Parameters
         ----------
-        stmts : list[indra.statements.Statement]
-            A list of INDRA statements to create the mappings from.
+        stmts : list[emmaa.statements.EmmaaStatement]
+            A list of EMMAA statements to create the mappings from.
         """
         ids_to_stmt_hashes = {}
-        for stmt in stmts:
-            stmt_hash = stmt.get_hash(refresh=True)
+        for estmt in stmts:
+            stmt_hash = estmt.stmt.get_hash(refresh=True)
             for evid in stmt.evidence:
                 if evid.pmid:
                     if evid.pmid in ids_to_stmt_hashes:
@@ -411,6 +408,8 @@ class EmmaaModel(object):
             ids_to_hashes = None
         em = klass(model_name, config, ids_to_hashes)
         em.stmts = stmts
+        if not ids_to_hashes:
+            em.ids_to_stmt_hashes = em.get_ids_to_hashes_from_stmts(stmts)
         return em
 
     def get_entities(self):

--- a/emmaa/tests/previous_model_stats.json
+++ b/emmaa/tests/previous_model_stats.json
@@ -52,10 +52,23 @@
   }
  },
  "paper_summary": {
-  "number_of_papers": 1
+  "raw_paper_ids": ["1234"],
+  "number_of_raw_papers": 1,
+  "assembled_paper_ids": ["1234"],
+  "number_of_assembled_papers": 1,
+  "stmts_by_paper": {
+    "1234": ["-23078353002754841", "-34603994586320440"]
+  },
+  "paper_distr": [
+    ["1234", 2]
+  ]
  },
  "paper_delta": {
-  "paper_ids_delta": {
+  "raw_paper_ids_delta": {
+    "added": [],
+    "removed": []
+   },
+  "assembled_paper_ids_delta": {
     "added": [],
     "removed": []
    }
@@ -64,7 +77,10 @@
   "number_of_statements": [
    2
   ],
-  "number_of_papers": [
+  "number_of_raw_papers": [
+   1
+  ],
+  "number_of_assembled_papers": [
    1
   ],
   "dates": [

--- a/emmaa/tests/previous_model_stats.json
+++ b/emmaa/tests/previous_model_stats.json
@@ -51,9 +51,21 @@
    "removed": []
   }
  },
+ "paper_summary": {
+  "number_of_papers": 1
+ },
+ "paper_delta": {
+  "paper_ids_delta": {
+    "added": [],
+    "removed": []
+   }
+ },
  "changes_over_time": {
   "number_of_statements": [
    2
+  ],
+  "number_of_papers": [
+   1
   ],
   "dates": [
    "2019-11-14-18-26-26"

--- a/emmaa/tests/test_stats.py
+++ b/emmaa/tests/test_stats.py
@@ -49,12 +49,8 @@ new_stmts = previous_stmts + [
                                   source_api='test_source2')])]
 
 
-previous_papers = {'1234': {previous_stmts[0].get_hash(),
-                            previous_stmts[1].get_hash()}}
-
-new_papers = deepcopy(previous_papers)
-new_papers.update({'2345': {new_stmts[2].get_hash(), new_stmts[3].get_hash()},
-                   '3456': set()})
+previous_papers = {'1234'}
+new_papers = {'1234', '2345', '3456'}
 
 
 def test_model_round():
@@ -80,12 +76,9 @@ def test_model_round():
     assert len(mr2.find_delta_hashes(mr, 'statements')['added']) == 2
     assert all(source_tuple in mr2.get_sources_distribution() for source_tuple
                in [('assertion', 2), ('test_source1', 1), ('test_source2', 1)])
-    assert mr2.get_number_papers(include_no_stmts=True) == 3
-    assert mr2.get_number_papers(include_no_stmts=False) == 2
-    assert set(mr2.find_delta_hashes(mr, 'papers', include_no_stmts=True)[
-        'added']) == {'2345', '3456'}
-    assert mr2.find_delta_hashes(mr, 'papers', include_no_stmts=False)[
-        'added'] == ['2345']
+    assert mr2.get_number_papers() == 3
+    assert set(mr2.find_delta_hashes(mr, 'papers')['added']) == {
+        '2345', '3456'}
 
 
 def test_test_round():


### PR DESCRIPTION
This PR adds the data about papers processed into the pipeline. EmmaaModel is updated to keep track of all papers processed for the current round. ModelRound and ModelStatsGenerator are updated to report about both papers used at the reading level and papers from which the evidences of assembled statements are extracted. This PR should be merged together with https://github.com/indralab/covid-19/pull/9 