### PR TITLE
EMMAA Statements metadata

### DIFF
--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -2,6 +2,8 @@ import logging
 import jsonpickle
 from collections import defaultdict
 from emmaa.model import load_stmts_from_s3
+from emmaa.statements import filter_emmaa_stmts_by_tag, \
+    filter_indra_stmts_by_tag
 from emmaa.model_tests import load_model_manager_from_s3
 from emmaa.util import find_latest_s3_file, find_nth_latest_s3_file, \
     strip_out_date, EMMAA_BUCKET_NAME, load_json_from_s3, save_json_to_s3, \
@@ -51,7 +53,7 @@ class Round(object):
 
     @classmethod
     def load_from_s3_key(cls, key):
-        raise NotImplementedError("Method must be implemented in child class.")        
+        raise NotImplementedError("Method must be implemented in child class.")
 
     def get_english_statement(self, stmt):
         ea = EnglishAssembler([stmt])
@@ -141,6 +143,11 @@ class ModelRound(Round):
         estmts = None
         if load_estmts:
             estmts, _ = load_stmts_from_s3(mm.model.name, bucket)
+        if mm.model.reading_config.get('filter'):
+            allowed_tags = mm.model.reading_config['filter']['allowed_tags']
+            statements = filter_indra_stmts_by_tag(statements, allowed_tags)
+            if estmts:
+                estmts = filter_emmaa_stmts_by_tag(estmts, allowed_tags)
         return cls(statements, date_str, paper_ids, paper_id_type, estmts)
 
     def get_total_statements(self):

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -2,8 +2,8 @@ import logging
 import jsonpickle
 from collections import defaultdict
 from emmaa.model import load_stmts_from_s3
-from emmaa.statements import filter_emmaa_stmts_by_tag, \
-    filter_indra_stmts_by_tag
+from emmaa.statements import filter_emmaa_stmts_by_metadata, \
+    filter_indra_stmts_by_metadata
 from emmaa.model_tests import load_model_manager_from_s3
 from emmaa.util import find_latest_s3_file, find_nth_latest_s3_file, \
     strip_out_date, EMMAA_BUCKET_NAME, load_json_from_s3, save_json_to_s3, \
@@ -144,10 +144,12 @@ class ModelRound(Round):
         if load_estmts:
             estmts, _ = load_stmts_from_s3(mm.model.name, bucket)
         if mm.model.reading_config.get('filter'):
-            allowed_tags = mm.model.reading_config['filter']['allowed_tags']
-            statements = filter_indra_stmts_by_tag(statements, allowed_tags)
+            conditions = mm.model.reading_config['filter']['conditions']
+            evid_policy = mm.model.reading_config['filter']['evid_policy']
+            statements = filter_indra_stmts_by_metadata(
+                statements, conditions, evid_policy)
             if estmts:
-                estmts = filter_emmaa_stmts_by_tag(estmts, allowed_tags)
+                estmts = filter_emmaa_stmts_by_metadata(estmts, conditions)
         return cls(statements, date_str, paper_ids, paper_id_type, estmts)
 
     def get_total_statements(self):

--- a/emmaa/filter_functions.py
+++ b/emmaa/filter_functions.py
@@ -1,24 +1,50 @@
 from indra.tools import assemble_corpus as ac
 
 
-filter_functions = {}
+node_filter_functions = {}
+edge_filter_functions = {}
 
 
-def register_filter(function):
+def register_filter(filter_type):
+    """Decorator to register node or edge filter functions.
+
+    A node filter function should take an agent as an argument and return True
+    if the agent is allowed to be in a path and False otherwise.
+
+    An edge filter function should take three (graph, source, target - for
+    DiGraph) or three (graph, source, target, key -  for MultiDiGraph)
+    parameters and return True if the edge should be in the graph and False
+    otherwise.
     """
-    Decorator to register a function as a filter for tests.
+    def register(function):
+        if filter_type == 'node':
+            func_dict = node_filter_functions
+        elif filter_type == 'edge':
+            func_dict = edge_filter_functions
+        func_dict[function.__name__] = function
+        return function
+    return register
 
