### PR TITLE
xDD integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,3 +83,4 @@ jobs:
         INDRALAB_USERS_DB: ${{ secrets.INDRALAB_USERS_DB }}
         EMMAADBTEST: ${{ secrets.EMMAADBTEST }}
         EMAIL_SIGN_SECRET: ${{ secrets.EMAIL_SIGN_SECRET }}
+        XDD_API_KEY: ${{ secrets.XDD_API_KEY }}

--- a/doc/modules/index.rst
+++ b/doc/modules/index.rst
@@ -16,4 +16,5 @@ EMMAA modules reference
    readers
    database
    aws_lambda_functions
+   xdd
    util

--- a/doc/modules/xdd.rst
+++ b/doc/modules/xdd.rst
@@ -1,0 +1,10 @@
+xDD client
+==========
+
+.. automodule:: emmaa.xdd
+    :members:
+    :show-inheritance:
+
+.. automodule:: emmaa.xdd.xdd_client
+    :members:
+    :show-inheritance:

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -1181,7 +1181,7 @@ def _get_trid_title(trid):
     if tc:
         title = unpack(tc.content)
         return title
-    tr = db.select_all(db.TextRef, db.TextRef.id == trid)
+    tr = db.select_one(db.TextRef, db.TextRef.id == trid)
     ref_dict = tr.get_ref_dict()
     if 'PMID' in ref_dict:
         pmid = ref_dict['PMID']

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -1193,7 +1193,7 @@ def _get_trid_title(trid):
         if title:
             return title
     if 'DOI' in ref_dict:
-        title = _get_doi_title(doi)
+        title = _get_doi_title(ref_dict['DOI'])
         if title:
             return title
 

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -1173,6 +1173,31 @@ def _get_pmcid_title(pmcid):
     return title
 
 
+def _get_trid_title(trid):
+    db = get_db('primary')
+    tc = db.select_one(db.TextContent,
+                       db.TextContent.text_ref_id == trid,
+                       db.TextContent.text_type == 'title')
+    if tc:
+        title = unpack(tc.content)
+        return title
+    tr = db.select_all(db.TextRef, db.TextRef.id == trid)
+    ref_dict = tr.get_ref_dict()
+    if 'PMID' in ref_dict:
+        pmid = ref_dict['PMID']
+        pmids_to_titles = _get_pmid_titles([pmid])
+        if pmid in pmids_to_titles:
+            return pmids_to_titles[pmid]
+    if 'PMCID' in ref_dict:
+        title = _get_pmcid_title(ref_dict['PMCID'])
+        if title:
+            return title
+    if 'DOI' in ref_dict:
+        title = _get_doi_title(doi)
+        if title:
+            return title
+
+
 def _get_publication_link(text_refs):
     if text_refs.get('PMCID'):
         name = 'PMC'

--- a/emmaa/tests/test_xdd.py
+++ b/emmaa/tests/test_xdd.py
@@ -23,13 +23,13 @@ def test_document_figures():
 
 
 def test_figures_from_query():
-    query = 'ACE2,TMPRSS2'
+    query = 'ATG12,ATG5'
     # Get full result
     fig_list = get_figures_from_query(query)
     assert fig_list
     assert len(fig_list[0]) == 3
     total = len(fig_list)
-    assert total > 90
+    assert total > 15, total
     # Set smaller limit
     fig_list = get_figures_from_query(query, limit=10)
     assert fig_list

--- a/emmaa/tests/test_xdd.py
+++ b/emmaa/tests/test_xdd.py
@@ -1,13 +1,19 @@
+from nose.plugins.attrib import attr
 from emmaa.xdd import get_document_figures, get_figures_from_query
 
 
-def test_document_figures():
-    # Should get results from different paper ID types
+def test_document_figures_doi():
     doi = '10.1101/2020.08.23.20180281'
     fig_list = get_document_figures(doi, 'DOI')
     assert fig_list
     # Should be a list of tuples with title and image bytes
     assert len(fig_list[0]) == 2
+
+
+# This would call database
+@attr('notravis')
+def test_document_figures_other_types():
+    # Should get results from different paper ID types
     trid = 31859624
     fig_list = get_document_figures(trid, 'TRID')
     assert fig_list

--- a/emmaa/tests/test_xdd.py
+++ b/emmaa/tests/test_xdd.py
@@ -2,6 +2,7 @@ from nose.plugins.attrib import attr
 from emmaa.xdd import get_document_figures, get_figures_from_query
 
 
+@attr('nonpublic')
 def test_document_figures_doi():
     doi = '10.1101/2020.08.23.20180281'
     fig_list = get_document_figures(doi, 'DOI')
@@ -11,7 +12,7 @@ def test_document_figures_doi():
 
 
 # This would call database
-@attr('notravis')
+@attr('notravis', 'nonpublic')
 def test_document_figures_other_types():
     # Should get results from different paper ID types
     trid = 31859624
@@ -28,6 +29,7 @@ def test_document_figures_other_types():
     assert len(fig_list[0]) == 2
 
 
