### PR TITLE
Implement literature prior for model initialization

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,6 @@ jobs:
         export NOSEATTR=$(if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then echo $NOSEATTR,!nonpublic; else echo $NOSEATTR; fi)
         export PYTHONPATH=$PYTHONPATH:`pwd`/covid-19:`pwd`/kappy
         export BNGPATH=`pwd`/BioNetGen-2.4.0
-        export NOSEATTR="!notravis"
         export INDRA_WM_CACHE="."
         nosetests -v -a $NOSEATTR emmaa/tests/test_s3.py
         nosetests -v -a $NOSEATTR --ignore-files='.*test_s3.py' --with-coverage --cover-inclusive --cover-package=emmaa -w emmaa/tests

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -175,9 +175,11 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 MOCK_MODULES = [
     'indra_db', 'indra_db.client', 'indra_db.client.statements',
     'indra_db.client.principal', 'indra_db.client.principal.curation',
+    'indra_db.client.principal.raw_statements',
     'indra_db.util', 'pygraphviz', 'bioagents', 'bioagents.tra',
     'bioagents.tra.tra', 'indra.pipeline',
-    'indra_reading', 'indra_reading.scripts',
+    'indra_reading', 'indra_reading.scripts', 'indra_reading.batch',
+    'indra_reading.batch.monitor',
     'indra_reading.scripts.submit_reading_pipeline'
 ]
 

--- a/doc/modules/priors.rst
+++ b/doc/modules/priors.rst
@@ -5,6 +5,13 @@ Priors (:py:mod:`emmaa.priors`)
     :members:
     :show-inheritance:
 
+Literature Prior (:py:mod:`emmaa.priors.literature_prior`)
+----------------------------------------------------------
+
+.. automodule:: emmaa.priors.literature_prior
+    :members:
+    :show-inheritance:
+
 TCGA Cancer Prior (:py:mod:`emmaa.priors.cancer_prior`)
 -------------------------------------------------------
 

--- a/emmaa/priors/literature_prior.py
+++ b/emmaa/priors/literature_prior.py
@@ -2,12 +2,15 @@
 some of the steps involved in starting a model around a set of
 literature searches. Example:
 
-lp = LiteraturePrior('some_disease', 'Some Disease',
-                     'This is a self-updating model of Some Disease',
-                     search_strings=['some disease'],
-                     assembly_config_template='nf')
-estmts = lp.get_statements()
-model = lp.make_model(estmts, upload_to_s3=True)
+.. code:: python
+
+    lp = LiteraturePrior('some_disease', 'Some Disease',
+                         'This is a self-updating model of Some Disease',
+                         search_strings=['some disease'],
+                         assembly_config_template='nf')
+    estmts = lp.get_statements()
+    model = lp.make_model(estmts, upload_to_s3=True)
+
 """
 import tqdm
 import logging
@@ -202,8 +205,8 @@ class LiteraturePrior:
 def get_raw_statements_for_pmids(pmids, mode='all', batch_size=100):
     """Return EmmaaStatements based on extractions from given PMIDs.
 
-    Paramters
-    ---------
+    Parameters
+    ----------
     pmids : set or list of str
         A set of PMIDs to find raw INDRA Statements for in the INDRA DB.
     mode : 'all' or 'distilled'

--- a/emmaa/priors/literature_prior.py
+++ b/emmaa/priors/literature_prior.py
@@ -21,11 +21,15 @@ class LiteraturePrior:
                  search_strings=None, mesh_ids=None,
                  assembly_config_template=None):
         self.name = name
-        self.human_readable_name = human_readable_name,
+        self.human_readable_name = human_readable_name
         self.description = description
         self.search_terms = \
             self.make_search_terms(search_strings, mesh_ids)
-        self.assembly_config = self.get_config_from(assembly_config_template)
+        if assembly_config_template:
+            self.assembly_config = \
+                self.get_config_from(assembly_config_template)
+        else:
+            self.assembly_config = {}
 
     def make_search_terms(self, search_strings, mesh_ids):
         search_terms = []
@@ -109,10 +113,11 @@ class LiteraturePrior:
             save_config_to_s3(self.name, config)
         return config
 
-    def make_model(self, upload_to_s3=False):
+    def make_model(self, estmts, upload_to_s3=False):
         from emmaa.model import EmmaaModel
         config = self.make_config(upload_to_s3=upload_to_s3)
         model = EmmaaModel(name=self.name, config=config)
+        model.add_statements(estmts)
         if upload_to_s3:
             model.save_to_s3()
         return model

--- a/emmaa/priors/literature_prior.py
+++ b/emmaa/priors/literature_prior.py
@@ -105,10 +105,17 @@ class LiteraturePrior:
             }
         }
         if upload_to_s3:
