### PR TITLE
Disable JSON model storage

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -395,7 +395,7 @@ class EmmaaModel(object):
         id_fname = f'papers/{self.name}/paper_ids_{date_str}.json'
         save_json_to_s3(list(self.paper_ids), bucket, key=id_fname)
         # Dump as json
-        save_json_to_s3(self.to_json(), bucket, key=fname+'.json')
+        # save_json_to_s3(self.to_json(), bucket, key=fname+'.json')
 
     @classmethod
     def load_from_s3(klass, model_name, bucket=EMMAA_BUCKET_NAME):

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -391,11 +391,15 @@ class EmmaaModel(object):
         fname = f'models/{self.name}/model_{date_str}'
         # Dump as pickle
         save_pickle_to_s3(self.stmts, bucket, key=fname+'.pkl')
-        # Dump as json
-        save_json_to_s3(self.stmts, bucket, key=fname+'.json')
         # Save ids to stmt hashes mapping as json
         id_fname = f'papers/{self.name}/paper_ids_{date_str}.json'
         save_json_to_s3(list(self.paper_ids), bucket, key=id_fname)
+        try:
+            # Dump as json
+            save_json_to_s3(self.to_json(), bucket, key=fname+'.json')
+        except Exception as e:
+            logger.info(e)
+            pass
 
     @classmethod
     def load_from_s3(klass, model_name, bucket=EMMAA_BUCKET_NAME):

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -394,12 +394,8 @@ class EmmaaModel(object):
         # Save ids to stmt hashes mapping as json
         id_fname = f'papers/{self.name}/paper_ids_{date_str}.json'
         save_json_to_s3(list(self.paper_ids), bucket, key=id_fname)
-        try:
-            # Dump as json
-            save_json_to_s3(self.to_json(), bucket, key=fname+'.json')
-        except Exception as e:
-            logger.info(e)
-            pass
+        # Dump as json
+        save_json_to_s3(self.to_json(), bucket, key=fname+'.json')
 
     @classmethod
     def load_from_s3(klass, model_name, bucket=EMMAA_BUCKET_NAME):

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -484,6 +484,7 @@ class EmmaaModel(object):
 
     def to_json(self):
         """Convert the model into a json dumpable dictionary"""
+        logger.info('Converting a model to JSON')
         json_output = {'name': self.name,
                        'ndex_network': self.ndex_network,
                        'search_terms': [st.to_json() for st

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -291,6 +291,7 @@ def load_json_from_s3(bucket, key):
 def save_json_to_s3(obj, bucket, key, save_format='json'):
     client = get_s3_client(unsigned=False)
     json_str = _get_json_str(obj, save_format=save_format)
+    logger.info(f'Uploading the {save_format} object to S3')
     client.put_object(Body=json_str.encode('utf8'),
                       Bucket=bucket, Key=key)
     del json_str
@@ -322,6 +323,7 @@ def save_zip_json_to_s3(obj, bucket, key, save_format='json'):
 
 
 def _get_json_str(json_obj, save_format='json'):
+    logger.info(f'Dumping the {save_format} into a string')
     if save_format == 'json':
         json_str = json.dumps(json_obj, indent=1)
     elif save_format == 'jsonl':

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -277,6 +277,7 @@ def save_pickle_to_s3(obj, bucket, key):
     obj_str = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
     logger.info(f'Saving object to {key}')
     client.put_object(Body=obj_str, Bucket=bucket, Key=key)
+    del obj_str
 
 
 def load_json_from_s3(bucket, key):
@@ -292,6 +293,7 @@ def save_json_to_s3(obj, bucket, key, save_format='json'):
     json_str = _get_json_str(obj, save_format=save_format)
     client.put_object(Body=json_str.encode('utf8'),
                       Bucket=bucket, Key=key)
+    del json_str
 
 
 def load_zip_json_from_s3(bucket, key):

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -277,7 +277,6 @@ def save_pickle_to_s3(obj, bucket, key):
     obj_str = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
     logger.info(f'Saving object to {key}')
     client.put_object(Body=obj_str, Bucket=bucket, Key=key)
-    del obj_str
 
 
 def load_json_from_s3(bucket, key):
@@ -294,7 +293,6 @@ def save_json_to_s3(obj, bucket, key, save_format='json'):
     logger.info(f'Uploading the {save_format} object to S3')
     client.put_object(Body=json_str.encode('utf8'),
                       Bucket=bucket, Key=key)
-    del json_str
 
 
 def load_zip_json_from_s3(bucket, key):


### PR DESCRIPTION
This PR disables the storing of JSON version of raw EMMAA model and adds a delete step to pickle/json upload functions to save memory.