### PR TITLE
Optimize stmt evidence page

### DIFF
--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -1479,7 +1479,7 @@ def get_query_page():
 def get_statement_evidence_page():
     """Render page displaying evidence for statement or return statement JSON.
     """
-    stmt_hashes = request.args.getlist('stmt_hash')
+    stmt_hashes = set(request.args.getlist('stmt_hash'))
     source = request.args.get('source')
     model = request.args.get('model')
     test_corpus = request.args.get('test_corpus', '')


### PR DESCRIPTION
This PR optimizes the loading of statement evidence page by removing unnecessary loops when filtering by a list of hashes and setting a limit on number of XDD figures