-    A function should take an agent as an argument and return True if the agent
-    is allowed to be in a path and False otherwise.
-    """
-    filter_functions[function.__name__] = function
-    return function
 
-
-@register_filter
+@register_filter('node')
 def filter_chem_mesh_go(agent):
     """Filter ungrounded agents and agents grounded to MESH, CHEBI, GO unless
     also grounded to HMDB.
     """
     gr = agent.get_grounding()
     return gr[0] not in {'MESH', 'CHEBI', 'GO', None}
+
+
+@register_filter('edge')
+def filter_to_internal_edges(g, u, v, *args):
+    """Return True if an edge is internal. NOTE it returns True if any of the
+    statements associated with an edge is internal.
+    """
+    if args:
+        edge = g[u][v][args[0]]
+    else:
+        edge = g[u][v]
+    for stmts_dict in edge['statements']:
+        if stmts_dict['internal']:
+            return True
+    return False

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -25,7 +25,7 @@ from emmaa.util import make_date_str, find_latest_s3_file, strip_out_date, \
     EMMAA_BUCKET_NAME, find_nth_latest_s3_file, load_pickle_from_s3, \
     save_pickle_to_s3, load_json_from_s3, save_json_to_s3, \
     load_gzip_json_from_s3, get_s3_client
-from emmaa.statements import to_emmaa_stmts
+from emmaa.statements import to_emmaa_stmts, is_internal
 
 
 logger = logging.getLogger(__name__)
@@ -337,7 +337,7 @@ class EmmaaModel(object):
         logger.info('Loading Statements from %s Disease Map' % map_name)
         sp = process_from_web(filenames=filenames, map_name=map_name)
         new_estmts = to_emmaa_stmts(
-            sp.statements, datetime.datetime.now(), [], 'internal')
+            sp.statements, datetime.datetime.now(), [], {'internal': True})
         logger.info('Got %d EMMAA Statements from %s Disease Map' %
                     (len(new_estmts), map_name))
         return new_estmts
@@ -352,7 +352,7 @@ class EmmaaModel(object):
             logger.info(f'Loaded {len(file_stmts)} statements from {fname}.')
             stmts += file_stmts
         new_estmts = to_emmaa_stmts(
-            stmts, datetime.datetime.now(), [], 'external')
+            stmts, datetime.datetime.now(), [], {'internal': False})
         return new_estmts
 
     def add_paper_ids(self, initial_ids, id_type='pmid'):
@@ -538,7 +538,9 @@ class EmmaaModel(object):
         if not self.assembled_stmts:
             self.run_assembly()
         ia = IndraNetAssembler(self.assembled_stmts)
-        signed_graph = ia.make_model(graph_type='signed')
+        signed_graph = ia.make_model(
+            graph_type='signed',
+            extra_columns=[('internal', is_internal)])
         if mode == 's3' and 'indranet' in self.export_formats:
             fname = f'indranet_{self.date_str}.tsv'
             df = ia.make_df()
@@ -554,7 +556,9 @@ class EmmaaModel(object):
         if not self.assembled_stmts:
             self.run_assembly()
         ia = IndraNetAssembler(self.assembled_stmts)
-        unsigned_graph = ia.make_model(graph_type='digraph')
+        unsigned_graph = ia.make_model(
+            graph_type='digraph',
+            extra_columns=[('internal', is_internal)])
         return unsigned_graph
 
     def to_json(self):

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -325,8 +325,9 @@ class EmmaaModel(object):
             other_stmts += file_stmts
         new_stmts, paper_ids = make_model_stmts(current_stmts, other_stmts)
         # TODO this probably needs refactoring to determine which statements
-        # internal vs external
-        new_estmts = to_emmaa_stmts(new_stmts, datetime.datetime.now(), [])
+        # are from literature vs curated pickled files
+        new_estmts = to_emmaa_stmts(
+            new_stmts, datetime.datetime.now(), [], {'internal': True})
         self.add_paper_ids(paper_ids, 'TRID')
         return new_estmts
 

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -324,6 +324,8 @@ class EmmaaModel(object):
             logger.info(f'Loaded {len(file_stmts)} statements from {fname}.')
             other_stmts += file_stmts
         new_stmts, paper_ids = make_model_stmts(current_stmts, other_stmts)
+        # TODO this probably needs refactoring to determine which statements
+        # internal vs external
         new_estmts = to_emmaa_stmts(new_stmts, datetime.datetime.now(), [])
         self.add_paper_ids(paper_ids, 'TRID')
         return new_estmts
@@ -334,7 +336,8 @@ class EmmaaModel(object):
         map_name = disease_map_config['map_name']
         logger.info('Loading Statements from %s Disease Map' % map_name)
         sp = process_from_web(filenames=filenames, map_name=map_name)
-        new_estmts = to_emmaa_stmts(sp.statements, datetime.datetime.now(), [])
+        new_estmts = to_emmaa_stmts(
+            sp.statements, datetime.datetime.now(), [], 'internal')
         logger.info('Got %d EMMAA Statements from %s Disease Map' %
                     (len(new_estmts), map_name))
         return new_estmts
@@ -348,7 +351,8 @@ class EmmaaModel(object):
             file_stmts = load_pickle_from_s3(bucket, fname)
             logger.info(f'Loaded {len(file_stmts)} statements from {fname}.')
             stmts += file_stmts
-        new_estmts = to_emmaa_stmts(stmts, datetime.datetime.now(), [])
+        new_estmts = to_emmaa_stmts(
+            stmts, datetime.datetime.now(), [], 'external')
         return new_estmts
 
     def add_paper_ids(self, initial_ids, id_type='pmid'):

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -173,7 +173,7 @@ class ModelManager(object):
             logger.info(f'Applying {filter_func.__name__}')
         results = mc.check_model(
             max_path_length=max_path_length, max_paths=max_paths,
-            agent_filter_func=filter_func)
+            agent_filter_func=filter_func, edge_filter_func_name=edge_filter)
         for (stmt, result) in results:
             self.add_result(mc_type, result)
 

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -31,7 +31,7 @@ from emmaa.util import make_date_str, get_s3_client, get_class_from_name, \
     EMMAA_BUCKET_NAME, find_latest_s3_file, load_pickle_from_s3, \
     save_pickle_to_s3, load_json_from_s3, save_json_to_s3, strip_out_date, \
     save_gzip_json_to_s3
-from emmaa.filter_functions import filter_functions
+from emmaa.filter_functions import node_filter_functions, edge_filter_functions
 
 
 logger = logging.getLogger(__name__)
@@ -130,7 +130,8 @@ class ModelManager(object):
         mm = cls(model, mode=mode)
         return mm
 
-    def get_updated_mc(self, mc_type, stmts, add_ns=False, edge_filter=None):
+    def get_updated_mc(self, mc_type, stmts, add_ns=False,
+                       edge_filter_func=None):
         """Update the ModelChecker and graph with stmts for tests/queries."""
         mc = self.mc_types[mc_type]['model_checker']
         mc.statements = stmts
@@ -139,10 +140,10 @@ class ModelManager(object):
             mc.model_stmts = self.model.assembled_stmts
             mc.get_graph(prune_im=True, prune_im_degrade=True,
                          add_namespaces=add_ns,
-                         edge_filter_func_name=edge_filter)
+                         edge_filter_func=edge_filter_func)
         else:
             mc.graph = None
-            mc.get_graph(edge_filter_func_name=edge_filter)
+            mc.get_graph(edge_filter_func=edge_filter_func)
         if mc_type in ('signed_graph', 'unsigned_graph'):
             mc.nodes_to_agents = {ag.name: ag for ag in self.entities}
         return mc
@@ -155,25 +156,25 @@ class ModelManager(object):
         """Add a result to a list of results."""
         self.mc_types[mc_type]['test_results'].append(result)
 
-    def run_all_tests(self, filter_func=None, edge_filter=None):
+    def run_all_tests(self, filter_func=None, edge_filter_func=None):
         """Run all applicable tests with all available ModelCheckers."""
         max_path_length, max_paths = self._get_test_configs()
         for mc_type in self.mc_types:
             self.run_tests_per_mc(mc_type, max_path_length, max_paths,
-                                  filter_func, edge_filter)
+                                  filter_func, edge_filter_func)
 
     def run_tests_per_mc(self, mc_type, max_path_length, max_paths,
-                         filter_func=None, edge_filter=None):
+                         filter_func=None, edge_filter_func=None):
         """Run all applicable tests with one ModelChecker."""
         mc = self.get_updated_mc(
             mc_type, [test.stmt for test in self.applicable_tests],
-            edge_filter=edge_filter)
+            edge_filter_func=edge_filter_func)
         logger.info(f'Running the tests with {mc_type} ModelChecker.')
         if filter_func:
             logger.info(f'Applying {filter_func.__name__}')
         results = mc.check_model(
             max_path_length=max_path_length, max_paths=max_paths,
-            agent_filter_func=filter_func, edge_filter_func_name=edge_filter)
+            agent_filter_func=filter_func, edge_filter_func=edge_filter_func)
         for (stmt, result) in results:
             self.add_result(mc_type, result)
 
@@ -645,10 +646,10 @@ class TestManager(object):
             logger.info(f'Created {len(model_manager.applicable_tests)} tests '
                         f'for {model_manager.model.name} model.')
 
-    def run_tests(self, filter_func=None, edge_filter=None):
+    def run_tests(self, filter_func=None, edge_filter_func=None):
         """Run tests for a list of model-test pairs"""
         for model_manager in self.model_managers:
-            model_manager.run_all_tests(filter_func, edge_filter)
+            model_manager.run_all_tests(filter_func, edge_filter_func)
 
 
 class TestConnector(object):
@@ -919,10 +920,12 @@ def run_model_tests_from_s3(model_name, test_corpus='large_corpus_tests',
     if mm.model.test_config.get('filters'):
         filter_func_name = mm.model.test_config['filters'].get(test_corpus)
         if filter_func_name:
-            filter_func = filter_functions.get(filter_func_name)
+            filter_func = node_filter_functions.get(filter_func_name)
     if mm.model.test_config.get('edge_filters'):
-        edge_filter = mm.model.test_config['edge_filters'].get(test_corpus)
-    tm.run_tests(filter_func, edge_filter)
+        edge_filter_func_name = mm.model.test_config['edge_filters'].get(
+            test_corpus)
+        edge_filter_func = edge_filter_functions.get(edge_filter_func_name)
+    tm.run_tests(filter_func, edge_filter_func)
     # Optionally upload test results to S3
     if upload_results:
         mm.upload_results(test_corpus, test_data, bucket=bucket)

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -916,7 +916,7 @@ def run_model_tests_from_s3(model_name, test_corpus='large_corpus_tests',
         test_connector = RefinementTestConnector()
     tm.make_tests(test_connector)
     filter_func = None
-    edge_filter = None
+    edge_filter_func = None
     if mm.model.test_config.get('filters'):
         filter_func_name = mm.model.test_config['filters'].get(test_corpus)
         if filter_func_name:

--- a/emmaa/readers/aws_reader.py
+++ b/emmaa/readers/aws_reader.py
@@ -4,7 +4,7 @@ from indra.literature.s3_client import get_reader_json_str, get_full_text
 from indra_reading.scripts.submit_reading_pipeline import \
     submit_reading
 from indra_reading.batch.monitor import BatchMonitor
-from emmaa.statements import EmmaaStatement
+from emmaa.statements import to_emmaa_stmts
 
 
 def read_pmid_search_terms(pmid_search_terms):
@@ -26,9 +26,9 @@ def read_pmid_search_terms(pmid_search_terms):
     pmid_stmts = read_pmids(pmids, date)
     estmts = []
     for pmid, stmts in pmid_stmts.items():
-        for stmt in stmts:
-            es = EmmaaStatement(stmt, date, pmid_search_terms[pmid])
-            estmts.append(es)
+        pmid_estmts = to_emmaa_stmts(stmts, date, pmid_search_terms[pmid],
+                                     'internal')
+        estmts += pmid_estmts
     return estmts
 
 

--- a/emmaa/readers/aws_reader.py
+++ b/emmaa/readers/aws_reader.py
@@ -27,7 +27,7 @@ def read_pmid_search_terms(pmid_search_terms):
     estmts = []
     for pmid, stmts in pmid_stmts.items():
         pmid_estmts = to_emmaa_stmts(stmts, date, pmid_search_terms[pmid],
-                                     'internal')
+                                     {'internal': True})
         estmts += pmid_estmts
     return estmts
 

--- a/emmaa/readers/db_client_reader.py
+++ b/emmaa/readers/db_client_reader.py
@@ -29,7 +29,7 @@ def read_db_ids_search_terms(id_search_terms, id_type):
     for _id, stmt_jsons in id_stmts.items():
         stmts = stmts_from_json(stmt_jsons)
         id_estmts = to_emmaa_stmts(
-            stmts, date, id_search_terms[_id], 'internal')
+            stmts, date, id_search_terms[_id], {'internal': True})
         estmts += id_estmts
     return estmts
 

--- a/emmaa/readers/db_client_reader.py
+++ b/emmaa/readers/db_client_reader.py
@@ -3,7 +3,7 @@ from indra_db.client.principal.raw_statements import \
     get_raw_stmt_jsons_from_papers
 from indra_db.util import get_db
 from indra.statements import stmts_from_json
-from emmaa.statements import EmmaaStatement
+from emmaa.statements import to_emmaa_stmts
 
 
 def read_db_ids_search_terms(id_search_terms, id_type):
@@ -28,9 +28,9 @@ def read_db_ids_search_terms(id_search_terms, id_type):
     estmts = []
     for _id, stmt_jsons in id_stmts.items():
         stmts = stmts_from_json(stmt_jsons)
-        for stmt in stmts:
-            es = EmmaaStatement(stmt, date, id_search_terms[_id])
-            estmts.append(es)
+        id_estmts = to_emmaa_stmts(
+            stmts, date, id_search_terms[_id], 'internal')
+        estmts += id_estmts
     return estmts
 
 

--- a/emmaa/readers/elsevier_eidos_reader.py
+++ b/emmaa/readers/elsevier_eidos_reader.py
@@ -3,7 +3,7 @@ import logging
 import datetime
 from indra.sources import eidos
 from indra.literature import elsevier_client
-from emmaa.statements import EmmaaStatement
+from emmaa.statements import to_emmaa_stmts
 
 
 logger = logging.getLogger(__name__)
@@ -32,8 +32,9 @@ def read_elsevier_eidos_search_terms(piis_to_terms):
         for stmt in stmts:
             for evid in stmt.evidence:
                 evid.annotations['pii'] = pii
-            es = EmmaaStatement(stmt, date, piis_to_terms[pii])
-            estmts.append(es)
+        pii_estmts = to_emmaa_stmts(stmts, date, piis_to_terms[pii],
+                                    'internal')
+        estmts += pii_estmts
     return estmts
 
 

--- a/emmaa/readers/elsevier_eidos_reader.py
+++ b/emmaa/readers/elsevier_eidos_reader.py
@@ -33,7 +33,7 @@ def read_elsevier_eidos_search_terms(piis_to_terms):
             for evid in stmt.evidence:
                 evid.annotations['pii'] = pii
         pii_estmts = to_emmaa_stmts(stmts, date, piis_to_terms[pii],
-                                    'internal')
+                                    {'internal': True})
         estmts += pii_estmts
     return estmts
 

--- a/emmaa/statements.py
+++ b/emmaa/statements.py
@@ -60,3 +60,23 @@ def emmaa_metadata_json(search_terms, date, source_tag):
 def add_emmaa_annotations(indra_stmt, annotation):
     for evid in indra_stmt.evidence:
         evid.annotations['emmaa'] = annotation
+
+
+def filter_emmaa_stmts_by_tag(estmts, allowed_tags=['internal']):
+    estmts_out = []
+    for estmt in estmts:
+        if estmt.source_tag in allowed_tags:
+            estmts_out.append(estmt)
+    return estmts_out
+
+
+def filter_indra_stmts_by_tag(stmts, allowed_tags=['internal']):
+    stmts_out = []
+    for stmt in stmts:
+        evid_tags = set()
+        for evid in stmt.evidence:
+            if evid.annotations.get('emmaa'):
+                evid_tags.add(evid.annotations['emmaa']['source_tag'])
+        if any([tag in allowed_tags for tag in evid_tags]):
+            stmts_out.append(stmt)
+    return stmts_out

--- a/emmaa/statements.py
+++ b/emmaa/statements.py
@@ -9,21 +9,24 @@ class EmmaaStatement(object):
         A datetime object that is attached to the Statement. Typically
         represents the time at which the Statement was created.
     search_terms : list[emmaa.priors.SearchTerm]
-        The slist of search terms that led to the creation of the Statement.
+        The list of search terms that led to the creation of the Statement.
+    source_tag : str
+        Tag of statement source (e.g. internal, external, ctd, etc.)
     """
