### PR TITLE
Put human readale name to model based tests

### DIFF
--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -789,7 +789,9 @@ def model_to_tests(model_name, upload=True, bucket=EMMAA_BUCKET_NAME):
     test_description = (
         f'These tests were generated from the {em.human_readable_name} '
         f'on {date_str[:10]}')
-    test_dict = {'test_data': {'description': test_description},
+    test_name = f'{em.human_readable_name} model test corpus'
+    test_dict = {'test_data': {'description': test_description,
+                               'name': test_name},
                  'tests': tests}
     if upload:
         save_tests_to_s3(test_dict, bucket,


### PR DESCRIPTION
This PR propagates human readable name to test corpus based on models. This name is used in tweets. For example, it would replace `nf_tests` with `Neurofibromatosis model test corpus`