### PR TITLE
Add better MeSH roots for ontology export

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
         cd ../indralab_web_templates
         pip install .
         cd ../..
-        pip install boto3 jsonpickle pygraphviz fnvhash sqlalchemy inflection pybel==0.15 flask_jwt_extended gilda tweepy nose coverage moto[iam] sqlalchemy_utils termcolor
+        pip install boto3 jsonpickle pygraphviz fnvhash sqlalchemy inflection pybel==0.15 flask_jwt_extended==3.25.0 gilda tweepy nose coverage moto[iam] sqlalchemy_utils termcolor
         pip install --no-dependencies .
         wget "https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.4.0/BioNetGen-2.4.0-Linux.tgz" -O bionetgen.tar.gz -nv
         tar xzf bionetgen.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='emmaa',
       packages=find_packages(),
       install_requires=['indra', 'boto3', 'jsonpickle', 'kappy==4.0.94',
                         'pygraphviz', 'fnvhash', 'sqlalchemy', 'inflection',
-                        'pybel==0.15', 'flask_jwt_extended', 'gilda',
+                        'pybel==0.15', 'flask_jwt_extended==3.25.0', 'gilda',
                         'tweepy'],
       extras_require={'test': ['nose', 'coverage', 'moto[iam]',
                                'sqlalchemy_utils']}


### PR DESCRIPTION
This PR improves the ontology export to include MeSH root nodes that aren't part of the standard structure of MeSH.