### PR TITLE
Use db to load statements in the API

### DIFF
--- a/emmaa/db/config.py
+++ b/emmaa/db/config.py
@@ -58,7 +58,14 @@ def get_databases(force_update=False, include_config=True):
                     def_dict['password'] = ':' + def_dict['password']
                 DATABASES[db_name] = (DB_STR_FMT.format(**def_dict),
                                       def_dict.get('type', 'query'))
-        DATABASES.update({k[len(ENV_PREFIX):].lower(): v
+
+        def get_db_with_type(db_url):
+            conf = db_url.split(';')
+            if len(conf) == 1:
+                conf.append('query')
+            return conf
+
+        DATABASES.update({k[len(ENV_PREFIX):].lower(): get_db_with_type(v)
                           for k, v in environ.items()
                           if k.startswith(ENV_PREFIX)})
     return DATABASES

--- a/emmaa/db/config.py
+++ b/emmaa/db/config.py
@@ -56,7 +56,8 @@ def get_databases(force_update=False, include_config=True):
                     def_dict['port'] = ':' + def_dict['port']
                 if def_dict['password']:
                     def_dict['password'] = ':' + def_dict['password']
-                DATABASES[db_name] = DB_STR_FMT.format(**def_dict)
+                DATABASES[db_name] = (DB_STR_FMT.format(**def_dict),
+                                      def_dict.get('type', 'query'))
         DATABASES.update({k[len(ENV_PREFIX):].lower(): v
                           for k, v in environ.items()
                           if k.startswith(ENV_PREFIX)})

--- a/emmaa/db/constructors.py
+++ b/emmaa/db/constructors.py
@@ -21,4 +21,5 @@ def get_db(name):
 
 def get_statements_db():
     """Get the statements database."""
+    # TODO: use the same config as the queries db, also configure which DB manager to use
     return StatementDatabaseManager(os.environ['STATEMENTS_DB_HOST'])

--- a/emmaa/db/constructors.py
+++ b/emmaa/db/constructors.py
@@ -12,7 +12,7 @@ def get_db(name):
     """Get a db instance based on its name in the config or env."""
     defaults = get_databases()
     db_name, db_type = defaults[name]
-    m = re.match('(\w+)://.*?/([\w.]+)', db_name)
+    m = re.match('(\w+)://.*?/*([\w.]+)', db_name)
     if m is None:
         logger.error("Poorly formed db name: %s" % db_name)
         return

--- a/emmaa/db/constructors.py
+++ b/emmaa/db/constructors.py
@@ -2,7 +2,7 @@ import re
 import logging
 
 from .config import get_databases
-from .manager import EmmaaDatabaseManager
+from .manager import QueryDatabaseManager, StatementDatabaseManager
 
 logger = logging.getLogger(__name__)
 
@@ -15,4 +15,10 @@ def get_db(name):
     if m is None:
         logger.error("Poorly formed db name: %s" % db_name)
         return
-    return EmmaaDatabaseManager(db_name, label=name)
+    return QueryDatabaseManager(db_name, label=name)
+
+
+def get_statements_db():
+    """Get the statements database."""
+    # NOTE this needs to be fixed to use the host
+    return StatementDatabaseManager('')

--- a/emmaa/db/constructors.py
+++ b/emmaa/db/constructors.py
@@ -11,16 +11,12 @@ logger = logging.getLogger(__name__)
 def get_db(name):
     """Get a db instance based on its name in the config or env."""
     defaults = get_databases()
-    db_name = defaults[name]
+    db_name, db_type = defaults[name]
     m = re.match('(\w+)://.*?/([\w.]+)', db_name)
     if m is None:
         logger.error("Poorly formed db name: %s" % db_name)
         return
-    return QueryDatabaseManager(db_name, label=name)
-
-
-def get_statements_db():
-    """Get the statements database."""
-    # TODO: use the same config as the queries db, also configure which DB manager to use
-    return StatementDatabaseManager(os.environ['STATEMENTS_DB_HOST'],
-                                    label='emmaa_statements_db')
+    if db_type == 'query':
+        return QueryDatabaseManager(db_name, label=name)
+    elif db_type == 'statement':
+        return StatementDatabaseManager(db_name, label=name)

--- a/emmaa/db/constructors.py
+++ b/emmaa/db/constructors.py
@@ -22,4 +22,5 @@ def get_db(name):
 def get_statements_db():
     """Get the statements database."""
     # TODO: use the same config as the queries db, also configure which DB manager to use
-    return StatementDatabaseManager(os.environ['STATEMENTS_DB_HOST'])
+    return StatementDatabaseManager(os.environ['STATEMENTS_DB_HOST'],
+                                    label='emmaa_statements_db')

--- a/emmaa/db/constructors.py
+++ b/emmaa/db/constructors.py
@@ -20,5 +20,4 @@ def get_db(name):
 
 def get_statements_db():
     """Get the statements database."""
-    # NOTE this needs to be fixed to use the host
-    return StatementDatabaseManager('')
+    return StatementDatabaseManager('8499')

--- a/emmaa/db/constructors.py
+++ b/emmaa/db/constructors.py
@@ -1,5 +1,6 @@
 import re
 import logging
+import os
 
 from .config import get_databases
 from .manager import QueryDatabaseManager, StatementDatabaseManager
@@ -20,4 +21,4 @@ def get_db(name):
 
 def get_statements_db():
     """Get the statements database."""
-    return StatementDatabaseManager('8499')
+    return StatementDatabaseManager(os.environ['STATEMENTS_DB_HOST'])

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -622,7 +622,7 @@ class StatementDatabaseManager(EmmaaDatabaseManager):
     table_order = ['statement']
     table_parent_class = StatementsDbTable
 
-    def build_from_s3(self, number_of_updates=7, bucket=EMMAA_BUCKET_NAME):
+    def build_from_s3(self, number_of_updates=3, bucket=EMMAA_BUCKET_NAME):
         """
         Build the database from S3 files.
         NOTE: This deletes existing database entries and repopulates the tables.
@@ -633,7 +633,7 @@ class StatementDatabaseManager(EmmaaDatabaseManager):
         for model, config in get_models(include_config=True):
             self.add_model_from_s3(model, config, number_of_updates, bucket)
 
-    def add_model_from_s3(self, model_id, config=None, number_of_updates=7,
+    def add_model_from_s3(self, model_id, config=None, number_of_updates=3,
                           bucket=EMMAA_BUCKET_NAME):
         """Add data for one model from S3 files."""
         if not config:
@@ -675,7 +675,7 @@ class StatementDatabaseManager(EmmaaDatabaseManager):
                 Statement.date == date)
             q.delete(synchronize_session=False)
 
-    def add_statements(self, model_id, date, stmt_jsons, max_updates=7):
+    def add_statements(self, model_id, date, stmt_jsons, max_updates=3):
         """Add statements to the database.
 
         Parameters

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -626,7 +626,7 @@ class StatementDatabaseManager(EmmaaDatabaseManager):
         """Build the database from S3 files."""
         self.create_tables()
         # Add each model one by one
-        for model, config in get_models():
+        for model, config in get_models(include_config=True):
             self.add_model_from_s3(model, config, number_of_updates, bucket)
 
     def add_model_from_s3(self, model_id, config=None, number_of_updates=7,

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -618,7 +618,7 @@ class StatementDatabaseManager(EmmaaDatabaseManager):
     table_order = ['statement']
     table_parent_class = StatementsDbTable
 
-    def add_statements(self, model_id, date, statements):
+    def add_statements(self, model_id, date, stmt_jsons):
         """Add statements to the database.
 
         Parameters
@@ -627,26 +627,23 @@ class StatementDatabaseManager(EmmaaDatabaseManager):
             The standard name of the model to add statements to.
         date : str
             The date when the model was generated.
-        statements : list[str]
-            A list of statements to add to the database.
+        stmt_jsons : list[dict]
+            A list of statement JSONs to add to the database.
 
         Returns
         -------
         bool
             True if the statements were added successfully, False otherwise.
         """
-        logger.info(f'Got request to add {len(statements)} statements to '
+        logger.info(f'Got request to add {len(stmt_jsons)} statements to '
                     f'model {model_id} on date {date}')
-        stmt_jsons = stmts_to_json(statements)
-        logger.info(f'Converted {len(statements)} statements to json')
         stmts_to_add = [Statement(model_id=model_id, date=date,
                                   stmt_hash=stmt_json['matches_hash'],
                                   statement_json=stmt_json)
                         for stmt_json in stmt_jsons]
-        logger.info(f'Converted {len(statements)} statements to db objects')
         with self.get_session() as sess:
             sess.add_all(stmts_to_add)
-        logger.info(f'Added {len(statements)} statements to db')
+        logger.info(f'Added {len(stmt_jsons)} statements to db')
         return
 
     def get_statements(self, model_id, date, offset=0, limit=None,

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -610,12 +610,15 @@ class EmmaaDatabaseManager(object):
         logger.info(f'Got request to add {len(statements)} statements to '
                     f'model {model_id} on date {date}')
         stmt_jsons = stmts_to_json(statements)
+        logger.info(f'Converted {len(statements)} statements to json')
         stmts_to_add = [Statement(model_id=model_id, date=date,
                                   stmt_hash=stmt_json['matches_hash'],
                                   statement_json=stmt_json)
                         for stmt_json in stmt_jsons]
+        logger.info(f'Converted {len(statements)} statements to db objects')
         with self.get_session() as sess:
             sess.add_all(stmts_to_add)
+        logger.info(f'Added {len(statements)} statements to db')
         return
 
     def get_statements(self, model_id, date, offset=0, limit=None):
@@ -667,7 +670,7 @@ class EmmaaDatabaseManager(object):
             A list of statements corresponding to the model and date.
         """
         logger.info(f'Got request to get statements for model {model_id} '
-                    f'on date {date}')
+                    f'on date {date} for {len(stmt_hashes)} hashes')
         with self.get_session() as sess:
             q = sess.query(Statement.statement_json).filter(
                 Statement.model_id == model_id,

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -635,6 +635,8 @@ class StatementDatabaseManager(EmmaaDatabaseManager):
         if not config:
             config = load_config_from_s3(model_id)
         test_corpora = config['test']['test_corpus']
+        if isinstance(test_corpora, str):
+            test_corpora = [test_corpora]
         stmt_files = sort_s3_files_by_date_str(
             bucket, f'assembled/{model_id}/statements_', '.gz')
         stmt_files_to_use = stmt_files[:number_of_updates]

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -655,7 +655,8 @@ class EmmaaDatabaseManager(object):
             A list of statements corresponding to the model and date.
         """
         logger.info(f'Got request to get statements for model {model_id} '
-                    f'on date {date}')
+                    f'on date {date} with offset {offset} and limit {limit} '
+                    f'and sort by {sort_by}')
         with self.get_session() as sess:
             q = sess.query(Statement.statement_json).filter(
                 Statement.model_id == model_id,
@@ -664,6 +665,8 @@ class EmmaaDatabaseManager(object):
             if sort_by == 'evidence':
                 q = q.order_by(jsonb_array_length(
                     Statement.statement_json["evidence"]).desc())
+            elif sort_by == 'belief':
+                q = q.order_by(Statement.statement_json['belief'].desc())
             if limit:
                 q = q.offset(offset).limit(limit)
             stmts = stmts_from_json([s for s, in q.all()])

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -835,6 +835,45 @@ class StatementDatabaseManager(EmmaaDatabaseManager):
             }
         return path_counts
 
+    def get_number_of_dates(self, model_id):
+        """Get the number of unique dates this model is available for.
+
+        Parameters
+        ----------
+        model_id : str
+            The standard name of the model.
+
+        Returns
+        -------
+        int
+            The number of unique dates this model is available for.
+        """
+        logger.info(f'Got request to get number of dates for model {model_id}')
+        with self.get_session() as sess:
+            q = sess.query(Statement.date).filter(
+                Statement.model_id == model_id).distinct()
+            return q.count()
+
+    def get_oldest_date(self, model_id):
+        """Get the oldest date this model is available for.
+
+        Parameters
+        ----------
+        model_id : str
+            The standard name of the model.
+
+        Returns
+        -------
+        str
+            The oldest date this model is available for.
+        """
+        logger.info(f'Got request to get oldest date for model {model_id}')
+        with self.get_session() as sess:
+            q = sess.query(Statement.date).filter(
+                Statement.model_id == model_id).order_by(
+                    Statement.date.asc()).first()
+            return q.date if q else None
+
 
 def _weed_results(result_iter, latest_order=1):
     # Each element of result_iter:

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -664,6 +664,7 @@ class EmmaaDatabaseManager(object):
                 Statement.date == date
             )
             if stmt_types:
+                stmt_types = [stmt_type.lower() for stmt_type in stmt_types]
                 q = q.filter(
                     func.lower(Statement.statement_json[
                         'type'].astext).in_(stmt_types))

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -9,7 +9,7 @@ __all__ = ['EmmaaDatabaseManager', 'EmmaaDatabaseError',
 import logging
 
 from botocore.exceptions import ClientError
-from sqlalchemy import create_engine, func, Float
+from sqlalchemy import create_engine, func, Float, nullslast
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql.expression import FunctionElement
 from sqlalchemy.ext.compiler import compiles
@@ -753,10 +753,11 @@ class StatementDatabaseManager(EmmaaDatabaseManager):
                     Statement.statement_json['belief'].astext.cast(
                         Float) <= float(max_belief))
             if sort_by == 'evidence':
-                q = q.order_by(jsonb_array_length(
-                    Statement.statement_json["evidence"]).desc())
+                q = q.order_by(nullslast(jsonb_array_length(
+                    Statement.statement_json["evidence"]).desc()))
             elif sort_by == 'belief':
-                q = q.order_by(Statement.statement_json['belief'].desc())
+                q = q.order_by(
+                    nullslast(Statement.statement_json['belief'].desc()))
             elif sort_by == 'paths':
                 q = q.order_by(Statement.path_count.desc())
             if offset:

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -683,8 +683,10 @@ class EmmaaDatabaseManager(object):
                 q = q.order_by(Statement.statement_json['belief'].desc())
             elif sort_by == 'paths':
                 q = q.order_by(Statement.path_count.desc())
+            if offset:
+                q = q.offset(offset)
             if limit:
-                q = q.offset(offset).limit(limit)
+                q = q.limit(limit)
             stmts = stmts_from_json([s for s, in q.all()])
             logger.info(f'Got {len(stmts)} statements')
         return stmts

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -739,7 +739,7 @@ class EmmaaDatabaseManager(object):
 
         Returns
         -------
-        dict[int, int]
+        dict[str, int]
             A dictionary mapping statement hashes to the number of times they
             were used in the paths.
         """
@@ -751,7 +751,7 @@ class EmmaaDatabaseManager(object):
                 Statement.date == date
             )
             path_counts = {
-                stmt_hash: path_count for stmt_hash, path_count in q.all()
+                str(stmt_hash): path_count for stmt_hash, path_count in q.all()
                 if path_count > 0
             }
         return path_counts

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -666,7 +666,14 @@ class StatementDatabaseManager(EmmaaDatabaseManager):
                     else:
                         raise e
 
-    # TODO: delete older records from the database when adding new ones
+    def delete_statements(self, model_id, date):
+        """Delete statements from the database."""
+        logger.info(f'Got request to delete stmts for {model_id} on {date}')
+        with self.get_session() as sess:
+            q = sess.query(Statement).filter(
+                Statement.model_id == model_id,
+                Statement.date == date)
+            q.delete(synchronize_session=False)
 
     def add_statements(self, model_id, date, stmt_jsons):
         """Add statements to the database.

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -623,7 +623,11 @@ class StatementDatabaseManager(EmmaaDatabaseManager):
     table_parent_class = StatementsDbTable
 
     def build_from_s3(self, number_of_updates=7, bucket=EMMAA_BUCKET_NAME):
-        """Build the database from S3 files."""
+        """
+        Build the database from S3 files.
+        NOTE: This deletes existing database entries and repopulates the tables.
+        """
+        self.drop_tables()
         self.create_tables()
         # Add each model one by one
         for model, config in get_models(include_config=True):

--- a/emmaa/db/manager.py
+++ b/emmaa/db/manager.py
@@ -727,6 +727,35 @@ class EmmaaDatabaseManager(object):
                     Statement.stmt_hash == stmt_hash).first()
                 stmt.path_count += path_count
 
+    def get_path_counts(self, model_id, date):
+        """Get the path counts for statements.
+
+        Parameters
+        ----------
+        model_id : str
+            The standard name of the model.
+        date : str
+            The date when the model was generated.
+
+        Returns
+        -------
+        dict[int, int]
+            A dictionary mapping statement hashes to the number of times they
+            were used in the paths.
+        """
+        logger.info(f'Got request to get path counts for model {model_id} '
+                    f'on date {date}')
+        with self.get_session() as sess:
+            q = sess.query(Statement.stmt_hash, Statement.path_count).filter(
+                Statement.model_id == model_id,
+                Statement.date == date
+            )
+            path_counts = {
+                stmt_hash: path_count for stmt_hash, path_count in q.all()
+                if path_count > 0
+            }
+        return path_counts
+
 
 def _weed_results(result_iter, latest_order=1):
     # Each element of result_iter:

--- a/emmaa/db/schema.py
+++ b/emmaa/db/schema.py
@@ -201,3 +201,4 @@ class Statement(Base, EmmaaTable):
     stmt_hash = Column(BigInteger, nullable=False)
     date = Column(String(10), nullable=False)
     statement_json = Column(JSONB, nullable=False)
+    path_count = Column(Integer, nullable=False, default=0)

--- a/emmaa/db/schema.py
+++ b/emmaa/db/schema.py
@@ -176,3 +176,28 @@ class Result(Base, EmmaaTable):
     mc_type = Column(String(20), default='pysb')
     all_result_hashes = Column(ARRAY(String), default=[])
     delta = Column(ARRAY(String), default=[])
+
+
+class Statement(Base, EmmaaTable):
+    """Statements in the model:
+
+    ``Statement(_id_, model_id, date, statement_json)``
+
+    Parameters
+    ----------
+    id : int
+        (auto, primary key) A database-assigned integer id.
+    model_id : str
+        (20 character) The short id/acronym for the given model.
+    stmt_hash : big-int
+        The hash of the statement.
+    date : str
+        The date when the model was assembled.
+    statement_json : json
+    """
+    __tablename__ = 'statement'
+    id = Column(Integer, primary_key=True)
+    model_id = Column(String(20), nullable=False)
+    stmt_hash = Column(BigInteger, nullable=False)
+    date = Column(String(10), nullable=False)
+    statement_json = Column(JSONB, nullable=False)

--- a/emmaa/db/schema.py
+++ b/emmaa/db/schema.py
@@ -46,10 +46,12 @@ class EmmaaTable(object):
 
 
 class QueriesDbTable(EmmaaTable):
+    __tablename__ = ''
     pass
 
 
 class StatementsDbTable(EmmaaTable):
+    __tablename__ = ''
     pass
 
 

--- a/emmaa/db/schema.py
+++ b/emmaa/db/schema.py
@@ -1,4 +1,4 @@
-__all__ = ['User', 'Query', 'UserQuery', 'Result', 'UserModel']
+__all__ = ['User', 'Query', 'UserQuery', 'Result', 'UserModel', 'Statement']
 
 import logging
 
@@ -45,7 +45,15 @@ class EmmaaTable(object):
                f'({", ".join(self._content_strings())})'
 
 
-class User(Base, EmmaaTable):
+class QueriesDbTable(EmmaaTable):
+    pass
+
+
+class StatementsDbTable(EmmaaTable):
+    pass
+
+
+class User(Base, QueriesDbTable):
     """A table containing users of EMMAA: ``User(_id_, email)``
 
     Parameters
@@ -62,7 +70,7 @@ class User(Base, EmmaaTable):
     email = Column(String, unique=True)
 
 
-class Query(Base, EmmaaTable):
+class Query(Base, QueriesDbTable):
     """Queries run on each model: ``Query(_hash_, model_id, json, qtype)``
 
     The hash column is a hash generated from the json and model_id columns
@@ -87,7 +95,7 @@ class Query(Base, EmmaaTable):
         )
 
 
-class UserQuery(Base, EmmaaTable):
+class UserQuery(Base, QueriesDbTable):
     """A table linking users to queries:
 
     ``UserQuery(_id_, user_id, query_hash, date, subscription, count)``
@@ -120,7 +128,7 @@ class UserQuery(Base, EmmaaTable):
     count = Column(Integer, nullable=False)
 
 
-class UserModel(Base, EmmaaTable):
+class UserModel(Base, QueriesDbTable):
     """A table linking users to models:
 
     ``UserModel(_id_, user_id, model_id, date, subscription)``
@@ -147,7 +155,7 @@ class UserModel(Base, EmmaaTable):
     subscription = Column(Boolean, nullable=False)
 
 
-class Result(Base, EmmaaTable):
+class Result(Base, QueriesDbTable):
     """Results of queries to models:
 
     ``Result(_id_, query_hash, date, result_json, mc_type, all_result_hashes,
@@ -178,7 +186,7 @@ class Result(Base, EmmaaTable):
     delta = Column(ARRAY(String), default=[])
 
 
-class Statement(Base, EmmaaTable):
+class Statement(Base, StatementsDbTable):
     """Statements in the model:
 
     ``Statement(_id_, model_id, date, statement_json)``

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -979,7 +979,7 @@ def get_models(include_config=False, include_dev=False,
     for pref in resp['CommonPrefixes']:
         model = pref['Prefix'].split('/')[1]
         config_json = config_load_func(model, bucket=bucket)
-        if not config_json:
+        if model == 'test' or not config_json:
             continue
         if not include_dev and config_json.get('dev_only', False):
             continue

--- a/emmaa/model.py
+++ b/emmaa/model.py
@@ -951,6 +951,45 @@ def get_assembled_statements(model, date=None, bucket=EMMAA_BUCKET_NAME):
     return stmts, latest_file_key
 
 
+def get_models(include_config=False, include_dev=False,
+               config_load_func=load_config_from_s3, bucket=EMMAA_BUCKET_NAME):
+    """Get a list of all models in the EMMAA bucket.
+
+    Parameters
+    ----------
+    include_config : bool
+        Whether to include the config file for each model.
+    include_dev : bool
+        Whether to include the models in dev mode.
+    config_load_func : function
+        A function to load the config file (e.g. from s3 or from cache).
+    bucket : str
+        Name of S3 bucket to look for a file. Defaults to 'emmaa'.
+
+    Returns
+    -------
+    model_data : list[str] or list(tuple(str, dict))
+        A list of model names. If `include_config` is True, the list is a
+        list of tuples of model names and configs.
+    """
+    s3 = get_s3_client()
+    resp = s3.list_objects(Bucket=bucket, Prefix='models/',
+                           Delimiter='/')
+    model_data = []
+    for pref in resp['CommonPrefixes']:
+        model = pref['Prefix'].split('/')[1]
+        config_json = config_load_func(model, bucket=bucket)
+        if not config_json:
+            continue
+        if not include_dev and config_json.get('dev_only', False):
+            continue
+        if include_config:
+            model_data.append((model, config_json))
+        else:
+            model_data.append(model)
+    return model_data
+
+
 @register_pipeline
 def load_custom_grounding_map(model, bucket=EMMAA_BUCKET_NAME):
     key = f'models/{model}/grounding_map.json'

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -709,7 +709,8 @@ class ModelManager(object):
         db.update_statements_path_counts(
             self.model.name, self.date_str[10:], self.path_stmt_counts)
 
-    def save_assembled_statements(self, bucket=EMMAA_BUCKET_NAME):
+    def save_assembled_statements(self, upload_to_db=True,
+                                  bucket=EMMAA_BUCKET_NAME):
         """Upload assembled statements jsons to S3 bucket."""
         def save_stmts(stmts, model_name, save_to_db):
             stmts_json = stmts_to_json(stmts)
@@ -732,7 +733,10 @@ class ModelManager(object):
                 db = get_db('stmt')
                 db.add_statements(model_name, self.date_str[10:], stmts_json)
 
-        save_stmts(self.model.assembled_stmts, self.model.name, save_to_db=True)
+        # Assembled statements are also dumped to the database unless specified
+        # otherwise; dynamic statements are only stored on s3
+        save_stmts(self.model.assembled_stmts, self.model.name,
+                   save_to_db=upload_to_db)
         if hasattr(self.model, 'dynamic_assembled_stmts') and \
                 self.model.dynamic_assembled_stmts:
             save_stmts(self.model.dynamic_assembled_stmts,

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -30,7 +30,7 @@ from emmaa.util import make_date_str, get_s3_client, \
     save_pickle_to_s3, load_json_from_s3, save_json_to_s3, strip_out_date, \
     save_gzip_json_to_s3
 from emmaa.filter_functions import node_filter_functions, edge_filter_functions
-from emmaa.db import get_statements_db
+from emmaa.db import get_db
 
 
 logger = logging.getLogger(__name__)
@@ -705,7 +705,7 @@ class ModelManager(object):
         save_json_to_s3(json_lines, bucket, latest_paths_key, 'jsonl')
 
         # Also save the path counts to the database
-        db = get_statements_db()
+        db = get_db('stmt')
         db.update_statements_path_counts(
             self.model.name, self.date_str[10:], self.path_stmt_counts)
 
@@ -729,7 +729,7 @@ class ModelManager(object):
             logger.info(f'Uploading assembled statements to {dated_zip}')
             save_gzip_json_to_s3(stmts_json, bucket, dated_zip, 'json')
             if save_to_db:
-                db = get_statements_db()
+                db = get_db('stmt')
                 db.add_statements(model_name, self.date_str[10:], stmts_json)
 
         save_stmts(self.model.assembled_stmts, self.model.name, save_to_db=True)

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -689,7 +689,8 @@ class ModelManager(object):
         return results_json, json_lines
 
     def upload_results(self, test_corpus='large_corpus_tests',
-                       test_data=None, bucket=EMMAA_BUCKET_NAME):
+                       test_data=None, upload_to_db=True,
+                       bucket=EMMAA_BUCKET_NAME):
         """Upload results to s3 bucket."""
         json_dict, json_lines = self.results_to_json(test_data)
         result_key = (f'results/{self.model.name}/results_'
@@ -704,10 +705,11 @@ class ModelManager(object):
         save_json_to_s3(json_lines, bucket, paths_key, save_format='jsonl')
         save_json_to_s3(json_lines, bucket, latest_paths_key, 'jsonl')
 
-        # Also save the path counts to the database
-        db = get_db('stmt')
-        db.update_statements_path_counts(
-            self.model.name, self.date_str[10:], self.path_stmt_counts)
+        # Also save the path counts to the database if requested
+        if upload_to_db:
+            db = get_db('stmt')
+            db.update_statements_path_counts(
+                self.model.name, self.date_str[10:], self.path_stmt_counts)
 
     def save_assembled_statements(self, upload_to_db=True,
                                   bucket=EMMAA_BUCKET_NAME):
@@ -1019,7 +1021,8 @@ def save_tests_to_s3(tests, bucket, key, save_format='pkl'):
 
 
 def run_model_tests_from_s3(model_name, test_corpus='large_corpus_tests',
-                            upload_results=True, bucket=EMMAA_BUCKET_NAME):
+                            upload_results=True, upload_to_db=True,
+                            bucket=EMMAA_BUCKET_NAME):
     """Run a given set of tests on a given model, both loaded from S3.
 
     After loading both the model and the set of tests, model/test overlap
@@ -1035,7 +1038,9 @@ def run_model_tests_from_s3(model_name, test_corpus='large_corpus_tests',
     upload_results : Optional[bool]
         Whether to upload test results to S3 in JSON format. Can be set
         to False when running tests. Default: True
-
+    upload_to_db : Optional[bool]
+        Whether to update path counts in the database. Can be set
+        to False when running tests. Default: True
     Returns
     -------
     emmaa.model_tests.ModelManager
@@ -1077,5 +1082,6 @@ def run_model_tests_from_s3(model_name, test_corpus='large_corpus_tests',
     tm.run_tests(filter_func, edge_filter_func, allow_direct)
     # Optionally upload test results to S3
     if upload_results:
-        mm.upload_results(test_corpus, test_data, bucket=bucket)
+        mm.upload_results(test_corpus, test_data, upload_to_db=upload_to_db,
+                          bucket=bucket)
     return mm

--- a/emmaa/model_tests.py
+++ b/emmaa/model_tests.py
@@ -709,7 +709,7 @@ class ModelManager(object):
         if upload_to_db:
             db = get_db('stmt')
             db.update_statements_path_counts(
-                self.model.name, self.date_str[10:], self.path_stmt_counts)
+                self.model.name, self.date_str[:10], self.path_stmt_counts)
 
     def save_assembled_statements(self, upload_to_db=True,
                                   bucket=EMMAA_BUCKET_NAME):
@@ -733,7 +733,7 @@ class ModelManager(object):
             save_gzip_json_to_s3(stmts_json, bucket, dated_zip, 'json')
             if save_to_db:
                 db = get_db('stmt')
-                db.add_statements(model_name, self.date_str[10:], stmts_json)
+                db.add_statements(model_name, self.date_str[:10], stmts_json)
 
         # Assembled statements are also dumped to the database unless specified
         # otherwise; dynamic statements are only stored on s3

--- a/emmaa/tests/db_setup.py
+++ b/emmaa/tests/db_setup.py
@@ -1,24 +1,44 @@
 from sqlalchemy_utils import create_database, drop_database, database_exists
-from emmaa.db import EmmaaDatabaseManager
+from emmaa.db import QueryDatabaseManager, StatementDatabaseManager
 
 
-db_url = 'postgresql://postgres:@localhost/emmaadb_test'
+query_db_url = 'postgresql://postgres:@localhost/emmaadb_test'
+stmt_db_url = 'postgresql://postgres:@localhost/emmaadb_stmt_test'
 
 
-def _get_test_db(db_name='emmaadb_test'):
-    db = EmmaaDatabaseManager(db_url)
+def _get_test_db(db_name='query'):
+    if db_name == 'query':
+        db = QueryDatabaseManager(query_db_url)
+    elif db_name == 'stmt':
+        db = StatementDatabaseManager(stmt_db_url)
     return db
 
 
-def setup_function():
+def setup_function(db_name, db_url):
     print('setup')
     if database_exists(db_url):
         drop_database(db_url)
     create_database(db_url)
-    db = _get_test_db()
+    db = _get_test_db(db_name)
     db.create_tables()
 
 
-def teardown_function():
+def teardown_function(db_url):
     print('tear')
     drop_database(db_url)
+
+
+def setup_query_db():
+    setup_function('query', query_db_url)
+
+
+def teardown_query_db():
+    teardown_function(query_db_url)
+
+
+def setup_stmt_db():
+    setup_function('stmt', stmt_db_url)
+
+
+def teardown_stmt_db():
+    teardown_function(stmt_db_url)

--- a/emmaa/tests/test_answer_queries.py
+++ b/emmaa/tests/test_answer_queries.py
@@ -4,16 +4,16 @@ from emmaa.answer_queries import QueryManager, format_results
 from emmaa.queries import Query, DynamicProperty, get_agent_from_trips
 from emmaa.model_tests import ModelManager
 from emmaa.tests.test_model import create_model
-from emmaa.tests.db_setup import _get_test_db, setup_function, \
-    teardown_function
+from emmaa.tests.db_setup import _get_test_db, setup_query_db, \
+    teardown_query_db
 
 
 def setup_module():
-    setup_function()
+    setup_query_db()
 
 
 def teardown_module():
-    teardown_function()
+    teardown_query_db()
 
 
 test_query = {'type': 'path_property', 'path': {'type': 'Activation',

--- a/emmaa/tests/test_db.py
+++ b/emmaa/tests/test_db.py
@@ -4,7 +4,8 @@ import random
 from nose.plugins.attrib import attr
 from nose.tools import with_setup
 
-from indra.statements import Activation,  Agent, Evidence, Phosphorylation
+from indra.statements import Activation,  Agent, Evidence, Phosphorylation, \
+    stmts_to_json
 from emmaa.db import Query, Result, User, UserQuery
 from emmaa.queries import Query as QueryObject, PathProperty
 from emmaa.tests.db_setup import _get_test_db, setup_query_db, \
@@ -258,7 +259,8 @@ def test_get_statements():
     stmts[1].belief = 0.9
     hash0 = stmts[0].get_hash()
     hash1 = stmts[1].get_hash()
-    db.add_statements(model_id, date, stmts)
+    stmt_jsons = stmts_to_json(stmts)
+    db.add_statements(model_id, date, stmt_jsons)
     db.update_statements_path_counts(model_id, date, {hash0: 1, hash1: 5})
 
     # Load statements with different sort/filter options
@@ -335,7 +337,8 @@ def test_get_statements_by_hash():
         ]
     hash0 = stmts[0].get_hash()
     hash1 = stmts[1].get_hash()
-    db.add_statements(model_id, date, stmts)
+    stmt_jsons = stmts_to_json(stmts)
+    db.add_statements(model_id, date, stmt_jsons)
 
     # Load statements by hash
     stmts_loaded = db.get_statements_by_hash(model_id, date, [hash0, hash1])
@@ -371,7 +374,8 @@ def test_path_counts():
         ]
     hash0 = str(stmts[0].get_hash())
     hash1 = str(stmts[1].get_hash())
-    db.add_statements(model_id, date, stmts)
+    stmt_jsons = stmts_to_json(stmts)
+    db.add_statements(model_id, date, stmt_jsons)
     # All path counts should be 0
     path_counts = db.get_path_counts(model_id, date)
     assert len(path_counts) == 0

--- a/emmaa/tests/test_db.py
+++ b/emmaa/tests/test_db.py
@@ -7,8 +7,8 @@ from nose.tools import with_setup
 from indra.statements import Activation,  Agent, Evidence, Phosphorylation
 from emmaa.db import Query, Result, User, UserQuery
 from emmaa.queries import Query as QueryObject, PathProperty
-from emmaa.tests.db_setup import _get_test_db, setup_function, \
-    teardown_function
+from emmaa.tests.db_setup import _get_test_db, setup_query_db, \
+    teardown_query_db, setup_stmt_db, teardown_stmt_db
 
 
 test_query_jsons = [{'type': 'path_property', 'path': {'type': 'Activation',
@@ -22,7 +22,7 @@ test_query_jsons = [{'type': 'path_property', 'path': {'type': 'Activation',
 test_queries = [QueryObject._from_json(qj) for qj in test_query_jsons]
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_query_db, teardown_query_db)
 @attr('nonpublic')
 def test_instantiation():
     db = _get_test_db()
@@ -30,7 +30,7 @@ def test_instantiation():
     return
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_query_db, teardown_query_db)
 @attr('nonpublic')
 def test_put_queries():
     db = _get_test_db()
@@ -45,7 +45,7 @@ def test_put_queries():
     assert len(queries) == 3, len(queries)
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_query_db, teardown_query_db)
 @attr('nonpublic')
 def test_get_queries():
     db = _get_test_db()
@@ -66,7 +66,7 @@ def _get_random_result():
         [{'12': [['This is fine.', '']]}, {'34': [['This is not ok.', '']]}])
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_query_db, teardown_query_db)
 @attr('nonpublic')
 def test_put_results():
     db = _get_test_db()
@@ -80,7 +80,7 @@ def test_put_results():
     assert len(db_results) == len(results)
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_query_db, teardown_query_db)
 @attr('nonpublic')
 def test_get_results():
     db = _get_test_db()
@@ -103,7 +103,7 @@ def test_get_results():
     assert all(isinstance(result[3], dict) for result in results)
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_query_db, teardown_query_db)
 @attr('nonpublic')
 def test_get_latest_results():
     db = _get_test_db()
@@ -132,7 +132,7 @@ def test_get_latest_results():
     assert all(isinstance(result[3], dict) for result in results)
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_query_db, teardown_query_db)
 @attr('nonpublic')
 def test_get_subscribed_queries():
     db = _get_test_db()
@@ -144,7 +144,7 @@ def test_get_subscribed_queries():
     assert queries[0][2] == test_queries[0].get_hash_with_model('aml')
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_query_db, teardown_query_db)
 @attr('nonpublic')
 def test_get_subscribed_users():
     db = _get_test_db()
@@ -156,7 +156,7 @@ def test_get_subscribed_users():
     assert emails[0] == 'test1@test.com'
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_query_db, teardown_query_db)
 @attr('nonpublic')
 def test_update_email_subscription():
     db = _get_test_db()
@@ -174,7 +174,7 @@ def test_update_email_subscription():
     assert not [q[0] for q in q.all()][0]  # new subscription status is False
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_query_db, teardown_query_db)
 @attr('nonpublic')
 def test_get_number_results():
     db = _get_test_db()
@@ -188,7 +188,7 @@ def test_get_number_results():
     assert db.get_number_of_results(qh, 'pysb') == 3
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_query_db, teardown_query_db)
 @attr('nonpublic')
 def test_get_all_result_hashes_and_delta():
     db = _get_test_db()
@@ -215,7 +215,7 @@ def test_get_all_result_hashes_and_delta():
     assert results[0][4] == [], results[0]
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_query_db, teardown_query_db)
 @attr('nonpublic')
 def test_model_subscription():
     db = _get_test_db()
@@ -232,10 +232,10 @@ def test_model_subscription():
     assert ms_users == []
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_stmt_db, teardown_stmt_db)
 @attr('nonpublic')
 def test_get_statements():
-    db = _get_test_db()
+    db = _get_test_db('stmt')
     # Put statements and path counts in the database
     model_id = 'test'
     date = '2021-01-01'
@@ -311,10 +311,10 @@ def test_get_statements():
     assert len(stmts_loaded) == 1
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_stmt_db, teardown_stmt_db)
 @attr('nonpublic')
 def test_get_statements_by_hash():
-    db = _get_test_db()
+    db = _get_test_db('stmt')
     # Put statements in the database
     model_id = 'test'
     date = '2021-01-01'
@@ -347,10 +347,10 @@ def test_get_statements_by_hash():
     assert stmts_loaded[0].get_hash() == hash0
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_stmt_db, teardown_stmt_db)
 @attr('nonpublic')
 def test_path_counts():
-    db = _get_test_db()
+    db = _get_test_db('stmt')
     # Put statements in the database
     model_id = 'test'
     date = '2021-01-01'

--- a/emmaa/tests/test_notifications.py
+++ b/emmaa/tests/test_notifications.py
@@ -3,19 +3,19 @@ from nose.plugins.attrib import attr
 from emmaa.subscription.notifications import make_str_report_per_user, \
     make_html_report_per_user, get_user_query_delta, \
     make_reports_from_results, get_all_update_messages
-from emmaa.tests.db_setup import _get_test_db, setup_function, \
-    teardown_function
+from emmaa.tests.db_setup import _get_test_db, setup_query_db, \
+    teardown_query_db
 from emmaa.tests.test_answer_queries import query_object, test_email, \
     test_response, fail_response, query_not_appl, open_query, dyn_query
 from emmaa.util import _make_delta_msg
 
 
 def setup_module():
-    setup_function()
+    setup_query_db()
 
 
 def teardown_module():
-    teardown_function()
+    teardown_query_db()
 
 
 @attr('nonpublic')

--- a/emmaa/tests/test_s3.py
+++ b/emmaa/tests/test_s3.py
@@ -227,7 +227,7 @@ def test_run_model_tests_from_s3():
     assert not last_updated_date('test', 'test_results', tests='simple_tests',
                                  extension='.json', bucket=TEST_BUCKET_NAME)
     mm = run_model_tests_from_s3('test', 'simple_tests', upload_results=True,
-                                 bucket=TEST_BUCKET_NAME)
+                                 upload_to_db=False, bucket=TEST_BUCKET_NAME)
     assert isinstance(mm, ModelManager)
     # Results are saved now
     assert last_updated_date('test', 'test_results', tests='simple_tests',

--- a/emmaa/tests/test_s3.py
+++ b/emmaa/tests/test_s3.py
@@ -12,9 +12,8 @@ from emmaa.tests.test_stats import previous_results, \
     previous_test_stats, previous_model_stats
 from emmaa.tests.test_answer_queries import query_object
 from emmaa.util import make_date_str, RE_DATETIMEFORMAT, RE_DATEFORMAT
-from emmaa.tests.db_setup import _get_test_db, setup_function, \
-    teardown_function
-
+from emmaa.tests.db_setup import _get_test_db, setup_query_db, \
+    teardown_query_db
 TEST_BUCKET_NAME = 'test_bucket'
 
 
@@ -343,7 +342,7 @@ def test_generate_stats_on_s3():
         TEST_BUCKET_NAME, 'stats/test/test_stats_') == 2
 
 
-@with_setup(setup_function, teardown_function)
+@with_setup(setup_query_db, teardown_query_db)
 @mock_s3
 def test_answer_queries_from_s3():
     # Local imports are recommended when using moto

--- a/emmaa/tests/test_s3.py
+++ b/emmaa/tests/test_s3.py
@@ -68,7 +68,8 @@ def setup_bucket(
             emmaa_model = create_model()
         mm = ModelManager(emmaa_model)
         mm.date_str = date_str
-        mm.save_assembled_statements(bucket=TEST_BUCKET_NAME)
+        mm.save_assembled_statements(
+            upload_to_db=False, bucket=TEST_BUCKET_NAME)
         save_model_manager_to_s3('test', mm, bucket=TEST_BUCKET_NAME)
     if add_tests:
         tests = [StatementCheckingTest(

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -830,7 +830,7 @@ def _count_curations(curations, stmts_by_hash):
 
 
 def _local_sort_filter_stmts(
-        stmts, stmts_by_hash, offset, sort_by, stmt_types, min_belief,
+        model, stmts, stmts_by_hash, offset, sort_by, stmt_types, min_belief,
         max_belief, filter_curated, cur_counts):
     # This is the old way of filtering/sorting statements after loading all of
     # them in memory, used when statements are not available in the db
@@ -1865,8 +1865,8 @@ def get_all_statements_page(model):
     if not from_db:
         # Apply filters and sort locally
         stmts, stmt_counts_dict = _local_sort_filter_stmts(
-            stmts, stmts_by_hash, offset, sort_by, stmt_types, min_belief,
-            max_belief, filter_curated, cur_counts)
+            model, stmts, stmts_by_hash, offset, sort_by, stmt_types,
+            min_belief, max_belief, filter_curated, cur_counts)
     else:
         # Most filters and sorting are already done in the database
         stmt_counts_dict = load_path_counts(model, date)

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -45,7 +45,7 @@ from emmaa.queries import PathProperty, get_agent_from_text, GroundingError, \
     DynamicProperty, OpenSearchQuery, SimpleInterventionProperty
 from emmaa.xdd import get_document_figures, get_figures_from_query
 from emmaa.analyze_tests_results import _get_trid_title, AgentStatsGenerator
-from emmaa.db import get_statements_db
+from emmaa.db import get_db
 
 from indralab_auth_tools.auth import auth, config_auth, resolve_auth
 from indralab_web_templates.path_templates import path_temps
@@ -491,7 +491,7 @@ def _load_stmts_from_cache(model, date):
 
 
 def load_stmts(model, date, stmt_hashes=None, **kwargs):
-    emmaa_db = get_statements_db()
+    emmaa_db = get_db('stmt')
     if stmt_hashes:
         stmts = emmaa_db.get_statements_by_hash(model, date, stmt_hashes)
     else:
@@ -513,7 +513,7 @@ def load_stmts(model, date, stmt_hashes=None, **kwargs):
 
 
 def load_path_counts(model, date):
-    emmaa_db = get_statements_db()
+    emmaa_db = get_db('stmt')
     return emmaa_db.get_path_counts(model, date)
 
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -500,6 +500,9 @@ def load_stmts(model, date, **kwargs):
                     'using S3/cache.')
         stmts = _load_stmts_from_cache(model, date)
         from_db = False
+    # Clear the cache for this model if it's not activelly used
+    if from_db and model in stmts_cache:
+        del stmts_cache[model]
     return stmts, from_db
 
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -45,7 +45,7 @@ from emmaa.queries import PathProperty, get_agent_from_text, GroundingError, \
     DynamicProperty, OpenSearchQuery, SimpleInterventionProperty
 from emmaa.xdd import get_document_figures, get_figures_from_query
 from emmaa.analyze_tests_results import _get_trid_title, AgentStatsGenerator
-from emmaa.db import get_db as get_emmaa_db
+from emmaa.db import get_statements_db
 
 from indralab_auth_tools.auth import auth, config_auth, resolve_auth
 from indralab_web_templates.path_templates import path_temps
@@ -491,7 +491,7 @@ def _load_stmts_from_cache(model, date):
 
 
 def load_stmts(model, date, **kwargs):
-    emmaa_db = get_emmaa_db('dev')
+    emmaa_db = get_statements_db()
     stmts = emmaa_db.get_statements(model, date, **kwargs)
     from_db = True
     # Statements for that model/date are not in db
@@ -507,7 +507,7 @@ def load_stmts(model, date, **kwargs):
 
 
 def load_stmts_by_hash(model, date, stmt_hashes):
-    emmaa_db = get_emmaa_db('dev')
+    emmaa_db = get_statements_db()
     stmts = emmaa_db.get_statements_by_hash(model, date, stmt_hashes)
     # Statements for that model/date are not in db
     if not stmts:
@@ -517,7 +517,7 @@ def load_stmts_by_hash(model, date, stmt_hashes):
 
 
 def load_path_counts(model, date):
-    emmaa_db = get_emmaa_db('dev')
+    emmaa_db = get_statements_db()
     return emmaa_db.get_path_counts(model, date)
 
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -1870,7 +1870,6 @@ def get_all_statements_page(model):
         model, date, sort_by=sort_by, offset=offset, limit=1000,
         stmt_types=stmt_types, min_belief=min_belief, max_belief=max_belief)
 
-    print("FROM DB: ", from_db)
     # For now agent filter is applied locally
     if agent:
         stmts = AgentStatsGenerator.filter_stmts(agent, stmts)

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -36,7 +36,7 @@ from emmaa.util import find_latest_s3_file, does_exist, \
     EMMAA_BUCKET_NAME, list_s3_files, find_index_of_s3_file, \
     find_number_of_files_on_s3, FORMATTED_TYPE_NAMES
 from emmaa.model import load_config_from_s3, last_updated_date, \
-    get_model_stats, _default_test, get_assembled_statements
+    get_model_stats, _default_test, get_assembled_statements, get_models
 from emmaa.model_tests import load_tests_from_s3
 from emmaa.answer_queries import QueryManager, load_model_manager_from_cache
 from emmaa.subscription.email_util import verify_email_signature,\
@@ -545,24 +545,9 @@ def _load_test_stats_from_cache(model, test_corpus, date=None):
 
 
 def _get_model_meta_data(bucket=EMMAA_BUCKET_NAME):
-    s3 = boto3.client('s3')
-    resp = s3.list_objects(Bucket=bucket, Prefix='models/',
-                           Delimiter='/')
-    model_data = []
-    for pref in resp['CommonPrefixes']:
-        model = pref['Prefix'].split('/')[1]
-        config_json = get_model_config(model, bucket=bucket)
-        if not config_json:
-            continue
-        dev_only = config_json.get('dev_only', False)
-        if dev_only:
-            if DEVMODE:
-                model_data.append((model, config_json))
-            else:
-                continue
-        else:
-            model_data.append((model, config_json))
-    return model_data
+    return get_models(include_config=True, include_dev=DEVMODE,
+                      config_load_func=get_model_config,
+                      bucket=bucket)
 
 
 def get_model_config(model, bucket=EMMAA_BUCKET_NAME):


### PR DESCRIPTION
This PR is aimed to offload the EMMAA service memory by loading the statements from the database instead of keeping them in memory. 

- A new statements database is created (can be set up locally on the EMMAA service machine) that allows:
    - storing the statements and the corresponding path counts
    - loading all statements per model/date sorted and filtered as requested (i.e. supporting all_statements page options)
    - loading statements by their model/date and statement hash (i.e. supporting statement evidence pages)
    - loading statements' path counts numbers (used for sorting and path badges)
- API is updated to leverage the database when the model is available; it falls back to "old" cache/filtering in memory option when the statements for model/date are not in the database
- ModelManager methods are updated to store statements and path counts in the database along with S3.
- Database Manager is refactored into a parent class with two child classes each of which supports methods for one database (query db or statements db).