### PR TITLE
Configurable model updates

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -307,6 +307,19 @@ class EmmaaModel(object):
                     (len_after - len_before))
 
     def update_with_cord19(self, cord19_config):
+        """Update model with new CORD19 dataset statements.
+
+        Relevant part of reading config should look similar to:
+
+        {"cord19_update": {
+            "metadata": {
+                "internal": true,
+                "curated": false
+                },
+            "date_limit": 5
+            }
+        }
+        """
         # Using local import to avoid dependency
         from covid_19.emmaa_update import make_model_stmts
         current_stmts = self.get_indra_stmts()
@@ -320,7 +333,19 @@ class EmmaaModel(object):
         return new_estmts
 
     def update_from_disease_map(self, disease_map_config):
-        """Update model by processing MINERVA Disease Map."""
+        """Update model by processing MINERVA Disease Map.
+
+        Relevant part of reading config should look similar to:
+
+        {"disease_map": {
+            "map_name": "covid19map",
+            "filenames" : "all",  # or a list of filenames
+            "metadata": {
+                "internal": true
+                }
+            }
+        }
+        """
         filenames = disease_map_config['filenames']
         map_name = disease_map_config['map_name']
         metadata = disease_map_config['metadata']
@@ -333,9 +358,19 @@ class EmmaaModel(object):
         return new_estmts
 
     def update_from_files(self, files_config):
-        """Add custom statements from files."""
-        bucket = files_config['bucket']
-        filenames = files_config['filenames']
+        """Add custom statements from files.
+
+        Relevant part of reading config should look similar to:
+
+        {"other_files": [
+            {
+                "bucket": "indra-covid19",
+                "filename": "ctd_stmts.pkl",
+                "metadata": {"internal": true, "curated": true}
+            }
+        ]
+        }
+        """
         new_estmts = []
         for file_dict in files_config:
             bucket = file_dict['bucket']

--- a/emmaa/statements.py
+++ b/emmaa/statements.py
@@ -1,3 +1,9 @@
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
 class EmmaaStatement(object):
     """Represents an EMMAA Statement.
 
@@ -38,6 +44,8 @@ class EmmaaStatement(object):
 def to_emmaa_stmts(stmt_list, date, search_terms, metadata=None):
     """Make EMMAA statements from INDRA Statements with the given metadata."""
     emmaa_stmts = []
+    logger.info(f'Making {len(stmt_list)} EMMAA statements with metadata: '
+                f'{metadata}')
     ann = emmaa_metadata_json(search_terms, date, metadata)
     for indra_stmt in stmt_list:
         add_emmaa_annotations(indra_stmt, ann)
@@ -78,6 +86,8 @@ def filter_emmaa_stmts_by_metadata(estmts, conditions):
     estmts_out : list[emmaa.statements.EmmaaStatement]
         A list of EMMAA Statements which meet the conditions.
     """
+    logger.info(f'Filtering {len(estmts)} EMMAA Statements with the following'
+                f' conditions: {conditions}')
     estmts_out = []
     for estmt in estmts:
         # Not filter out "old version" statements without metadata
@@ -91,6 +101,7 @@ def filter_emmaa_stmts_by_metadata(estmts, conditions):
         # Only keep statements meeting all conditions
         if all(checks):
             estmts_out.append(estmt)
+    logger.info(f'Got {len(estmts_out)} EMMAA Statements after filtering')
     return estmts_out
 
 
@@ -117,11 +128,14 @@ def filter_indra_stmts_by_metadata(stmts, conditions, evid_policy='any'):
     stmts_out : list[indra.statements.Statement]
         A list of INDRA Statements which meet the conditions.
     """
+    logger.info(f'Filtering {len(stmts)} INDRA Statements with the following'
+                f' conditions: {conditions} in {evid_policy} evidence')
     stmts_out = []
     for stmt in stmts:
         add = check_stmt(stmt, conditions, evid_policy)
         if add:
             stmts_out.append(stmt)
+    logger.info(f'Got {len(stmts_out)} INDRA Statements after filtering')
     return stmts_out
 
 


### PR DESCRIPTION
This PR updates EmmaaModel methods for custom model updates (non-reading updates such as `update_with_cord19`, `update_from_disease_map`, and `update_from_files`). Instead of using default/hardcoded metadata, filenames, and other parameters, all information can be now provided in model config files. Loading COVID19 custom pickle files part is removed from `update_with_cord19` method, instead `update_from_files` should be used for that step with new configuration. This allows passing any custom metadata to statements loaded from a particular file or other source. This PR should be merged together with https://github.com/indralab/covid-19/pull/17