+@attr('nonpublic')
 def test_figures_from_query():
     query = 'ATG12,ATG5'
     # Get full result

--- a/emmaa/tests/test_xdd.py
+++ b/emmaa/tests/test_xdd.py
@@ -1,0 +1,42 @@
+from emmaa.xdd import get_document_figures, get_figures_from_query
+
+
+def test_document_figures():
+    # Should get results from different paper ID types
+    doi = '10.1101/2020.08.23.20180281'
+    fig_list = get_document_figures(doi, 'DOI')
+    assert fig_list
+    # Should be a list of tuples with title and image bytes
+    assert len(fig_list[0]) == 2
+    trid = 31859624
+    fig_list = get_document_figures(trid, 'TRID')
+    assert fig_list
+    assert len(fig_list[0]) == 2
+    pmid = '32838361'
+    fig_list = get_document_figures(pmid, 'PMID')
+    assert fig_list
+    assert len(fig_list[0]) == 2
+    pmcid = 'PMC7362813'
+    fig_list = get_document_figures(pmcid, 'PMCID')
+    assert fig_list
+    assert len(fig_list[0]) == 2
+
+
+def test_figures_from_query():
+    query = 'ACE2,TMPRSS2'
+    # Get full result
+    fig_list = get_figures_from_query(query)
+    assert fig_list
+    assert len(fig_list[0]) == 3
+    total = len(fig_list)
+    assert total > 90
+    # Set smaller limit
+    fig_list = get_figures_from_query(query, limit=10)
+    assert fig_list
+    assert len(fig_list[0]) == 3
+    assert len(fig_list) == 10
+    # If limit is larger than total, get total
+    fig_list = get_figures_from_query(query, limit=(total+10))
+    assert fig_list
+    assert len(fig_list[0]) == 3
+    assert len(fig_list) == total

--- a/emmaa/xdd/__init__.py
+++ b/emmaa/xdd/__init__.py
@@ -1,1 +1,3 @@
+"""This modules provides an interface to query xDD content for figures and
+tables."""
 from .xdd_client import get_document_figures, get_figures_from_query

--- a/emmaa/xdd/__init__.py
+++ b/emmaa/xdd/__init__.py
@@ -1,1 +1,1 @@
-from .xdd_client import get_document_figures, get_search_figures
+from .xdd_client import get_document_figures, get_figures_from_query

--- a/emmaa/xdd/__init__.py
+++ b/emmaa/xdd/__init__.py
@@ -1,1 +1,1 @@
-from .xdd_client import get_document_figures
+from .xdd_client import get_document_figures, get_search_figures

--- a/emmaa/xdd/__init__.py
+++ b/emmaa/xdd/__init__.py
@@ -1,0 +1,1 @@
+from .xdd_client import get_document_figures

--- a/emmaa/xdd/xdd_client.py
+++ b/emmaa/xdd/xdd_client.py
@@ -24,7 +24,7 @@ def get_document_objects(doi):
     return objects
 
 
-def get_figure(obj_dict):
+def get_figure_from_document_object(obj_dict):
     txt = obj_dict['header_content']
     url = f"{obj_url}{obj_dict['id']}"
     res = requests.get(url, {'api_key': api_key})
@@ -56,7 +56,7 @@ def get_document_figures(paper_id, paper_id_type):
         return []
     fig_list = []
     for obj in objects:
-        fig_list.append(get_figure(obj))
+        fig_list.append(get_figure_from_document_object(obj))
     return fig_list
 
 

--- a/emmaa/xdd/xdd_client.py
+++ b/emmaa/xdd/xdd_client.py
@@ -13,16 +13,25 @@ query_url = 'https://xdd.wisc.edu/sets/xdd-covid-19/cosmos/api/search'
 
 def get_document_objects(doi):
     """Get a list of figure/table object dictionaries for a given DOI."""
-    res = requests.get(doc_url, params={'doi': doi, 'api_key': api_key})
-    rj = res.json()
-    if 'objects' not in rj:
-        logger.warning(f'Could not get objects for {doi}')
-        if 'error' in rj:
-            logger.warning(rj['error'])
-        return
-    objects = [
-        obj for obj in rj['objects'] if obj['cls'] in ['Figure', 'Table']]
-    return objects
+    logger.info(f'Got a request to get figures for DOI {doi}')
+    # Get first batch of results and find the total number of results
+    rj = send_document_search_request(doi, page=0)
+    if not rj:
+        return []
+    total = rj.get('total', 0)
+    logger.info(f'Got a total of {total} objects')
+    objects = rj['objects']
+    page = 0
+    while len(objects) < total:
+        page += 1
+        rj = send_document_search_request(doi, page=page)
+        if not rj:
+            logger.warning(f'Did not get results for {doi} page {page}')
+            break
+        objects += rj['objects']
+    filtered_objects = [
+        obj for obj in objects if obj['cls'] in ['Figure', 'Table']]
+    return filtered_objects
 
 
 def get_figure_from_document_object(obj_dict):
