### PR TITLE
Local mode and PyBEL versioning

### DIFF
--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -113,8 +113,9 @@ class ModelManager(object):
         # No need to store raw statements
         model.stmts = []
         # Loading assembled statements to avoid reassembly
-        stmts, _ = get_assembled_statements(model_name, bucket=bucket)
+        stmts, fname = get_assembled_statements(model_name, bucket=bucket)
         model.assembled_stmts = stmts
+        model.date_str = strip_out_date(fname, 'datetime')
         mm = cls(model, mode=mode)
         return mm
 

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -80,7 +80,7 @@ class ModelManager(object):
     date_str : str
         Time when this object was created.
     """
-    def __init__(self, model):
+    def __init__(self, model, mode='local'):
         self.model = model
         self.mc_mapping = {
             'pysb': (self.model.assemble_pysb, PysbModelChecker,
@@ -96,7 +96,7 @@ class ModelManager(object):
         self.mc_types = {}
         for mc_type in model.test_config.get('mc_types', ['pysb']):
             self.mc_types[mc_type] = {}
-            assembled_model = self.mc_mapping[mc_type][0]()
+            assembled_model = self.mc_mapping[mc_type][0](mode=mode)
             self.mc_types[mc_type]['model'] = assembled_model
             self.mc_types[mc_type]['model_checker'] = (
                 self.mc_mapping[mc_type][1](assembled_model))

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -782,6 +782,7 @@ def load_model_manager_from_s3(model_name=None, key=None,
                     logger.info('Could not load the model manager from '
                                 'statements')
                     logger.info(e)
+                    return None
     # Now try find the latest key for given model
     if model_name:
         # Versioned

--- a/scripts/update_model_manager.py
+++ b/scripts/update_model_manager.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     model = EmmaaModel.load_from_s3(args.model)
-    mm = ModelManager(model)
+    mm = ModelManager(model, mode='s3')
     mm.model.update_to_ndex()
     mm.save_assembled_statements()
     save_model_manager_to_s3(args.model, mm)


### PR DESCRIPTION
This PR makes several changes to EmmaaModel and ModelManager:
- Updates PyBEL version in setup
- Adds `mode` parameter to EmmaaModel methods for different formats assembly, it's set to "local" by default to avoid unnecessary uploads of exports to s3 and is only set to "s3" in model manager update script run by Batch daily (in this case it will upload exported formats as configured in model config)
- Adds alternative way to load a model manager pickle from s3 - if the pickle load fails (which can happen in case of a new PyBEL or PySB version), then it loads the assembled statements instead and assembles the required model types.