### PR TITLE
Load figures when requested only

### DIFF
--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -1534,7 +1534,8 @@ def get_paper_statements(model):
     date = request.args.get('date')
     paper_id = request.args.get('paper_id')
     paper_id_type = request.args.get('paper_id_type')
-    
+    include_figures = (request.args.get('figures', False) == 'true')
+
     if paper_id_type.upper() == 'TRID':
         trid = paper_id
     else:
@@ -1584,7 +1585,10 @@ def get_paper_statements(model):
     paper_title = _get_title(trid, model_stats)
     table_title = f'Statements from the paper "{paper_title}"'
 
-    fig_list = get_document_figures(paper_id, paper_id_type)
+    if include_figures:
+        fig_list = get_document_figures(paper_id, paper_id_type)
+    else:
+        fig_list = None
     return render_template('evidence_template.html',
                            stmt_rows=stmt_rows,
                            model=model,
@@ -1594,6 +1598,7 @@ def get_paper_statements(model):
                            paper_id=paper_id,
                            paper_id_type=paper_id_type,
                            fig_list=fig_list,
+                           include_figures=include_figures,
                            tabs=True)
 
 
@@ -1745,6 +1750,8 @@ def get_statement_evidence_page():
     date = request.args.get('date')
     paper_id = request.args.get('paper_id')
     paper_id_type = request.args.get('paper_id_type')
+    include_figures = (request.args.get('figures', False) == 'true')
+
     stmts = []
     if not date:
         date = get_latest_available_date(model, _default_test(model))
@@ -1794,9 +1801,10 @@ def get_statement_evidence_page():
             else:
                 with_evid = True
                 tabs = True
-                query = ','.join(
-                    [ag.name for ag in stmts[0].real_agent_list()])
-                fig_list = get_figures_from_query(query, limit=10)
+                if include_figures:
+                    query = ','.join(
+                        [ag.name for ag in stmts[0].real_agent_list()])
+                    fig_list = get_figures_from_query(query, limit=10)
             for stmt in stmts:
                 stmt_row = _get_stmt_row(stmt, source, model, cur_counts, date,
                                          test_corpus, stmt_counts_dict,
@@ -1819,6 +1827,7 @@ def get_statement_evidence_page():
                            is_all_stmts=False,
                            date=date,
                            fig_list=fig_list,
+                           include_figures=include_figures,
                            tabs=tabs)
 
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -1587,8 +1587,10 @@ def get_paper_statements(model):
 
     if include_figures:
         fig_list = get_document_figures(paper_id, paper_id_type)
+        tab = 'figures'
     else:
         fig_list = None
+        tab = 'statements'
     return render_template('evidence_template.html',
                            stmt_rows=stmt_rows,
                            model=model,
@@ -1599,7 +1601,8 @@ def get_paper_statements(model):
                            paper_id_type=paper_id_type,
                            fig_list=fig_list,
                            include_figures=include_figures,
-                           tabs=True)
+                           tabs=True,
+                           tab=tab)
 
 
 @app.route('/tests/<model>')
@@ -1786,6 +1789,7 @@ def get_statement_evidence_page():
     if display_format == 'html':
         stmt_rows = []
         tabs = False