-            from emmaa.util import save_json_to_s3
-            save_json_to_s3(config, bucket='emmaa',
-                            key=f'models/{self.name}/config.json')
+            from emmaa.model import save_config_to_s3
+            save_config_to_s3(self.name, config)
         return config
+
+    def make_model(self, upload_to_s3=False):
+        from emmaa.model import EmmaaModel
+        config = self.make_config(upload_to_s3=upload_to_s3)
+        model = EmmaaModel(name=self.name, config=config)
+        if upload_to_s3:
+            model.save_to_s3()
+        return model
 
 
 def get_raw_statements_for_pmids(pmids, mode='all', batch_size=100):

--- a/emmaa/priors/literature_prior.py
+++ b/emmaa/priors/literature_prior.py
@@ -1,0 +1,32 @@
+import tqdm
+from indra_db import get_db
+from indra_db.util import distill_stmts
+from indra.util import batch_iter
+from indra.literature import pubmed_client
+from indra.statements import stmts_to_json_file
+
+
+def get_pmids(search_terms=None, mesh_ids=None):
+    search_terms = [] if not search_terms else search_terms
+    mesh_ids = [] if not mesh_ids else mesh_ids
+    all_ids = set()
+    for term in search_terms:
+        all_ids |= set(pubmed_client.get_ids(term))
+    for mesh_id in mesh_ids:
+        all_ids |= set(pubmed_client.get_ids_for_mesh(mesh_id))
+    return all_ids
+
+
+def get_raw_statements_for_pmdis(pmids, batch_size=100):
+    db = get_db('primary')
+    print(f'Getting raw statements for {len(pmids)} PMIDs')
+    all_stmts = []
+    for pmid_batch in tqdm.tqdm(batch_iter(pmids, return_func=set,
+                                           batch_size=batch_size)):
+        clauses = [
+            db.TextRef.pmid.in_(pmid_batch),
+            db.TextContent.text_ref_id == db.TextRef.id,
+            db.Reading.text_content_id == db.TextContent.id,
+            db.RawStatements.reading_id == db.Reading.id]
+        all_stmts += distill_stmts(db, get_full_stmts=True, clauses=clauses)
+    return all_stmts

--- a/emmaa/priors/literature_prior.py
+++ b/emmaa/priors/literature_prior.py
@@ -1,12 +1,34 @@
 import tqdm
+import logging
+import datetime
+from indra.util import batch_iter
 from indra_db import get_db
 from indra_db.util import distill_stmts
-from indra.util import batch_iter
+from indra_db.client.principal import get_raw_stmt_jsons_from_papers
 from indra.literature import pubmed_client
-from indra.statements import stmts_to_json_file
+from indra.statements import stmts_from_json
+from emmaa.statements import EmmaaStatement
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_pmids(search_terms=None, mesh_ids=None):
+    """Return a set of PMIDs based on search terms and/or MeSH IDs.
+
+    Parameters
+    ----------
+    search_terms : list of str or None
+        Any number of string search terms to find PMIDs.
+    mesh_ids : list of str or None
+        Any number of MeSH IDs to find PMIDs.
+
+    Returns
+    -------
+    set of str
+        A set of PMIDs found using the given search terms and/or MeSH
+        IDs.
+    """
     search_terms = [] if not search_terms else search_terms
     mesh_ids = [] if not mesh_ids else mesh_ids
     all_ids = set()
@@ -17,16 +39,52 @@ def get_pmids(search_terms=None, mesh_ids=None):
     return all_ids
 
 
-def get_raw_statements_for_pmdis(pmids, batch_size=100):
+def get_raw_statements_for_pmids(pmids, mode='all', batch_size=100):
+    """Return EmmaaStatements based on extractions from given PMIDs.
+
+    Paramters
+    ---------
+    pmids : set or list of str
+        A set of PMIDs to find raw INDRA Statements for in the INDRA DB.
+    mode : 'all' or 'distilled'
+        The 'distilled' mode makes sure that the "best", non-redundant
+        set of raw statements are found across potentially redundant text
+        contents and reader versions. The 'all' mode doesn't do such
+        distillation but is significantly faster.
+    batch_size : Optional[int]
+        Determines how many PMIDs to fetch statements for in each
+        iteration. Default: 100.
+
+    Returns
+    -------
+    list of emmaa.statement.Statement
+        A list of EMMAA Statements that wrap the obtained raw INDRA
+        Statements.
+    """
     db = get_db('primary')
     print(f'Getting raw statements for {len(pmids)} PMIDs')
