### PR TITLE
Model to tests

### DIFF
--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -838,15 +838,16 @@ def update_model_manager_on_s3(model_name, bucket=EMMAA_BUCKET_NAME):
 
 
 def model_to_tests(model_name, upload=True, bucket=EMMAA_BUCKET_NAME):
-    em = EmmaaModel.load_from_s3(model_name, bucket=bucket)
-    em.run_assembly()
-    tests = [StatementCheckingTest(stmt) for stmt in em.assembled_stmts if
+    """Create StatementCheckingTests from model statements."""
+    stmts, _ = get_assembled_statements(model_name, bucket=bucket)
+    config = load_config_from_s3(model_name, bucket=bucket)
+    tests = [StatementCheckingTest(stmt) for stmt in stmts if
              all(stmt.agent_list())]
     date_str = make_date_str()
     test_description = (
-        f'These tests were generated from the {em.human_readable_name} '
-        f'on {date_str[:10]}')
-    test_name = f'{em.human_readable_name} model test corpus'
+        f'These tests were generated from the '
+        f'{config.get("human_readable_name")} on {date_str[:10]}')
+    test_name = f'{config.get("human_readable_name")} model test corpus'
     test_dict = {'test_data': {'description': test_description,
                                'name': test_name},
                  'tests': tests}

--- a/emmaa/tests/test_s3.py
+++ b/emmaa/tests/test_s3.py
@@ -266,12 +266,13 @@ def test_save_load_update_model_manager():
     assert find_number_of_files_on_s3(
         TEST_BUCKET_NAME, 'results/test/model_manager_', '.pkl') == 2
 
+
 @mock_s3
 def test_model_to_tests():
     # Local imports are recommended when using moto
     from emmaa.model_tests import model_to_tests, load_tests_from_s3, \
         StatementCheckingTest
-    client = setup_bucket(add_model=True)
+    client = setup_bucket(add_model=True, add_mm=True)
     test_dict = model_to_tests('test', bucket=TEST_BUCKET_NAME)
     assert isinstance(test_dict, dict)
     assert 'test_data' in test_dict


### PR DESCRIPTION
This PR updates `model_to_tests` function to load assembled statements instead of reassembling them to create tests.