+        tab = None
         fig_list = None
         if stmts:
             stmts_by_hash = {str(stmt.get_hash(refresh=True)): stmt
@@ -1801,7 +1805,9 @@ def get_statement_evidence_page():
             else:
                 with_evid = True
                 tabs = True
+                tab = 'statements'
                 if include_figures:
+                    tab = 'figures'
                     query = ','.join(
                         [ag.name for ag in stmts[0].real_agent_list()])
                     fig_list = get_figures_from_query(query, limit=10)
@@ -1828,7 +1834,8 @@ def get_statement_evidence_page():
                            date=date,
                            fig_list=fig_list,
                            include_figures=include_figures,
-                           tabs=tabs)
+                           tabs=tabs,
+                           tab=tab)
 
 
 @app.route('/all_statements/<model>')

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -1523,18 +1523,21 @@ def get_paper_statements(model):
         Format to return the result as ('json' or 'html').
     """
     display_format = request.args.get('format', 'html')
+    include_figures = (request.args.get('figures', False) == 'true')
     if display_format == 'html':
         loaded = request.args.get('loaded')
         loaded = (loaded == 'true')
         if not loaded:
-            return render_template(
-                'loading.html',
-                msg=('Please wait while we load the statements '
-                     'from this paper...'))
+            if include_figures:
+                msg = ('Please wait while we load the figures and tables '
+                       'for this paper...')
+            else:
+                msg = ('Please wait while we load the statements '
+                       'from this paper...')
+            return render_template('loading.html', msg=msg)
     date = request.args.get('date')
     paper_id = request.args.get('paper_id')
     paper_id_type = request.args.get('paper_id_type')
-    include_figures = (request.args.get('figures', False) == 'true')
 
     if paper_id_type.upper() == 'TRID':
         trid = paper_id
@@ -1739,13 +1742,17 @@ def get_statement_evidence_page():
     """Render page displaying evidence for statement or return statement JSON.
     """
     display_format = request.args.get('format', 'html')
+    include_figures = (request.args.get('figures', False) == 'true')
     if display_format == 'html':
         loaded = request.args.get('loaded')
         loaded = (loaded == 'true')
         if not loaded:
-            return render_template(
-                'loading.html',
-                msg='Please wait while we load the statement evidence...')
+            if include_figures:
+                msg = ('Please wait while we load the figures and tables for '
+                       'this statement...')
+            else:
+                msg = 'Please wait while we load the statement evidence...'
+            return render_template('loading.html', msg=msg)
     stmt_hashes = set(request.args.getlist('stmt_hash'))
     source = request.args.get('source')
     model = request.args.get('model')
@@ -1753,7 +1760,6 @@ def get_statement_evidence_page():
     date = request.args.get('date')
     paper_id = request.args.get('paper_id')
     paper_id_type = request.args.get('paper_id_type')
-    include_figures = (request.args.get('figures', False) == 'true')
 
     stmts = []
     if not date:

--- a/emmaa_service/templates/evidence_template.html
+++ b/emmaa_service/templates/evidence_template.html
@@ -144,17 +144,32 @@
     <div class="container nav-container">
       <nav>
         <div class="nav nav-tabs" id="nav-tab" role="tablist">
+          {% if tab == 'statements' %}
           <a class="nav-item nav-link active" id="nav-stmts-tab" data-toggle="tab" href="#nav-stmts" role="tab" aria-controls="nav-stmts" aria-selected="true">Statements</a>
           <a class="nav-item nav-link" id="nav-figures-tab" data-toggle="tab" href="#nav-figures" role="tab" aria-controls="nav-figures" aria-selected="false">Figures</a>
+          {% else %}
+          <a class="nav-item nav-link" id="nav-stmts-tab" data-toggle="tab" href="#nav-stmts" role="tab" aria-controls="nav-stmts" aria-selected="false">Statements</a>
+          <a class="nav-item nav-link active" id="nav-figures-tab" data-toggle="tab" href="#nav-figures" role="tab" aria-controls="nav-figures" aria-selected="true">Figures</a>
+          {% endif %}
         </div>
       </nav>
     </div>
     <div class="tab-content" id="nav-tabContent">
+      {% if tab == 'statements' %}
       <div class="tab-pane fade show active" id="nav-stmts" role="tabpanel" aria-labelledby="nav-stmts-tab">
+      {% else %}
+      <div class="tab-pane fade" id="nav-stmts" role="tabpanel" aria-labelledby="nav-stmts-tab">
+      {% endif %}
       {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
+
       </div>
-      <div class="tab-pane fade" id="nav-figures" role="tabpanel" aria-labelledby="nav-figures-tab">  
-      {{ figure_tab(fig_list, source) }}
+      {% if tab == 'figures' %}
+      <div class="tab-pane fade show active" id="nav-figures" role="tabpanel" aria-labelledby="nav-figures-tab">
+      {% else %}
+      <div class="tab-pane fade" id="nav-figures" role="tabpanel" aria-labelledby="nav-figures-tab">
+      {% endif %}
+
+      {{ figure_tab(fig_list, source, include_figures) }}
   {% else %}
     {{ path_card(stmt_rows, table_title, "EvidId", [], url=url) }}
   {% endif %}

--- a/emmaa_service/templates/tabs/figures_tab.html
+++ b/emmaa_service/templates/tabs/figures_tab.html
@@ -1,31 +1,42 @@
 {% from "path_macros.html" import path_card %}
 
-{% macro figure_tab(fig_list, source) -%}
-  {% if fig_list %}
-    {% for figure in fig_list %}
-      {% if figure|length == 3 %}
-        {% set urls, fig_title, fig_bytes = figure %}
-        {% for url in urls %}
-          <a href="{{ url }}">View paper</a>
-        {% endfor %}
+{% macro figure_tab(fig_list, source, include_figures) -%}
+  {% if include_figures %}
+    {% if fig_list %}
+      {% for figure in fig_list %}
+        {% if figure|length == 3 %}
+          {% set urls, fig_title, fig_bytes = figure %}
+          {% for url in urls %}
+            <a href="{{ url }}">View paper</a>
+          {% endfor %}
+          <br>
+        {% else %}
+          {% set fig_title, fig_bytes = figure %}
+        {% endif %}
         <br>
-      {% else %}
-        {% set fig_title, fig_bytes = figure %}
-      {% endif %}
-      <br>
-      {% if fig_title %}
-      {{ fig_title }}
-      <br>
-      {% endif %}
-      <img src="data:image/jpg;base64, {{ fig_bytes }}" style="max-width: 50vw; max-height: 60vh;">
-      <br>
-      <hr class="solid" style="border-top: solid 5px;">
-    {% endfor %}
-  {% else %}
-    {% if source == 'paper' %}
-      Could not get any figures and tables for this paper
+        {% if fig_title %}
+        {{ fig_title }}
+        <br>
+        {% endif %}
+        <img src="data:image/jpg;base64, {{ fig_bytes }}" style="max-width: 50vw; max-height: 60vh;">
+        <br>
+        <hr class="solid" style="border-top: solid 5px;">
+      {% endfor %}
     {% else %}
-      Could not get any figures and tables for this statement
+      {% if source == 'paper' %}
+        Could not get any figures and tables for this paper
+      {% else %}
+        Could not get any figures and tables for this statement
+      {% endif %}
     {% endif %}
+  {% else %}
+  <div class="card-body">
+    {% if source == 'paper' %}
+    Click this button to load figures and tables for this paper:
+    {% else %}
+    Click this button to load figures and tables for this statement:
+    {% endif %}
+  <button class="btn btn-outline-secondary p-2" style="position: relative; left: 15px" onClick="redirectOneArgument('true', 'figures')" type="button">Load Figures</button>
+  </div>
   {% endif %}
 {%- endmacro %}


### PR DESCRIPTION
This PR changes the way figures and tables are loaded from XDD on EMMAA statement and paper pages. Instead of querying the XDD service every time the page is loaded, it will be only queried if a user clicks on a button on "Figures" tab.