-    all_stmts = []
+    estmts = []
+    timestamp = datetime.datetime.now()
     for pmid_batch in tqdm.tqdm(batch_iter(pmids, return_func=set,
-                                           batch_size=batch_size)):
-        clauses = [
-            db.TextRef.pmid.in_(pmid_batch),
-            db.TextContent.text_ref_id == db.TextRef.id,
-            db.Reading.text_content_id == db.TextContent.id,
-            db.RawStatements.reading_id == db.Reading.id]
-        all_stmts += distill_stmts(db, get_full_stmts=True, clauses=clauses)
-    return all_stmts
+                                           batch_size=batch_size),
+                                total=len(pmids)/batch_size):
+        if mode == 'distilled':
+            clauses = [
+                db.TextRef.pmid.in_(pmid_batch),
+                db.TextContent.text_ref_id == db.TextRef.id,
+                db.Reading.text_content_id == db.TextContent.id,
+                db.RawStatements.reading_id == db.Reading.id]
+            distilled_stmts = distill_stmts(db, get_full_stmts=True,
+                                            clauses=clauses)
+            estmts += [EmmaaStatement(stmt, timestamp, [])
+                       for stmt in distilled_stmts]
+        else:
+            id_stmts = \
+                get_raw_stmt_jsons_from_papers(pmid_batch, id_type='pmid',
+                                               db=db)
+            estmts = []
+            for _id, stmt_jsons in id_stmts.items():
+                stmts = stmts_from_json(stmt_jsons)
+                estmts += [EmmaaStatement(stmt, timestamp, [])
+                           for stmt in stmts]
+    return estmts

--- a/emmaa/priors/literature_prior.py
+++ b/emmaa/priors/literature_prior.py
@@ -1,42 +1,66 @@
 import tqdm
 import logging
 import datetime
+from collections import defaultdict
 from indra.util import batch_iter
 from indra_db import get_db
 from indra_db.util import distill_stmts
 from indra_db.client.principal import get_raw_stmt_jsons_from_papers
+from indra.databases import mesh_client
 from indra.literature import pubmed_client
 from indra.statements import stmts_from_json
+from . import SearchTerm
+from emmaa.model import EmmaaModel
 from emmaa.statements import EmmaaStatement
 
 
 logger = logging.getLogger(__name__)
 
 
-def get_pmids(search_terms=None, mesh_ids=None):
-    """Return a set of PMIDs based on search terms and/or MeSH IDs.
+class LiteraturePrior:
+    def __init__(self, name, human_readable_name, description,
+                 search_strings, mesh_ids):
+        self.name = name
+        self.human_readable_name = human_readable_name,
+        self.description = description
+        self.search_terms = \
+            self.make_search_terms(search_strings, mesh_ids)
 
-    Parameters
-    ----------
-    search_terms : list of str or None
-        Any number of string search terms to find PMIDs.
-    mesh_ids : list of str or None
-        Any number of MeSH IDs to find PMIDs.
+    def make_search_terms(self, search_strings, mesh_ids):
+        search_terms = []
+        for search_string in search_strings:
+            search_term = SearchTerm(type='other', name=search_string,
+                                     db_refs={}, search_term=search_string)
+            search_terms.append(search_term)
+        for mesh_id in mesh_ids:
+            mesh_name = mesh_client.get_mesh_name(mesh_id)
+            suffix = 'mh' if mesh_id.startswith('D') else 'nm'
+            search_term = SearchTerm(type='mesh', name=mesh_name,
+                                     db_refs={'MESH': mesh_id},
+                                     search_term=f'{mesh_name} [{suffix}]')
+            search_terms.append(search_term)
+        return search_terms
 
-    Returns
-    -------
-    set of str
-        A set of PMIDs found using the given search terms and/or MeSH
-        IDs.
-    """
-    search_terms = [] if not search_terms else search_terms
-    mesh_ids = [] if not mesh_ids else mesh_ids
-    all_ids = set()
-    for term in search_terms:
-        all_ids |= set(pubmed_client.get_ids(term))
-    for mesh_id in mesh_ids:
-        all_ids |= set(pubmed_client.get_ids_for_mesh(mesh_id))
-    return all_ids
+    def get_statements(self, mode='all', batch_size=100):
+        terms_to_pmids = \
+            EmmaaModel.search_pubmed(search_terms=self.search_terms,
+                                     date_limit=None)
+        pmids_to_terms = defaultdict(list)
+        for term, pmids in terms_to_pmids.items():
+            for pmid in pmids:
+                pmids_to_terms[pmid].append(term)
+        pmids_to_terms = dict(pmids_to_terms)
+        all_pmids = set(pmids_to_terms.values())
+        raw_statements_by_pmid = \
+            get_raw_statements_for_pmids(all_pmids, mode=mode,
+                                         batch_size=batch_size)
+        timestamp = datetime.datetime.now()
+        estmts = []
+        for pmid, stmts in raw_statements_by_pmid.items():
+            for stmt in stmts:
+                estmts.append(EmmaaStatement(stmt, timestamp,
+                                             pmids_to_terms[pmid]))
+        return estmts
 
 
 def get_raw_statements_for_pmids(pmids, mode='all', batch_size=100):
