### PR TITLE
Handle anchor when using loading template

### DIFF
--- a/emmaa_service/templates/loading.html
+++ b/emmaa_service/templates/loading.html
@@ -81,11 +81,19 @@
 <script>
   var loc = window.location.href;
   if (loc.includes('?')) {
-    loc = loc.concat('&loaded=true')
-    window.location.replace(loc);
+    if (loc.includes('#')) {
+      parts = loc.split("#")
+      loc = parts[0].concat('&loaded=true')
+      loc = loc.concat('#')
+      loc = loc.concat(parts[1])
+      window.location.replace(loc);
+    } else {
+      loc = loc.concat('&loaded=true')
+      window.location.replace(loc);
+    }
   } else {
     loc = loc.concat('?loaded=true')
-    window.location.replace(loc);    
+    window.location.replace(loc);
   }
 </script>
 </html>


### PR DESCRIPTION
This PR handles using loading template when the URL contains an anchor tag (by inserting the loading=true before anchor instead of the end of the URL)