-    def __init__(self, stmt, date, search_terms):
+    def __init__(self, stmt, date, search_terms, source_tag):
         self.stmt = stmt
         self.date = date
         self.search_terms = search_terms
+        self.source_tag = source_tag
 
     def __repr__(self):
-        return '%s(%s, %s, %s)' % (self.__class__.__name__, self.stmt,
-                                   self.date, self.search_terms)
+        return '%s(%s, %s, %s, %s)' % (self.__class__.__name__, self.stmt,
+                                       self.date, self.search_terms,
+                                       self.source_tag)
 
     def to_json(self):
-        output_json = {'search_terms': [st.to_json() for st
-                                        in self.search_terms],
-                       'date': self.date.strftime('%Y-%m-%d-%H-%M-%S')}
+        output_json = emmaa_metadata_json(self.search_terms, self.date,
+                                          self.source_tag)
         # Get json representation of statement
         json_stmt = self.stmt.to_json(use_sbo=False)
         # Stringify source hashes: JavaScript can't handle int's of length > 16
@@ -33,10 +36,23 @@ class EmmaaStatement(object):
         return output_json
 
 
-def to_emmaa_stmts(stmt_list, date, search_terms):
+def to_emmaa_stmts(stmt_list, date, search_terms, source_tag):
     """Make EMMAA statements from INDRA Statements with the given metadata."""
     emmaa_stmts = []