@@ -126,12 +135,9 @@ def get_figures_from_query(query, limit=None):
     return figures
 
 
-def send_query_search_request(query, page):
-    """Send a request to get one page of results for a query."""
-    logger.info(f'Sending a request for query {query}, page {page}')
-    res = requests.get(
-        query_url,
-        params={'query': query, 'inclusive': True, 'page': page})
+def send_request(url, params):
+    """Send a request and handle potential errors."""
+    res = requests.get(url, params=params)
     try:
         rj = res.json()
         if 'objects' not in rj:
@@ -145,9 +151,23 @@ def send_query_search_request(query, page):
     return rj
 
 
+def send_query_search_request(query, page):
+    """Send a request to get one page of results for a query."""
+    logger.info(f'Sending a request for query {query}, page {page}')
+    return send_request(query_url,
+                        {'query': query, 'inclusive': True, 'page': page})
+
+
+def send_document_search_request(doi, page):
+    """Send a request to get one page of results for a DOI."""
+    logger.info(f'Sending a request for DOI {doi}, page {page}')
+    return send_request(doc_url,
+                        {'doi': doi, 'api_key': api_key, 'page': page})
+
+
 def get_figures_from_query_objects(objects):
     """Get a list of figure titles and their content bytes from a list of
-    object dictionaries (returned from query api).
+    object dictionaries (returned from query api)."""
     figures = []
     for obj in objects:
         for child in obj['children']:

--- a/emmaa/xdd/xdd_client.py
+++ b/emmaa/xdd/xdd_client.py
@@ -101,7 +101,8 @@ def get_figures_from_query(query, limit=None):
     Returns
     -------
     figures : list[tuple]
