### PR TITLE
Add zero initial values to Gromet export

### DIFF
--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -1129,6 +1129,11 @@ def pysb_to_gromet(pysb_model, model_name, statements=None, fname=None):
     species_nodes = [str(sp) for sp in pysb_model.species]
     # Add all species junctions
     for ix, sp in enumerate(pysb_model.species):
+        if ix not in species_values:
+            species_values[ix] = Literal(
+                uid=None, type=UidType("Integer"),
+                value=Val(0),
+                name=None, metadata=None)
         # Map to a list of agents
         agents = []
         for mp in sp.monomer_patterns:

--- a/emmaa/tests/test_model.py
+++ b/emmaa/tests/test_model.py
@@ -151,6 +151,7 @@ def test_pysb_to_gromet():
     assert len(pysb_model.species) == 5
     assert len(pysb_model.reactions) == 2
     assert len(gromet.junctions) == 7
+    assert all(j.value is not None for j in gromet.junctions)
     assert len([j for j in gromet.junctions if j.type == 'State']) == 5
     assert len([j for j in gromet.junctions if j.type == 'Rate']) == 2
     # Number of wires match total number of reactants and products in reactions


### PR DESCRIPTION
This PR adds values for junctions representing species even if their initial values are not explicitly set (i.e., they are zero). 