### PR TITLE
Fix pickle protocol to 4

### DIFF
--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -274,7 +274,7 @@ def load_pickle_from_s3(bucket, key):
 def save_pickle_to_s3(obj, bucket, key):
     client = get_s3_client(unsigned=False)
     logger.info('Pickling object')
-    obj_str = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
+    obj_str = pickle.dumps(obj, protocol=4)
     logger.info(f'Saving object to {key}')
     client.put_object(Body=obj_str, Bucket=bucket, Key=key)
 


### PR DESCRIPTION
This PR sets the pickle protocol to 4 when dumping pickles since EMMAA jobs are running in a Python 3.7 environment which cannot use any pickles that were dumped using protocol 5 (which is the HIGHEST_PROTOCOL in Python 3.8+).