### PR TITLE
Bug fixes

### DIFF
--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -631,7 +631,7 @@ class ModelManager(object):
                 for edge in resp['edge_list']:
                     for (_, sentence, _) in edge['stmts']:
                         sentences.append(sentence)
-                response_str = ' '.join(sentences)
+                response_str = ' '.join(sorted(sentences))
                 response_hash = str(fnv1a_32(response_str.encode('utf-8')))
                 response_dict[response_hash] = resp
         elif isinstance(response, dict):

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -160,6 +160,17 @@
   {% endif %}
 </div>
 <script>
+  const url = new URL(window.location);
+  console.log(url)
+  if (url.href.includes('&loaded=true')) {
+    console.log('&')
+    url.href = url.href.replace('&loaded=true', '')
+    window.history.pushState('', '', url);
+  } else if (url.href.includes('?loaded=true')) {
+    console.log('?')
+    url.href = url.href.replace('?loaded=true', '')
+    window.history.pushState('', '', url);
+  }
   Vue.prototype.$stmt_hash_url = "{{ url_for('get_statement_by_hash_model', model=model, date=date, hash_val='') }}";
   Vue.prototype.$curation_url = "{{ url_for('submit_curation_endpoint', hash_val='') }}";
   Vue.prototype.$curation_list_url = "{{ url_for('list_curations', stmt_hash='', src_hash='') }}".slice(0, -2);


### PR DESCRIPTION
This PR fixes a couple small bugs:
- Make sure that query results with different order of statements supporting an edges are not considered different
- Add a script for updating url after the page is loaded to evidence template (it was added to generic emmaa page template but wasn't activated on some pages probably due to having Vue components on the same page)