### PR TITLE
Add endpoint for getting curated statements in model

### DIFF
--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -463,10 +463,20 @@ def _set_curation(stmt_hash, correct, incorrect):
     return cur
 
 
-def _label_curations(**kwargs):
+def _label_curations(include_partial=False, **kwargs):
     logger.info('Getting curations')
     curations = get_curations(**kwargs)
     logger.info('Labeling curations')
+    if include_partial:
+        correct = {str(c['pa_hash']) for c in curations if
+                   c['tag'] == 'correct'}
+        partial = {str(c['pa_hash']) for c in curations if
+                   c['tag'] in ['act_vs_amt', 'hypothesis'] and
+                   str(c['pa_hash']) not in correct}
+        incorrect = {str(c['pa_hash']) for c in curations if
+                     str(c['pa_hash']) not in correct and
+                     str(c['pa_hash']) not in partial}
+        return correct, incorrect, partial
     correct_tags = ['correct', 'act_vs_amt', 'hypothesis']
     correct = {str(c['pa_hash']) for c in curations if
                c['tag'] in correct_tags}

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -1273,6 +1273,16 @@ def get_statement_evidence_page():
                            is_all_stmts=False,
                            date=date)
 
+@app.route('/curated_statements/<model>')
+def get_curated_statements(model):
+    date = request.args.get('date')
+    if not date:
+        date = get_latest_available_date(model, _default_test(model))
+    stmts = _load_stmts_from_cache(model, date)
+    stmt_hashes = {stmt.get_hash() for stmt in stmts}
+    curation_hashes = {cur['pa_hash'] for cur in get_curations()}
+    return jsonify(sorted(stmt_hashes & curation_hashes))
+
 
 @app.route('/all_statements/<model>')
 def get_all_statements_page(model):


### PR DESCRIPTION
This PR adds a simple endpoint to return a list of statement hashes in an EMMAA model that have been curated.