-        A list of tuples where each tuple is a figure title and bytes content.
+        A list of tuples where each tuple is a link to the paper, a figure
+        title and bytes content.
     """
     logger.info(f'Got a request for query {query} with limit {limit}')
     # Get first batch of results and find the total number of results
@@ -174,8 +175,8 @@ def send_document_search_request(doi, page):
 
 
 def get_figures_from_query_objects(objects):
-    """Get a list of figure titles and their content bytes from a list of
-    object dictionaries (returned from query api)."""
+    """Get a list of paper links, figure titles and their content bytes from
+    a list of object dictionaries (returned from query api)."""
     figures = []
     for obj in objects:
         for child in obj['children']:

--- a/emmaa/xdd/xdd_client.py
+++ b/emmaa/xdd/xdd_client.py
@@ -4,7 +4,7 @@ import logging
 from indra_db import get_db
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 api_key = os.environ.get('XDD_API_KEY')
 doc_url = 'https://xdddev.chtc.io/sets/xdd-covid-19/cosmos/api/document'
 obj_url = 'https://xdddev.chtc.io/sets/xdd-covid-19/cosmos/api/object/'
@@ -160,8 +160,9 @@ def send_request(url, params):
 def send_query_search_request(query, page):
     """Send a request to get one page of results for a query."""
     logger.info(f'Sending a request for query {query}, page {page}')
-    return send_request(query_url,
-                        {'query': query, 'inclusive': True, 'page': page})
+    return send_request(
+        query_url,
+        {'query': query, 'inclusive': True, 'page': page, 'api_key': api_key})
 
 
 def send_document_search_request(doi, page):

--- a/emmaa/xdd/xdd_client.py
+++ b/emmaa/xdd/xdd_client.py
@@ -1,0 +1,40 @@
+import os
+import requests
+from indra_db import get_db
+
+
+api_key = os.environ.get('XDD_API_KEY')
+doc_url = 'https://xdddev.chtc.io/sets/xdd-covid-19/cosmos/api/document'
+obj_url = 'https://xdddev.chtc.io/sets/xdd-covid-19/cosmos/api/object/'
+
+
+def get_document_objects(doi):
+    res = requests.get(doc_url, params={'doi': doi, 'api_key': api_key})
+    rj = res.json()
+    if 'objects' not in rj:
+        return
+    objects = [
+        obj for obj in rj['objects'] if obj['cls'] in ['Figure', 'Table']]
+    return objects
+
+
+def get_figure(obj_dict):
+    txt = obj_dict['header_content']
+    url = f"{obj_url}{obj_dict['id']}"
+    res = requests.get(url, {'api_key': api_key})
+    rj = res.json()
+    if 'objects' not in rj:
+        return txt, None
+    b = rj['objects'][0]['children'][0]['bytes']
+    return txt, b
+
+
+def get_document_figures(paper_id, paper_id_type):
+    if paper_id_type == 'DOI':
+        doi = paper_id
+
+    objects = get_document_objects(doi)
+    fig_list = []
+    for obj in objects:
+        fig_list.append(get_figure(obj))
+    return fig_list

--- a/emmaa/xdd/xdd_client.py
+++ b/emmaa/xdd/xdd_client.py
@@ -181,5 +181,8 @@ def get_figures_from_query_objects(objects):
             if child['cls'] in ['Figure', 'Table']:
                 txt = child['header_content']
                 b = child['bytes']
-                figures.append((txt, b))
+                urls = set()
+                for link in obj['bibjson']['link']:
+                    urls.add(link['url'])
+                figures.append((urls, txt, b))
     return figures

--- a/emmaa/xdd/xdd_client.py
+++ b/emmaa/xdd/xdd_client.py
@@ -75,6 +75,8 @@ def get_document_figures(paper_id, paper_id_type):
         ref_dict = tr.get_ref_dict()
         doi = ref_dict.get('DOI')
     if not doi:
+        logger.warning(f'Could not get DOI from {paper_id_type} {paper_id}, '
+                       'returning 0 figures and tables')
         return []
     objects = get_document_objects(doi)
     if not objects:
@@ -82,6 +84,7 @@ def get_document_figures(paper_id, paper_id_type):
     figures = []
     for obj in objects:
         figures.append(get_figure_from_document_object(obj))
+    logger.info(f'Returning {len(figures)} figures and tables.')
     return figures
 
 
@@ -122,7 +125,9 @@ def get_figures_from_query(query, limit=None):
             new_figures = get_figures_from_query_objects(rj['objects'])
             figures += new_figures
             objects += rj['objects']
-        return figures[: limit]
+        figures = figures[: limit]
+        logger.info(f'Returning {len(figures)} figures and tables.')
+        return figures
     # There's no limit so we want to get all objects before getting figures
     while len(objects) < total:
         page += 1
@@ -132,6 +137,7 @@ def get_figures_from_query(query, limit=None):
             break
         objects += rj['objects']
     figures = get_figures_from_query_objects(objects)
+    logger.info(f'Returning {len(figures)} figures and tables.')
     return figures
 
 

--- a/emmaa/xdd/xdd_client.py
+++ b/emmaa/xdd/xdd_client.py
@@ -147,7 +147,8 @@ def send_request(url, params):
     try:
         rj = res.json()
         if 'objects' not in rj:
-            logger.warning(f'Could not get objects for {query}')
+            params.pop('api_key')
+            logger.warning(f'Could not get objects for {params}')
             if 'error' in rj:
                 logger.warning(rj['error'])
             return

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -37,6 +37,7 @@ from emmaa.subscription.email_util import verify_email_signature,\
 from emmaa.queries import PathProperty, get_agent_from_text, GroundingError, \
     DynamicProperty, OpenSearchQuery, Query
 from emmaa.xdd import get_document_figures
+from emmaa.analyze_tests_results import _get_trid_title
 
 from indralab_auth_tools.auth import auth, config_auth, resolve_auth
 from indralab_web_templates.path_templates import path_temps
@@ -592,24 +593,16 @@ def get_new_papers(model, model_stats, date):
     return new_papers
 
 
-def _get_trid_title_from_db(trid):
-    db = get_db('primary')
-    tc = db.select_one(db.TextContent,
-                       db.TextContent.text_ref_id == trid,
-                       db.TextContent.text_type == 'title')
-    if tc:
-        title = unpack(tc.content)
-        return title
-
-
 def _get_title(paper_id, model_stats):
     id_to_title = model_stats['paper_summary'].get('paper_titles')
     title = None
     if id_to_title:
         title = id_to_title.get(str(paper_id))
     if title is None:
-        title = _get_trid_title_from_db(paper_id)
-    return title
+        title = _get_trid_title(paper_id)
+    if title:
+        return title
+    return "Title not available"
 
 
 def _get_paper_title_tuple(paper_id, model_stats, date):

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -36,7 +36,7 @@ from emmaa.subscription.email_util import verify_email_signature,\
     register_email_unsubscribe, get_email_subscriptions
 from emmaa.queries import PathProperty, get_agent_from_text, GroundingError, \
     DynamicProperty, OpenSearchQuery, Query
-from emmaa.xdd import get_document_figures
+from emmaa.xdd import get_document_figures, get_search_figures
 from emmaa.analyze_tests_results import _get_trid_title
 
 from indralab_auth_tools.auth import auth, config_auth, resolve_auth
@@ -1284,6 +1284,8 @@ def get_statement_evidence_page():
     else:
         stmt_json = json.dumps(stmts[0].to_json(), indent=1)
         return Response(stmt_json, mimetype='application/json')
+    query = ' '.join([ag.name for ag in stmts[0].agent_list()])
+    fig_list = get_search_figures(query)
     return render_template('evidence_template.html',
                            stmt_rows=stmt_rows,
                            model=model,
@@ -1292,7 +1294,8 @@ def get_statement_evidence_page():
                            table_title='Statement Evidence and Curation',
                            msg=None,
                            is_all_stmts=False,
-                           date=date)
+                           date=date,
+                           fig_list=fig_list)
 
 
 @app.route('/curated_statements/<model>')

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -928,16 +928,19 @@ def get_paper_statements(model):
             trid = str(trids[0])
         else:
             abort(Response(f'Invalid paper ID: {paper_id}', 400))
-    all_stmts = _load_stmts_from_cache(model, date)
     model_stats = _load_model_stats_from_cache(model, date)
     raw_paper_ids = model_stats['paper_summary']['raw_paper_ids']
     paper_hashes = model_stats['paper_summary']['stmts_by_paper'].get(trid, [])
-    paper_stmts = [stmt for stmt in all_stmts
-                   if stmt.get_hash() in paper_hashes]
-    updated_stmts = [filter_evidence(stmt, trid, 'TRID')
-                     for stmt in paper_stmts]
-    updated_stmts = sorted(updated_stmts, key=lambda x: len(x.evidence),
-                           reverse=True)
+    if paper_hashes:
+        all_stmts = _load_stmts_from_cache(model, date)
+        paper_stmts = [stmt for stmt in all_stmts
+                       if stmt.get_hash() in paper_hashes]
+        updated_stmts = [filter_evidence(stmt, trid, 'TRID')
+                         for stmt in paper_stmts]
+        updated_stmts = sorted(updated_stmts, key=lambda x: len(x.evidence),
+                               reverse=True)
+    else:
+        updated_stmts = []
     if display_format == 'json':
         resp = {'statements': stmts_to_json(updated_stmts)}
         return resp

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -36,7 +36,7 @@ from emmaa.subscription.email_util import verify_email_signature,\
     register_email_unsubscribe, get_email_subscriptions
 from emmaa.queries import PathProperty, get_agent_from_text, GroundingError, \
     DynamicProperty, OpenSearchQuery, Query
-from emmaa.xdd import get_document_figures, get_search_figures
+from emmaa.xdd import get_document_figures, get_figures_from_query
 from emmaa.analyze_tests_results import _get_trid_title
 
 from indralab_auth_tools.auth import auth, config_auth, resolve_auth
@@ -1284,8 +1284,8 @@ def get_statement_evidence_page():
     else:
         stmt_json = json.dumps(stmts[0].to_json(), indent=1)
         return Response(stmt_json, mimetype='application/json')
-    query = ' '.join([ag.name for ag in stmts[0].agent_list()])
-    fig_list = get_search_figures(query)
+    query = ','.join([ag.name for ag in stmts[0].agent_list()])
+    fig_list = get_figures_from_query(query, limit=None)
     return render_template('evidence_template.html',
                            stmt_rows=stmt_rows,
                            model=model,

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -964,7 +964,7 @@ def get_paper_statements(model):
                                  trid, 'TRID')
         stmt_rows.append(stmt_row)
     if not stmt_rows:
-        if trid in raw_paper_ids:
+        if int(trid) in raw_paper_ids:
             stmt_rows = 'We did not get assembled statements from this paper'
         else:
             stmt_rows = 'We did not process this paper in this model'

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -36,6 +36,7 @@ from emmaa.subscription.email_util import verify_email_signature,\
     register_email_unsubscribe, get_email_subscriptions
 from emmaa.queries import PathProperty, get_agent_from_text, GroundingError, \
     DynamicProperty, OpenSearchQuery, Query
+from emmaa.xdd import get_document_figures
 
 from indralab_auth_tools.auth import auth, config_auth, resolve_auth
 from indralab_web_templates.path_templates import path_temps
@@ -915,7 +916,7 @@ def get_paper_statements(model):
     paper_id = request.args.get('paper_id')
     paper_id_type = request.args.get('paper_id_type')
     display_format = request.args.get('format', 'html')
-    if paper_id_type == 'TRID':
+    if paper_id_type.upper() == 'TRID':
         trid = paper_id
     else:
         db = get_db('primary')
@@ -957,6 +958,8 @@ def get_paper_statements(model):
         stmt_rows.append(stmt_row)
     paper_title = _get_title(trid, model_stats)
     table_title = f'Statements from the paper "{paper_title}"'
+
+    fig_list = get_document_figures(paper_id, paper_id_type)
     return render_template('evidence_template.html',
                            stmt_rows=stmt_rows,
                            model=model,
@@ -964,7 +967,8 @@ def get_paper_statements(model):
                            table_title=table_title,
                            date=date,
                            paper_id=paper_id,
-                           paper_id_type=paper_id_type)
+                           paper_id_type=paper_id_type,
+                           fig_list=fig_list)
 
 
 @app.route('/tests/<model>')

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -930,7 +930,7 @@ def get_paper_statements(model):
             abort(Response(f'Invalid paper ID: {paper_id}', 400))
     all_stmts = _load_stmts_from_cache(model, date)
     model_stats = _load_model_stats_from_cache(model, date)
-    all_papers = model_stats['paper_summary']['raw_paper_ids']
+    raw_paper_ids = model_stats['paper_summary']['raw_paper_ids']
     paper_hashes = model_stats['paper_summary']['stmts_by_paper'].get(trid, [])
     paper_stmts = [stmt for stmt in all_stmts
                    if stmt.get_hash() in paper_hashes]

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -930,7 +930,8 @@ def get_paper_statements(model):
             abort(Response(f'Invalid paper ID: {paper_id}', 400))
     all_stmts = _load_stmts_from_cache(model, date)
     model_stats = _load_model_stats_from_cache(model, date)
-    paper_hashes = model_stats['paper_summary']['stmts_by_paper'][trid]
+    all_papers = model_stats['paper_summary']['raw_paper_ids']
+    paper_hashes = model_stats['paper_summary']['stmts_by_paper'].get(trid, [])
     paper_stmts = [stmt for stmt in all_stmts
                    if stmt.get_hash() in paper_hashes]
     updated_stmts = [filter_evidence(stmt, trid, 'TRID')
@@ -959,6 +960,11 @@ def get_paper_statements(model):
                                  date, None, None, cur_dict, with_evid,
                                  trid, 'TRID')
         stmt_rows.append(stmt_row)
+    if not stmt_rows:
+        if trid in raw_paper_ids:
+            stmt_rows = 'We did not get assembled statements from this paper'
+        else:
+            stmt_rows = 'We did not process this paper in this model'
     paper_title = _get_title(trid, model_stats)
     table_title = f'Statements from the paper "{paper_title}"'
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -973,7 +973,8 @@ def get_paper_statements(model):
                            date=date,
                            paper_id=paper_id,
                            paper_id_type=paper_id_type,
-                           fig_list=fig_list)
+                           fig_list=fig_list,
+                           tabs=True)
 
 
 @app.route('/tests/<model>')
@@ -1274,8 +1275,14 @@ def get_statement_evidence_page():
         cur_counts = _count_curations(curations, stmts_by_hash)
         if len(stmts) > 1:
             with_evid = False
+            tabs = False
+            fig_list = None
         else:
             with_evid = True
+            tabs = True
+            query = ','.join(
+                [ag.name for ag in stmts[0].agent_list() if ag is not None])
+            fig_list = get_figures_from_query(query, limit=None)
         for stmt in stmts:
             stmt_row = _get_stmt_row(stmt, source, model, cur_counts, date,
                                      test_corpus, stmt_counts_dict,
@@ -1284,8 +1291,6 @@ def get_statement_evidence_page():
     else:
         stmt_json = json.dumps(stmts[0].to_json(), indent=1)
         return Response(stmt_json, mimetype='application/json')
-    query = ','.join([ag.name for ag in stmts[0].agent_list()])
-    fig_list = get_figures_from_query(query, limit=None)
     return render_template('evidence_template.html',
                            stmt_rows=stmt_rows,
                            model=model,
@@ -1295,7 +1300,8 @@ def get_statement_evidence_page():
                            msg=None,
                            is_all_stmts=False,
                            date=date,
-                           fig_list=fig_list)
+                           fig_list=fig_list,
+                           tabs=tabs)
 
 
 @app.route('/curated_statements/<model>')
@@ -1402,7 +1408,8 @@ def get_all_statements_page(model):
                            filter_curated=filter_curated,
                            sort_by=sort_by,
                            link=link,
-                           date=date)
+                           date=date,
+                           tabs=False)
 
 
 @app.route('/query/<model>')

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -108,8 +108,9 @@
         {{ fig_title }}
         <br>
         {% endif %}
-        <img src="data:image/jpg;base64, {{ fig_bytes }}">
+        <img src="data:image/jpg;base64, {{ fig_bytes }}" style="width: 50vw;">
         <br>
+        <hr class="solid" style="border-top: solid 5px;">
       {% endfor %}
     {% else %}
       {% if source == 'paper' %}

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -98,15 +98,19 @@
   
     </div>
     <div class="tab-pane fade" id="nav-figures" role="tabpanel" aria-labelledby="nav-figures-tab">  
-    {% for fig_title, fig_bytes in fig_list %}
-      <br>
-      {% if fig_title %}
-      {{ fig_title }}
-      <br>
-      {% endif %}
-      <img src="data:image/jpg;base64, {{ fig_bytes }}">
-      <br>
-    {% endfor %}
+    {% if fig_list %}
+      {% for fig_title, fig_bytes in fig_list %}
+        <br>
+        {% if fig_title %}
+        {{ fig_title }}
+        <br>
+        {% endif %}
+        <img src="data:image/jpg;base64, {{ fig_bytes }}">
+        <br>
+      {% endfor %}
+    {% else %}
+      "Could not get any figures and tables for this paper"
+    {% endif %}
   {% endif %}
 
 </div>

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -1,5 +1,6 @@
 {% extends "emmaa_page_template.html" %}
 {% from "path_macros.html" import path_table, path_card %}
+{% from "tabs/figures_tab.html" import figure_tab %}
 
 {% block additional_scripts %}
 <style>
@@ -84,40 +85,22 @@
   {% set url = url_for('get_statement_by_paper', model=model, paper_id=paper_id, paper_id_type=paper_id_type, date=date, hash_val='') %}
   {% endif %}
   {% if tabs %}
-  <div class="container nav-container">
-    <nav>
-      <div class="nav nav-tabs" id="nav-tab" role="tablist">
-        <a class="nav-item nav-link active" id="nav-stmts-tab" data-toggle="tab" href="#nav-stmts" role="tab" aria-controls="nav-stmts" aria-selected="true">Statements</a>
-        <a class="nav-item nav-link" id="nav-figures-tab" data-toggle="tab" href="#nav-figures" role="tab" aria-controls="nav-figures" aria-selected="false">Figures</a>
-      </div>
-    </nav>
-  </div>
-  <div class="tab-content" id="nav-tabContent">
-    <div class="tab-pane fade show active" id="nav-stmts" role="tabpanel" aria-labelledby="nav-stmts-tab">
-    {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
-  
+    <div class="container nav-container">
+      <nav>
+        <div class="nav nav-tabs" id="nav-tab" role="tablist">
+          <a class="nav-item nav-link active" id="nav-stmts-tab" data-toggle="tab" href="#nav-stmts" role="tab" aria-controls="nav-stmts" aria-selected="true">Statements</a>
+          <a class="nav-item nav-link" id="nav-figures-tab" data-toggle="tab" href="#nav-figures" role="tab" aria-controls="nav-figures" aria-selected="false">Figures</a>
+        </div>
+      </nav>
     </div>
-    <div class="tab-pane fade" id="nav-figures" role="tabpanel" aria-labelledby="nav-figures-tab">  
-    {% if fig_list %}
-      {% for fig_title, fig_bytes in fig_list %}
-        <br>
-        {% if fig_title %}
-        {{ fig_title }}
-        <br>
-        {% endif %}
-        <img src="data:image/jpg;base64, {{ fig_bytes }}" style="width: 50vw;">
-        <br>
-        <hr class="solid" style="border-top: solid 5px;">
-      {% endfor %}
-    {% else %}
-      {% if source == 'paper' %}
-      Could not get any figures and tables for this paper
-      {% else %}
-      Could not get any figures and tables for this statement
-      {% endif %}
-    {% endif %}
+    <div class="tab-content" id="nav-tabContent">
+      <div class="tab-pane fade show active" id="nav-stmts" role="tabpanel" aria-labelledby="nav-stmts-tab">
+      {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
+      </div>
+      <div class="tab-pane fade" id="nav-figures" role="tabpanel" aria-labelledby="nav-figures-tab">  
+      {{ figure_tab(fig_list, source) }}
   {% else %}
-  {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
+    {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
   {% endif %}
 </div>
 <script>

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -74,7 +74,11 @@
       </div>
     </div>
   </div>
-{% endif %}
+<div class="container" id="app">
+  {% set url = url_for('get_statement_by_hash_model', model=model, date=date, hash_val='') %}
+  {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
+</div>
+{% else %}
 <div class="container" id="app">
   {% if source == 'model_statement' %}
   {% set url = url_for('get_statement_by_hash_model', model=model, date=date, hash_val='') %}
@@ -114,7 +118,7 @@
       Could not get any figures and tables for this statement
       {% endif %}
     {% endif %}
-
+{% endif %}
 </div>
 <script>
   Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, date=date, hash_val='') }}";

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -109,7 +109,7 @@
         <br>
       {% endfor %}
     {% else %}
-      "Could not get any figures and tables for this paper"
+      Could not get any figures and tables for this paper
     {% endif %}
   {% endif %}
 

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -78,12 +78,11 @@
 <div class="container" id="app">
   {% if source == 'model_statement' %}
   {% set url = url_for('get_statement_by_hash_model', model=model, date=date, hash_val='') %}
-  {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
   {% elif source == 'test' %}
   {% set url = url_for('get_tests_by_hash', test_corpus=test_corpus, hash_val='') %}
-  {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
   {% elif source == 'paper' %}
   {% set url = url_for('get_statement_by_paper', model=model, paper_id=paper_id, paper_id_type=paper_id_type, date=date, hash_val='') %}
+  {% endif %}
   <div class="container nav-container">
     <nav>
       <div class="nav nav-tabs" id="nav-tab" role="tablist">
@@ -109,9 +108,12 @@
         <br>
       {% endfor %}
     {% else %}
+      {% if source == 'paper' %}
       Could not get any figures and tables for this paper
+      {% else %}
+      Could not get any figures and tables for this statement
+      {% endif %}
     {% endif %}
-  {% endif %}
 
 </div>
 <script>

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -74,11 +74,7 @@
       </div>
     </div>
   </div>
-<div class="container" id="app">
-  {% set url = url_for('get_statement_by_hash_model', model=model, date=date, hash_val='') %}
-  {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
-</div>
-{% else %}
+{% endif %}
 <div class="container" id="app">
   {% if source == 'model_statement' %}
   {% set url = url_for('get_statement_by_hash_model', model=model, date=date, hash_val='') %}
@@ -87,6 +83,7 @@
   {% elif source == 'paper' %}
   {% set url = url_for('get_statement_by_paper', model=model, paper_id=paper_id, paper_id_type=paper_id_type, date=date, hash_val='') %}
   {% endif %}
+  {% if tabs %}
   <div class="container nav-container">
     <nav>
       <div class="nav nav-tabs" id="nav-tab" role="tablist">
@@ -119,7 +116,9 @@
       Could not get any figures and tables for this statement
       {% endif %}
     {% endif %}
-{% endif %}
+  {% else %}
+  {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
+  {% endif %}
 </div>
 <script>
   Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, date=date, hash_val='') }}";

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -78,12 +78,37 @@
 <div class="container" id="app">
   {% if source == 'model_statement' %}
   {% set url = url_for('get_statement_by_hash_model', model=model, date=date, hash_val='') %}
+  {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
   {% elif source == 'test' %}
   {% set url = url_for('get_tests_by_hash', test_corpus=test_corpus, hash_val='') %}
+  {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
   {% elif source == 'paper' %}
   {% set url = url_for('get_statement_by_paper', model=model, paper_id=paper_id, paper_id_type=paper_id_type, date=date, hash_val='') %}
+  <div class="container nav-container">
+    <nav>
+      <div class="nav nav-tabs" id="nav-tab" role="tablist">
+        <a class="nav-item nav-link active" id="nav-stmts-tab" data-toggle="tab" href="#nav-stmts" role="tab" aria-controls="nav-stmts" aria-selected="true">Statements</a>
+        <a class="nav-item nav-link" id="nav-figures-tab" data-toggle="tab" href="#nav-figures" role="tab" aria-controls="nav-figures" aria-selected="false">Figures</a>
+      </div>
+    </nav>
+  </div>
+  <div class="tab-content" id="nav-tabContent">
+    <div class="tab-pane fade show active" id="nav-stmts" role="tabpanel" aria-labelledby="nav-stmts-tab">
+    {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
+  
+    </div>
+    <div class="tab-pane fade" id="nav-figures" role="tabpanel" aria-labelledby="nav-figures-tab">  
+    {% for fig_title, fig_bytes in fig_list %}
+      <br>
+      {% if fig_title %}
+      {{ fig_title }}
+      <br>
+      {% endif %}
+      <img src="data:image/jpg;base64, {{ fig_bytes }}">
+      <br>
+    {% endfor %}
   {% endif %}
-  {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
+
 </div>
 <script>
   Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, date=date, hash_val='') }}";

--- a/emmaa_service/templates/tabs/figures_tab.html
+++ b/emmaa_service/templates/tabs/figures_tab.html
@@ -2,7 +2,16 @@
 
 {% macro figure_tab(fig_list, source) -%}
   {% if fig_list %}
-    {% for fig_title, fig_bytes in fig_list %}
+    {% for figure in fig_list %}
+      {% if figure|length == 3 %}
+        {% set urls, fig_title, fig_bytes = figure %}
+        {% for url in urls %}
+          <a href="{{ url }}">View paper</a>
+        {% endfor %}
+        <br>
+      {% else %}
+        {% set fig_title, fig_bytes = figure %}
+      {% endif %}
       <br>
       {% if fig_title %}
       {{ fig_title }}

--- a/emmaa_service/templates/tabs/figures_tab.html
+++ b/emmaa_service/templates/tabs/figures_tab.html
@@ -8,7 +8,7 @@
       {{ fig_title }}
       <br>
       {% endif %}
-      <img src="data:image/jpg;base64, {{ fig_bytes }}" style="width: 50vw;">
+      <img src="data:image/jpg;base64, {{ fig_bytes }}" style="max-width: 50vw; max-height: 60vh;">
       <br>
       <hr class="solid" style="border-top: solid 5px;">
     {% endfor %}

--- a/emmaa_service/templates/tabs/figures_tab.html
+++ b/emmaa_service/templates/tabs/figures_tab.html
@@ -1,0 +1,22 @@
+{% from "path_macros.html" import path_card %}
+
+{% macro figure_tab(fig_list, source) -%}
+  {% if fig_list %}
+    {% for fig_title, fig_bytes in fig_list %}
+      <br>
+      {% if fig_title %}
+      {{ fig_title }}
+      <br>
+      {% endif %}
+      <img src="data:image/jpg;base64, {{ fig_bytes }}" style="width: 50vw;">
+      <br>
+      <hr class="solid" style="border-top: solid 5px;">
+    {% endfor %}
+  {% else %}
+    {% if source == 'paper' %}
+      Could not get any figures and tables for this paper
+    {% else %}
+      Could not get any figures and tables for this statement
+    {% endif %}
+  {% endif %}
+{%- endmacro %}


### PR DESCRIPTION
This PR enables retrieving figures and tables from xDD content and displaying them on EMMAA dashboard.

- xDD client that supports two main types of queries: document based (provide a paper ID of any type) and entity based (provide any agent name or comma-separated names)
- New tab on statements from paper page that shows all figures and tables extracted from that paper.
- New tab on statements evidence page that shows all figures and tables returned by querying for statement's agents names.