+    ann = emmaa_metadata_json(search_terms, date, source_tag)
     for indra_stmt in stmt_list:
-        es = EmmaaStatement(indra_stmt, date, search_terms)
+        add_emmaa_annotations(indra_stmt, ann)
+        es = EmmaaStatement(indra_stmt, date, search_terms, source_tag)
         emmaa_stmts.append(es)
     return emmaa_stmts
+
+
+def emmaa_metadata_json(search_terms, date, source_tag):
+    return {'search_terms': [st.to_json() for st in search_terms],
+            'date': date.strftime('%Y-%m-%d-%H-%M-%S'),
+            'source_tag': source_tag}
+
+
+def add_emmaa_annotations(indra_stmt, annotation):
+    for evid in indra_stmt.evidence:
+        evid.annotations['emmaa'] = annotation

--- a/emmaa/statements.py
+++ b/emmaa/statements.py
@@ -13,16 +13,20 @@ class EmmaaStatement(object):
     source_tag : str
         Tag of statement source (e.g. internal, external, ctd, etc.)
     """
-    def __init__(self, stmt, date, search_terms, source_tag):
+    def __init__(self, stmt, date, search_terms, source_tag=None):
         self.stmt = stmt
         self.date = date
         self.search_terms = search_terms
-        self.source_tag = source_tag
+        self.source_tag = source_tag if source_tag else ''
 
     def __repr__(self):
-        return '%s(%s, %s, %s, %s)' % (self.__class__.__name__, self.stmt,
-                                       self.date, self.search_terms,
-                                       self.source_tag)
+        if hasattr(self, 'source_tag'):
+            return '%s(%s, %s, %s, %s)' % (self.__class__.__name__, self.stmt,
+                                           self.date, self.search_terms,
+                                           self.source_tag)
+        else:
+            return '%s(%s, %s, %s)' % (self.__class__.__name__, self.stmt,
+                                       self.date, self.search_terms)
 
     def to_json(self):
         output_json = emmaa_metadata_json(self.search_terms, self.date,

--- a/emmaa/statements.py
+++ b/emmaa/statements.py
@@ -62,6 +62,9 @@ def add_emmaa_annotations(indra_stmt, annotation):
 def filter_emmaa_stmts_by_metadata(estmts, conditions):
     estmts_out = []
     for estmt in estmts:
+        if not hasattr(estmt, 'metadata'):
+            estmts_out.append(estmt)
+            continue
         checks = []
         for key, value in conditions.items():
             checks.append(estmt.metadata.get(key) == value)
@@ -91,6 +94,8 @@ def check_stmt(stmt, conditions, evid_policy='any'):
             evid_checks.append(all(checks))
             if all(checks) and evid_policy == 'any':
                 break
+    if not evid_checks:
+        return True
     if evid_policy == 'any':
         return any(evid_checks)
     elif evid_policy == 'all':

--- a/emmaa/tests/test_filters.py
+++ b/emmaa/tests/test_filters.py
@@ -1,0 +1,46 @@
+import networkx as nx
+from emmaa.filter_functions import filter_chem_mesh_go, \
+    filter_to_internal_edges
+from indra.statements import Agent
+from indra.explanation.pathfinding import get_subgraph
+
+edges = [
+    (1, 2, {'statements': [{'internal': True}]}),
+    (2, 3, {'statements': [{'internal': False}]}),
+    (3, 4, {'statements': [{'internal': True}, {'internal': True}]}),
+    (4, 5, {'statements': [{'internal': True}, {'internal': False}]}),
+    (5, 6, {'statements': [{'internal': False}, {'internal': False}]}),
+]
+g = nx.DiGraph()
+g.add_edges_from(edges)
+
+
+def test_filter_to_internal():
+    assert filter_to_internal_edges(g, 1, 2)
+    assert not filter_to_internal_edges(g, 2, 3)
+    assert filter_to_internal_edges(g, 3, 4)
+    assert filter_to_internal_edges(g, 4, 5)  # enough to have one internal
+    assert not filter_to_internal_edges(g, 5, 6)
+
+
+def test_internal_subgraph():
+    new_g = get_subgraph(g, filter_to_internal_edges)
+    assert isinstance(new_g, nx.DiGraph)
+    assert len(new_g.edges) == 3
+    assert (2, 3) not in new_g.edges
+    assert (5, 6) not in new_g.edges
+    assert (4, 5) in new_g.edges
+
+
+def test_filter_chem_mesh_go():
+    a = Agent('A', db_refs={'HGNC': '1234'})
+    b = Agent('B', db_refs={'CHEBI': '2345'})
+    c = Agent('C', db_refs={'MESH': '3456'})
+    d = Agent('D', db_refs={'GO': '4567'})
+    e = Agent('E', db_refs={'CHEBI': '5678', 'HGNC': '6789'})
+    assert filter_chem_mesh_go(a)
+    assert not filter_chem_mesh_go(b)
+    assert not filter_chem_mesh_go(c)
+    assert not filter_chem_mesh_go(d)
+    # Decision made based on default namespace order
+    assert filter_chem_mesh_go(e)

--- a/emmaa/tests/test_statements.py
+++ b/emmaa/tests/test_statements.py
@@ -1,0 +1,97 @@
+import datetime
+from copy import deepcopy
+
+from emmaa.statements import EmmaaStatement, to_emmaa_stmts, \
+    filter_emmaa_stmts_by_metadata, filter_indra_stmts_by_metadata
+from emmaa.priors import SearchTerm
+from indra.statements import Activation, Agent, Evidence
+
+
+braf = Agent('BRAF', db_refs={'HGNC': '1097'})
+map2k1 = Agent('MAP2K1', db_refs={'HGNC': '6840'})
+stmt = Activation(braf, map2k1,
+                  evidence=[Evidence(text='BRAF activates MAP2K1.',
+                            source_api='assertion',
+                            text_refs={'TRID': '1234'})])
+date = datetime.datetime.now()
+search_terms = [
+    SearchTerm('gene', braf.name, braf.db_refs, '"BRAF"'),
+    SearchTerm('gene', map2k1.name, map2k1.db_refs, '"MAP2K1"')]
+
+
+def test_to_emmaa_stmts():
+    estmts = to_emmaa_stmts(
+        [stmt],
+        date=date,
+        search_terms=search_terms,
+        metadata={'internal': True})
+    assert estmts
+    estmt = estmts[0]
+    assert isinstance(estmt, EmmaaStatement)
+    assert estmt.stmt == stmt
+    assert estmt.metadata == {'internal': True}
+    emmaa_anns = estmt.stmt.evidence[0].annotations.get('emmaa')
+    assert emmaa_anns
+    assert len(emmaa_anns['search_terms']) == 2
+    assert isinstance(emmaa_anns['date'], str)
+    assert emmaa_anns['metadata'] == {'internal': True}
+
+
+def test_filter_emmaa_stmts():
+    estmt1 = EmmaaStatement(stmt, date, search_terms, {'internal': True})
+    estmt2 = EmmaaStatement(stmt, date, search_terms, {'internal': False})
+    estmt3 = EmmaaStatement(stmt, date, search_terms)
+    del estmt3.metadata  # Imitate older style statement withou metadata
+    # Only estmt2 with internal False should be filtered out
+    filtered_estmts = filter_emmaa_stmts_by_metadata(
+        [estmt1, estmt2, estmt3], {'internal': True})
+    assert len(filtered_estmts) == 2
+    assert estmt1 in filtered_estmts
+    assert estmt3 in filtered_estmts
+
+
+def test_filter_indra_stmts():
+    def make_stmt_with_evid_anns(internal_list):
+        new_stmt = deepcopy(stmt)
+        new_stmt.evidence = []
+        for internal_val in internal_list:
+            new_evid = Evidence(text='BRAF activates MAP2K1.',
+                                source_api='assertion',
+                                text_refs={'TRID': '1234'})
+            if internal_val is None:
+                new_evid.annotations = {}
+            # True or False
+            else:
+                new_evid.annotations = {
+                    'emmaa': {
+                        'metadata': {'internal': internal_val}}}
+            new_stmt.evidence.append(new_evid)
+        return new_stmt
+
+    stmt1 = make_stmt_with_evid_anns([None, None])  # Not filter unknown anns
+    stmt2 = make_stmt_with_evid_anns([True])  # Only true anns
+    stmt3 = make_stmt_with_evid_anns([True, True])  # Only true anns
+    stmt4 = make_stmt_with_evid_anns([None, True])  # Only true or unknown anns
+    stmt5 = make_stmt_with_evid_anns([False, True])  # Mixed true and false
+    stmt6 = make_stmt_with_evid_anns([False])  # Only false anns
+    stmt7 = make_stmt_with_evid_anns([None, False])  # Filter false or unknown
+    stmt8 = make_stmt_with_evid_anns([False, False])  # Only false anns
+
+    conditions = {'internal': True}
+    stmts = [stmt1, stmt2, stmt3, stmt4, stmt5, stmt6, stmt7, stmt8]
+
+    filtered_any = filter_indra_stmts_by_metadata(stmts, conditions, 'any')
+    assert len(filtered_any) == 5
+    assert stmt6 not in filtered_any
+    assert stmt7 not in filtered_any
+    assert stmt8 not in filtered_any
+    # Mixed is not filtered
+    assert stmt5 in filtered_any
+
+    filtered_all = filter_indra_stmts_by_metadata(stmts, conditions, 'all')
+    assert len(filtered_all) == 4
+    assert stmt6 not in filtered_all
+    assert stmt7 not in filtered_all
+    assert stmt8 not in filtered_all
+    # Mixed is filtered too here
+    assert stmt5 not in filtered_all

--- a/scripts/emmaa_model_from_stmts.py
+++ b/scripts/emmaa_model_from_stmts.py
@@ -21,7 +21,8 @@ def create_upload_model(model_name, indra_stmts, config_file):
     config_file : str
         Path to the local config.json file.
     """
