### PR TITLE
Add template for lists of demos

### DIFF
--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -1343,6 +1343,12 @@ def get_latest_date():
     return jsonify({'date': date})
 
 
+@app.route('/demos')
+@jwt_optional
+def get_demos_page():
+    return render_template('demos_template.html', link_list=link_list)
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser('Run the EMMAA dashboard service.')
     parser.add_argument('--host', default='0.0.0.0')

--- a/emmaa_service/templates/demos_template.html
+++ b/emmaa_service/templates/demos_template.html
@@ -2,17 +2,37 @@
 
 {% block body %}
 <div class="container">
-    <h3>Demos, talks and posters about EMMAA</h3>
-    <ul>
-        <li>
-            Demo of the EMMAA Dashboard (<a href="https://sorger.med.harvard.edu/data/bgyori/emmaa_dashboard_intro.mov">video</a>)
-        </li>
-        <li>
-        A machine-built self-updating model of COVID-19 mechanisms
-            (<a href="https://zenodo.org/record/4267215/files/2020-11-12_gyori_disease_maps_poster_talk.mp4?download=1">video</a>,
-            <a href="https://zenodo.org/record/4267215/files/2020-11-12_gyori_disease_maps_poster.pdf?download=1">poster</a>)
-        </li>
-    </ul>
+    <h3>Demos and talks</h3>
+    <iframe width="280" height="157" src="https://www.youtube.com/embed/WI-NnFEXY_Y"
+        frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen class="float-left">
+    </iframe>
+    <p>
+      <b>Self-updating and self-testing causal models to accelerate drug discovery in Neurofibromatosis</b>
+        (<a href="https://zenodo.org/record/4267215/files/2020-11-12_gyori_disease_maps_poster.pdf?download=1">poster</a>)
+    </p>
+    <div style="clear: both;"></div>
+    <p>&nbsp;</p>
+
+    <iframe width="280" height="157" src="https://www.youtube.com/embed/N_LP4XSeQXg"
+            frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowfullscreen class="float-left">
+    </iframe>
+    <p>
+        <b>A machine-built self-updating model of COVID-19 disease mechanisms</b>
+    </p>
+    <div style="clear: both;"></div>
+    <p>&nbsp;</p>
+
+    <iframe width="280" height="157" src="https://www.youtube.com/embed/IoRFm2WwnX4"
+            frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowfullscreen class="float-left">
+    </iframe>
+    <p>
+        <b>Introduction to the EMMAA Dashboard</b>
+    </p>
+
+
     <p>&nbsp;</p>
     <p>&nbsp;</p>
     <p>&nbsp;</p>

--- a/emmaa_service/templates/demos_template.html
+++ b/emmaa_service/templates/demos_template.html
@@ -9,7 +9,6 @@
     </iframe>
     <p>
       <b>Self-updating and self-testing causal models to accelerate drug discovery in Neurofibromatosis</b>
-        (<a href="https://zenodo.org/record/4267215/files/2020-11-12_gyori_disease_maps_poster.pdf?download=1">poster</a>)
     </p>
     <div style="clear: both;"></div>
     <p>&nbsp;</p>
@@ -20,6 +19,7 @@
     </iframe>
     <p>
         <b>A machine-built self-updating model of COVID-19 disease mechanisms</b>
+        (<a href="https://zenodo.org/record/4267215/files/2020-11-12_gyori_disease_maps_poster.pdf?download=1">poster</a>)
     </p>
     <div style="clear: both;"></div>
     <p>&nbsp;</p>

--- a/emmaa_service/templates/demos_template.html
+++ b/emmaa_service/templates/demos_template.html
@@ -1,0 +1,23 @@
+{% extends "emmaa_page_template.html" %}
+
+{% block body %}
+<div class="container">
+    <h3>Demos, talks and posters about EMMAA</h3>
+    <ul>
+        <li>
+            Demo of the EMMAA Dashboard (<a href="https://sorger.med.harvard.edu/data/bgyori/emmaa_dashboard_intro.mov">video</a>)
+        </li>
+        <li>
+        A machine-built self-updating model of COVID-19 mechanisms
+            (<a href="https://zenodo.org/record/4267215/files/2020-11-12_gyori_disease_maps_poster_talk.mp4?download=1">video</a>,
+            <a href="https://zenodo.org/record/4267215/files/2020-11-12_gyori_disease_maps_poster.pdf?download=1">poster</a>)
+        </li>
+    </ul>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+</div>
+{% endblock %}

--- a/emmaa_service/templates/demos_template.html
+++ b/emmaa_service/templates/demos_template.html
@@ -24,6 +24,28 @@
     <div style="clear: both;"></div>
     <p>&nbsp;</p>
 
+
+    <iframe width="280" height="157" src="https://www.youtube.com/embed/1DAfqSr75Vk"
+            frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowfullscreen class="float-left">
+    </iframe>
+    <p>
+        <b>Demo: A self-updating and self-testing causal model of COVID-19 drug and disease mechanisms</b>
+    </p>
+
+    <div style="clear: both;"></div>
+    <p>&nbsp;</p>
+
+    <iframe width="280" height="157" src="https://www.youtube.com/embed/bHrzj_hztnw"
+            frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowfullscreen class="float-left">
+    </iframe>
+    <p>
+        <b>Poster: A Self-Updating and Self-Testing Causal Model of COVID-19 Drug and Disease Mechanisms</b>
+    </p>
+    <div style="clear: both;"></div>
+    <p>&nbsp;</p>
+
     <iframe width="280" height="157" src="https://www.youtube.com/embed/IoRFm2WwnX4"
             frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowfullscreen class="float-left">

--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -167,7 +167,7 @@
         <nav class="d-inline-flex p-2">
         <a class="p-2 text-dark" href="https://emmaa.readthedocs.io/en/latest/dashboard/index.html" target="_blank">Help</a>
         <a class="p-2 text-dark" href="#about">About</a>
-        <a class="p-2 text-dark" href="https://sorger.med.harvard.edu/data/bgyori/emmaa_dashboard_intro.mov">Demo</a>
+        <a class="p-2 text-dark" href="/demos">Demos</a>
       </nav>
         <div class="d-inline-flex button-container p-2">
           <button class="btn btn-primary"


### PR DESCRIPTION
This PR changes the link in the header from Demo to Demos, and links it to a template served from an API endpoint. The page lists demos/talks/posters related to EMMAA that can easily be extended with more content.