### PR TITLE
Belief models

### DIFF
--- a/doc/model_config.rst
+++ b/doc/model_config.rst
@@ -106,7 +106,13 @@ First level fields of config.json
                 "Viral replication": {"MESH": "D014779"},
                 "viral replication cycle": {"MESH": "D014779"}}}},
             {"function": "run_preassembly",
-             "kwargs": {"return_toplevel": false}},
+             "kwargs": {"return_toplevel": false,
+                        "belief_scorer": {
+                            "function": "load_belief_scorer",
+                            "kwargs": {"bucket": "indra-belief",
+                                       "key": "1.20.0/default_scorer.pkl"}
+                            }
+                        }},
             {"function": "filter_by_curation",
              "args": [{"function": "get_curations"},
                       "any",

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -953,7 +953,7 @@ def load_belief_scorer(bucket, key):
     return scorer
 
 
-def load_extra_evidence(stmts, ev_limit=10):
+def load_extra_evidence(stmts, ev_limit=10, batch_size=2000):
     """Load additional evidence for statements from database.
 
     Parameters
@@ -974,10 +974,10 @@ def load_extra_evidence(stmts, ev_limit=10):
     new_stmts = []
     offset = 0
     while True:
-        proc = get_statements_by_hash(stmt_hashes[offset:(offset + 2000)],
+        proc = get_statements_by_hash(stmt_hashes[offset:(offset + batch_size)],
                                       ev_limit=ev_limit)
         new_stmts += proc.statements
-        offset += 2000
+        offset += batch_size
         if offset >= len(stmt_hashes):
             break
     logger.info(f'Found {len(new_stmts)} stmts in the database')

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -1010,7 +1010,7 @@ def load_extra_evidence(stmts, method='db_query', ev_limit=1000,
 @register_pipeline
 def run_preassembly_with_extra_evidence(stmts_in, return_toplevel=True,
                                         belief_scorer=None,
-                                        query_method='db_query', ev_limit=10,
+                                        query_method='db_query', ev_limit=1000,
                                         batch_size=3000, **kwargs):
     """Run preassembly on a list of statements.
 

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -957,9 +957,14 @@ def load_extra_evidence(stmts):
     stmt_hashes = [stmt.get_hash() for stmt in stmts]
     # get stmts from database
     logger.info(f'Loading additional evidences for {len(stmts)} stmts from db')
-    # TODO handle batches of 2000 hashes at a time
-    proc = get_statements_by_hash(stmt_hashes)
-    new_stmts = proc.statements
+    new_stmts = []
+    offset = 0
+    while True:
+        proc = get_statements_by_hash(stmt_hashes[offset:(offset + 2000)])
+        new_stmts += proc.statements
+        offset += 2000
+        if offset >= len(stmt_hashes):
+            break
     logger.info(f'Found {len(new_stmts)} stmts in the database')
     evid_by_hash = {stmt.get_hash(): stmt.evidence for stmt in new_stmts}
     # add db evidence to emmaa stmts evidence

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -945,6 +945,13 @@ def get_search_term_names(model, bucket=EMMAA_BUCKET_NAME):
     return [st['name'] for st in config['search_terms']]
 
 
+@register_pipeline
+def load_belief_scorer(bucket, key):
+    logger.info(f'Loading the belief model from {key}')
+    scorer = load_pickle_from_s3(bucket, key)
+    return scorer
+
+
 def pysb_to_gromet(pysb_model, model_name, statements=None, fname=None):
     """Convert PySB model to GroMEt object and save it to a JSON file.
 


### PR DESCRIPTION
This PR enables a choice of a belief model for assembly. To switch to a different model, run reassembly step in model assembly config has to be updated. On the UI side this PR adds belief badges and an option to sort statements by belief score.