-    emmaa_stmts = to_emmaa_stmts(indra_stmts, datetime.datetime.now(), [])
+    emmaa_stmts = to_emmaa_stmts(indra_stmts, datetime.datetime.now(), [],
+                                 'internal')
     # Load config information
     with open(config_file, 'rt') as f:
         config_json = json.load(f)

--- a/scripts/emmaa_model_from_stmts.py
+++ b/scripts/emmaa_model_from_stmts.py
@@ -22,7 +22,7 @@ def create_upload_model(model_name, indra_stmts, config_file):
         Path to the local config.json file.
     """
     emmaa_stmts = to_emmaa_stmts(indra_stmts, datetime.datetime.now(), [],
-                                 'internal')
+                                 {'internal': True})
     # Load config information
     with open(config_file, 'rt') as f:
         config_json = json.load(f)


### PR DESCRIPTION
This PR makes the following changes:
- Adds `metadata` field to EMMAA Statement object to allow tagging statements as e.g. internal/external, literature/curated, etc.
- Propagates metadata from EMMAA Statement to the underlying INDRA Statement as annotations.
- Adds functions to filter both EMMAA and INDRA statement based on some conditions in metadata.
- Information about whether the statement is internal is propagated to edge data when assembling signed/unsigned graphs from EMMAA Model.
- Model configs allow to filter out statements from statistics based on criteria (e.g. filter out external statements from stats)
- Model-test configs allow to specify which edges should be filtered out in model checking for a given model-test corpus pair (this part depends on https://github.com/sorgerlab/indra/pull/1273)