### PR TITLE
Use the bioresolver to look up additional entity metadata

### DIFF
--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -1899,7 +1899,8 @@ def entity_info(model):
     rv = {'url': url}
     bioresolver_json = _lookup_bioresolver(namespace, identifier)
     if bioresolver_json:
-        rv.update(bioresolver_json)  # TODO how is best to organize this?
+        rv['name'] = bioresolver_json.get('name')
+        rv['definition'] = bioresolver_json.get('definition')
     return rv
 
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -1895,7 +1895,22 @@ def entity_info(model):
     namespace = request.args.get('namespace')
     identifier = request.args.get('id')
     url = get_identifiers_url(namespace, identifier)
-    return {'url': url}
+    rv = {'url': url}
+    bioresolver_json = _lookup_bioresolver(namespace, identifier)
+    if bioresolver_json:
+        rv.update(bioresolver_json)  # TODO how is best to organize this?
+    return rv
+
+
+def _lookup_bioresolver(prefix: str, identifier: str):
+    url = get_config(‘ENTITY_RESOLVER_URL’)
+    if url is None:
+        return
+    res = requests.get(f'{url}/resolve/{prefix}:{identifier}')
+    res_json = res.json()
+    if not res_json['success']:
+        return  # there was a problem looking up CURIE in the bioresolver
+    return res_json
 
 
 if __name__ == '__main__':

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -3,6 +3,7 @@ import json
 import boto3
 import logging
 import argparse
+import requests
 from datetime import datetime, timedelta
 from botocore.exceptions import ClientError
 from flask import abort, Flask, request, Response, render_template, jsonify,\
@@ -1903,7 +1904,7 @@ def entity_info(model):
 
 
 def _lookup_bioresolver(prefix: str, identifier: str):
-    url = get_config(‘ENTITY_RESOLVER_URL’)
+    url = get_config('ENTITY_RESOLVER_URL')
     if url is None:
         return
     res = requests.get(f'{url}/resolve/{prefix}:{identifier}')

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='emmaa',
       packages=find_packages(),
       install_requires=['indra', 'boto3', 'jsonpickle', 'kappy==4.0.94',
                         'pygraphviz', 'fnvhash', 'sqlalchemy<1.4',
-                        'inflection', 'pybel==0.15',
+                        'inflection', 'pybel==0.15', 'requests',
                         'flask_jwt_extended==3.25.0', 'gilda', 'tweepy'],
       extras_require={'test': ['nose', 'coverage', 'moto[iam]',
                                'sqlalchemy_utils']}

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='emmaa',
       packages=find_packages(),
       install_requires=['indra', 'boto3', 'jsonpickle', 'kappy==4.0.94',
                         'pygraphviz', 'fnvhash', 'sqlalchemy<1.4',
-                        'inflection', 'pybel==0.15', 'requests',
+                        'inflection', 'pybel==0.15',
                         'flask_jwt_extended==3.25.0', 'gilda', 'tweepy'],
       extras_require={'test': ['nose', 'coverage', 'moto[iam]',
                                'sqlalchemy_utils']}


### PR DESCRIPTION
This PR extends the `emmaa.api.entity_info()` function to use the Bioresolver web service to look up the name, definition, alternative provider URLs, and other metadata about the entity. It assumes the base URl for the bioresolver service is stored in the INDRA configuration such that it can be looked up with `indra.config.get_config('ENTITY_RESOLVER_URL')`

questions:
- should all metadata be returned? Currently this just updates the returned dictionary with everything from the Bioresolver's response (this includes some extra data that isn't necessary, like the success message)
- should the metadata go inside a deeper dictionary? This is more of a question on whether the logic for navigating this dictionary should be done on the frontend or pre-organized in the backend