@@ -57,14 +81,13 @@ def get_raw_statements_for_pmids(pmids, mode='all', batch_size=100):
 
     Returns
     -------
-    list of emmaa.statement.Statement
-        A list of EMMAA Statements that wrap the obtained raw INDRA
-        Statements.
+    dict
+        A dict keyed by PMID with values INDRA Statements obtained
+        from the given PMID.
     """
     db = get_db('primary')
-    print(f'Getting raw statements for {len(pmids)} PMIDs')
-    estmts = []
-    timestamp = datetime.datetime.now()
+    logger.info(f'Getting raw statements for {len(pmids)} PMIDs')
+    all_stmts = defaultdict(list)
     for pmid_batch in tqdm.tqdm(batch_iter(pmids, return_func=set,
                                            batch_size=batch_size),
                                 total=len(pmids)/batch_size):
@@ -76,15 +99,13 @@ def get_raw_statements_for_pmids(pmids, mode='all', batch_size=100):
                 db.RawStatements.reading_id == db.Reading.id]
             distilled_stmts = distill_stmts(db, get_full_stmts=True,
                                             clauses=clauses)
-            estmts += [EmmaaStatement(stmt, timestamp, [])
-                       for stmt in distilled_stmts]
+            for stmt in distilled_stmts:
+                all_stmts[stmt.evidence[0].pmid].append(stmt)
         else:
             id_stmts = \
                 get_raw_stmt_jsons_from_papers(pmid_batch, id_type='pmid',
                                                db=db)
-            estmts = []
-            for _id, stmt_jsons in id_stmts.items():
-                stmts = stmts_from_json(stmt_jsons)
-                estmts += [EmmaaStatement(stmt, timestamp, [])
-                           for stmt in stmts]
-    return estmts
+            for pmid, stmt_jsons in id_stmts.items():
+                all_stmts[pmid] += stmts_from_json(stmt_jsons)
+    all_stmts = dict(all_stmts)
+    return all_stmts

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -552,14 +552,17 @@ def get_model_dashboard(model):
         abort(Response(f'Data for {model} and {test_corpus} for {date} '
                        f'was not found', 404))
     logger.info('Getting model information')
-    ndex_id = 'None available'
+    ndex_id = None
     description = 'None available'
     for mid, mmd in model_meta_data:
         if mid == model:
-            ndex_id = mmd['ndex']['network']
+            try:
+                ndex_id = mmd['ndex']['network']
+            except KeyError:
+                pass
             description = mmd['description']
             twitter_link = mmd.get('twitter_link')
-    if ndex_id == 'None available':
+    if ndex_id is None:
         logger.warning(f'No ndex ID found for {model}')
     available_tests = _get_test_corpora(model)
     model_info_contents = [
@@ -567,10 +570,12 @@ def get_model_dashboard(model):
         [('', 'Latest Data Available', ''), ('', latest_date, '')],
         [('', 'Data Displayed', ''),
          ('', date,
-          'Click on the point on time graph to see earlier results')],
-        [('', 'Network on Ndex', ''),
+          'Click on the point on time graph to see earlier results')]]
+    if ndex_id:
+        model_info_contents.append([
+         ('', 'Network on Ndex', ''),
          (f'http://www.ndexbio.org/#/network/{ndex_id}', ndex_id,
-          'Click to see network on Ndex')]]
+          'Click to see network on Ndex')])
     if twitter_link:
         model_info_contents.append([
             ('', 'Twitter', ''),

--- a/emmaa_service/templates/index_template.html
+++ b/emmaa_service/templates/index_template.html
@@ -22,8 +22,10 @@
             <div class="btn-group">
               <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('get_model_dashboard', model=model_id, tab='model') }}" target="_blank">Details</a>
               <a class="btn btn-sm btn-outline-secondary" style="margin-left: 3px; ;" href="{{ url_for('get_query_page', tab='open', preselected=model_id) }}" target="_blank">Query</a>
+              {% if 'ndex' in model_meta %}
               <a class="btn btn-sm btn-outline-secondary" style="margin-left: 3px;" 
                  href="http://www.ndexbio.org/#/network/{{ model_meta['ndex']['network'] }}" target="_blank">NDEx</a>
+              {% endif %}
               {% if 'twitter_link' in model_meta %}
               <a href="{{ model_meta['twitter_link'] }}"  target="_blank" class="btn btn-sm fa fa-twitter" style="margin-left: 3px;"></a>
               {% endif %}


### PR DESCRIPTION
This PR implements a new prior module that allows initializing a model by searching for extractions from a specific subset of literature (given a list of search strings or MeSH IDs to find relevant papers). The prior class can also generate an initial config and upload the model and config to S3.