### PR TITLE
Refinements

### DIFF
--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -350,19 +350,18 @@ class ModelManager(object):
     def open_query_per_mc(self, mc_type, mc, query, max_path_length,
                           max_paths):
         g = mc.get_graph()
-        subj_nodes, obj_nodes, res_code = mc.get_all_subjects_objects(
-            query.path_stmt)
+        subj_nodes, obj_nodes, res_code = mc.process_statement(query.path_stmt)
         if res_code:
             return self.hash_response_list(RESULT_CODES[res_code])
         else:
             if query.entity_role == 'subject':
                 reverse = False
-                assert subj_nodes is not None
-                nodes = subj_nodes
+                assert subj_nodes.all_nodes
+                nodes = subj_nodes.all_nodes
             else:
                 reverse = True
-                assert obj_nodes is not None
-                nodes = obj_nodes
+                assert obj_nodes
+                nodes = obj_nodes.all_nodes
             sign = query.get_sign(mc_type)
             if mc_type == 'pysb':
                 terminal_ns = None

--- a/emmaa/tests/test_model_tests.py
+++ b/emmaa/tests/test_model_tests.py
@@ -1,9 +1,8 @@
 from nose.plugins.attrib import attr
 
-from indra.statements import Activation, Agent
+from indra.statements import *
 from indra.explanation.model_checker import PathResult, PysbModelChecker, \
     PybelModelChecker, SignedGraphModelChecker, UnsignedGraphModelChecker
-from indra.statements.statements import Statement, Agent
 from emmaa.model import EmmaaModel
 from emmaa.model_tests import StatementCheckingTest, ModelManager, \
     ScopeTestConnector, TestManager, RefinementTestConnector
@@ -73,3 +72,73 @@ def test_applicability():
     mm.applicable_tests = []
     tm.make_tests(RefinementTestConnector())
     assert len(mm.applicable_tests) == 2
+
+
+def test_paths_content():
+    model = create_model()
+    model.run_assembly()
+    # Add statements with similar subject and object to test grouping
+    map2k1 = model.assembled_stmts[1].subj
+    mapk1 = model.assembled_stmts[1].obj
+    phos = Phosphorylation(map2k1, mapk1)
+    phos_t185 = Phosphorylation(map2k1, mapk1, 'T', '185')
+    phos_y187 = Phosphorylation(map2k1, mapk1, 'Y', '187')
+    inc = IncreaseAmount(map2k1, mapk1)
+    inh = Inhibition(map2k1, mapk1)
+    model.assembled_stmts += [phos, phos_t185, phos_y187, inc, inh]
+    mm = ModelManager(model)
+    tests = [StatementCheckingTest(
+             Activation(Agent('BRAF', db_refs={'HGNC': '1097'}),
+                        Agent('MAPK1', db_refs={'UP': 'P28482'})))]
+    tm = TestManager([mm], tests)
+    tm.make_tests(ScopeTestConnector())
+    tm.run_tests()
+    result_json, json_lines = mm.results_to_json()
+    assert len(result_json) == 2
+    assert len(result_json[1]) == 6, len(result_json[1])
+    # The second edge will be supported differently in different model types
+    assert result_json[1]['pysb']['path_json'][0]['path'] == \
+        'BRAF → MAP2K1 → MAPK1'
+    second_edge = result_json[1]['pysb']['path_json'][0]['edge_list'][1]
+    # Only Activation statement will be in the edge in PySB
+    assert len(second_edge['stmts']) == 1
+    assert second_edge['stmts'][0][1] == 'Active MAP2K1 activates MAPK1.'
+    assert second_edge['stmts'][0][0].count('stmt_hash') == 1
+    # Positive (Activation and IncreaseAmount) in SignedGraph edge
+    assert result_json[1]['signed_graph']['path_json'][0]['path'] == \
+        'BRAF → MAP2K1 → MAPK1'
+    second_edge = result_json[1]['signed_graph']['path_json'][0][
+        'edge_list'][1]
+    assert len(second_edge['stmts']) == 2
+    assert second_edge['stmts'][0][1] == 'MAP2K1 activates MAPK1.'
+    assert second_edge['stmts'][0][0].count('stmt_hash') == 1
+    assert second_edge['stmts'][1][1] == ('MAP2K1 increases the amount of '
+                                          'MAPK1.')
+    assert second_edge['stmts'][1][0].count('stmt_hash') == 1
+    # All statement types support unsigned graph edge, but different statements
+    # of the same type are grouped together
+    assert result_json[1]['unsigned_graph']['path_json'][0]['path'] == \
+        'BRAF → MAP2K1 → MAPK1'
+    second_edge = result_json[1]['unsigned_graph']['path_json'][0][
+        'edge_list'][1]
+    assert len(second_edge['stmts']) == 4
+    assert second_edge['stmts'][0][1] == 'MAP2K1 activates MAPK1.'
+    assert second_edge['stmts'][0][0].count('stmt_hash') == 1
+    assert second_edge['stmts'][1][1] == 'MAP2K1 phosphorylates MAPK1.'
+    assert second_edge['stmts'][1][0].count('stmt_hash') == 3
+    assert second_edge['stmts'][2][1] == 'MAP2K1 inhibits MAPK1.'
+    assert second_edge['stmts'][2][0].count('stmt_hash') == 1
+    assert second_edge['stmts'][3][1] == ('MAP2K1 increases the amount of '
+                                          'MAPK1.')
+    assert second_edge['stmts'][3][0].count('stmt_hash') == 1
+    # Test JSONL representation
+    assert len(json_lines) == 3
+    for path_dict in json_lines:
+        assert len(path_dict['edges']) == 2
+        assert len(path_dict['edges'][0]) == 1
+        if path_dict['graph_type'] == 'pysb':
+            assert len(path_dict['edges'][1]) == 1
+        elif path_dict['graph_type'] == 'signed_graph':
+            assert len(path_dict['edges'][1]) == 2
+        elif path_dict['graph_type'] == 'unsigned_graph':
+            assert len(path_dict['edges'][1]) == 6


### PR DESCRIPTION
This PR goes together with https://github.com/sorgerlab/indra/pull/1216 and includes adding a new class to check applicability of tests by refinements and propagates the use of refinements in pathfinding and reporting to emmaa tests and queries. It also updates the paths JSONL format to include the type of the edge (statements, PybelEdge, RefEdge). Finally it simplifies the English assembly of reported statements by making use of INDRA `make_string_from_sort_key` function.