### PR TITLE
Re-introduce adding metadata from Biolookup Service

### DIFF
--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -987,7 +987,8 @@ def _update_bioresolver(prefix: str, identifier: str, rv) -> None:
     if not bioresolver_json:
         return
     for key in 'name', 'definition', 'species':
-        rv.setdefault(key, bioresolver_json.get(key))
+        if not rv.get(key):
+            rv[key] = bioresolver_json.get(key)
 
 
 def _lookup_bioresolver(prefix: str, identifier: str):

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -982,18 +982,26 @@ def get_subscribed_queries(query_type, user_email=None):
     return sub_results, headers
 
 
+def _update_bioresolver(prefix: str, identifier: str, rv) -> None:
+    bioresolver_json = _lookup_bioresolver(prefix, identifier)
+    if not bioresolver_json:
+        return
+    for key in 'name', 'definition', 'species':
+        rv.setdefault(key, bioresolver_json.get(key))
+
+
 def _lookup_bioresolver(prefix: str, identifier: str):
     url = get_config('ENTITY_RESOLVER_URL')
     if url is None:
         return
     try:
-        res = requests.get(f'{url}/resolve/{prefix}:{identifier}')
+        res = requests.get(f'{url}/api/lookup/{prefix}:{identifier}')
         res_json = res.json()
         if not res_json['success']:
-            return  # there was a problem looking up CURIE in the bioresolver
+            return  # there was a problem looking up CURIE in the Biolookup Service
     except Exception as e:
         logger.warning(e)
-        logger.warning('Could not connect to bioresolver')
+        logger.warning('Could not connect to the Biolookup Service')
         return
     return res_json
 
@@ -2308,6 +2316,7 @@ class EntityInfo(Resource):
             rv['definition'] = uniprot_client.get_function(up_id)
         else:
             rv['definition'] = None
+        _update_bioresolver(namespace, identifier, rv)
         return rv
 
 


### PR DESCRIPTION
Closes #248 

This PR re-introduces lookup of information from the biolookup service if the internal bioontology doesn't provide it. This includes definition strings and species annotations.

In addition to this PR, you could change the `ENTITY_RESOLVER_URL` configuration to point to `http://biolookup.io` (though this isn't necessary since the load balancer address didn't change)

We could also consider having the EMMAA code import the `biolookup` package for getting this data directly, and possibly have it connect directly to the database instead of going through the API, though this might be a bit complicated for little gain