### PR TITLE
Fix test loading

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
         export AWS_DEFAULT_REGION='us-east-1'
         export NOSEATTR="!notravis"
         export NOSEATTR=$(if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then echo $NOSEATTR,!nonpublic; else echo $NOSEATTR; fi)
-        export PYTHONPATH=$PYTHONPATH:`pwd`/covid-19:`pwd`/kappy:`pwd`/indra_world:`pwd`/automates/scripts
+        export PYTHONPATH=$PYTHONPATH:`pwd`/covid-19:`pwd`/kappy:`pwd`/indra_world:`pwd`/automates/scripts/gromet
         export BNGPATH=`pwd`/BioNetGen-2.4.0
         export INDRA_WM_CACHE="."
         nosetests -v -a $NOSEATTR emmaa/tests/test_s3.py

--- a/emmaa/analyze_tests_results.py
+++ b/emmaa/analyze_tests_results.py
@@ -222,7 +222,7 @@ class ModelRound(Round):
         logger.info('Mapping papers to statements')
         stmts_by_papers = {}
         for stmt in self.statements:
-            stmt_hash = stmt.get_hash()
+            stmt_hash = stmt.get_hash(refresh=True)
             for evid in stmt.evidence:
                 paper_id = None
                 if id_type == 'pii':

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -946,7 +946,7 @@ def pysb_to_gromet(pysb_model, model_name, fname=None):
     g : automates.script.gromet.gromet.Gromet
         A GroMEt object built from PySB model.
     """
-    from gromet.gromet import Gromet, gromet_to_json, \
+    from gromet import Gromet, gromet_to_json, \
         Junction, Wire, UidJunction, UidType, UidWire, Relation, \
         UidBox, UidGromet, Literal, Val
     from pysb import Parameter

--- a/emmaa/tests/test_model.py
+++ b/emmaa/tests/test_model.py
@@ -138,7 +138,7 @@ def test_papers():
 
 
 def test_pysb_to_gromet():
-    from gromet.gromet import Gromet
+    from gromet import Gromet
     emmaa_model = create_model()
     pysb_model = emmaa_model.assemble_pysb()
     gromet = pysb_to_gromet(pysb_model, 'test_model', 'gromet_test.json')

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -447,8 +447,11 @@ def _get_all_tests(bucket=EMMAA_BUCKET_NAME):
 
 def _load_tests_from_cache(test_corpus):
     tests, file_key = tests_cache.get(test_corpus, (None, None))
-    latest_on_s3 = find_latest_s3_file(
-        EMMAA_BUCKET_NAME, f'tests/{test_corpus}', '.pkl')
+    try:
+        latest_on_s3 = find_latest_s3_file(
+            EMMAA_BUCKET_NAME, f'tests/{test_corpus}', '.pkl')
+    except ValueError:
+        latest_on_s3 = f'tests/{test_corpus}.pkl'
     if file_key != latest_on_s3:
         tests, file_key = load_tests_from_s3(test_corpus, EMMAA_BUCKET_NAME)
         if isinstance(tests, dict):


### PR DESCRIPTION
This PR fixes a couple of bugs related to tests loading in the api:
1) when there are multiple test corpora with the same prefix but the difference between them is not the date (i.e. we cannot pick one by sorting by date), e.g. covid19_curated_tests, covid19_curated_tests_c19dm.
2) when the stats are generated with refreshed hash but the test objects are stored with old hash and there's no match to load evidence (need to force hash refresh).
