### PR TITLE
Preparation for Pompe Disease model

### DIFF
--- a/emmaa/priors/gene_list_prior.py
+++ b/emmaa/priors/gene_list_prior.py
@@ -1,11 +1,10 @@
-from typing import Optional
+from typing import List, Optional
 
 from indra.sources import tas
 from indra.statements import Agent
 from indra.databases import hgnc_client
 from . import SearchTerm, get_drugs_for_gene
 from . prior_stmts import get_stmts_for_gene_list
-import datetime
 from emmaa.statements import EmmaaStatement
 from emmaa.model import EmmaaModel, save_config_to_s3
 
@@ -55,8 +54,10 @@ class GeneListPrior(object):
         self.search_terms = terms
         return terms
 
-    def make_gene_statements(self):
+    def make_gene_statements(self) -> List[EmmaaStatement]:
         """Generate Statements from the gene list."""
+        if self.stmts:
+            return self.stmts
 
         def is_internal(stmt):
             # If all the agents are gene names, this is an internal statement.
@@ -71,6 +72,7 @@ class GeneListPrior(object):
                                  {'internal': is_internal(stmt)})
                   for stmt in indra_stmts]
         self.stmts = estmts
+        return self.stmts
 
     def make_config(self):
         """Generate a configuration based on attributes."""

--- a/emmaa/priors/gene_list_prior.py
+++ b/emmaa/priors/gene_list_prior.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from indra.sources import tas
 from indra.statements import Agent
 from indra.databases import hgnc_client
@@ -20,12 +22,13 @@ class GeneListPrior(object):
     human_readable_name : str
         The human readable name (display name) of the model
     """
-    def __init__(self, gene_list, name, human_readable_name):
+    def __init__(self, gene_list, name, human_readable_name, description: Optional[str] = None):
         self.name = name
         self.gene_list = gene_list
         self.human_readable_name = human_readable_name
         self.stmts = []
         self.search_terms = []
+        self.description = description
 
     def make_search_terms(self, drug_gene_stmts=None):
         """Generate search terms from the gene list."""
@@ -83,6 +86,8 @@ class GeneListPrior(object):
             'belief_cutoff': 0.8,
             'filter_ungrounded': True
         }
+        if self.description:
+            config['description'] = self.description
         return config
 
     def make_model(self):

--- a/emmaa/priors/literature_prior.py
+++ b/emmaa/priors/literature_prior.py
@@ -159,6 +159,22 @@ class LiteraturePrior:
             # These are the search terms constructed upon
             # initialization
             'search_terms': [st.to_json() for st in self.search_terms],
+            # We configure the large corpus tests by default
+            'test': {
+                'statement_checking': {
+                    'max_path_length': 10,
+                    'max_paths': 1
+                },
+                'mc_types': [
+                    'signed_graph', 'unsigned_graph'
+                ],
+                'make_links': True,
+                'test_corpus': ['large_corpus_tests'],
+                'default_test_corpus': 'large_corpus_tests',
+                'filters': {
+                    'large_corpus_tests': 'filter_chem_mesh_go'
+                }
+            }
         }
         # This is adopted from the template specified upon
         # initialization

--- a/emmaa/priors/literature_prior.py
+++ b/emmaa/priors/literature_prior.py
@@ -288,7 +288,6 @@ def make_search_terms(
         search_terms.append(search_term)
     for mesh_id in mesh_ids:
         mesh_name = mesh_client.get_mesh_name(mesh_id)
-        # TODO explicitly handle mesh_id.startswith("C")?
         suffix = 'mh' if mesh_id.startswith('D') else 'nm'
         search_term = SearchTerm(type='mesh', name=mesh_name,
                                  db_refs={'MESH': mesh_id},

--- a/emmaa/priors/literature_prior.py
+++ b/emmaa/priors/literature_prior.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 class LiteraturePrior:
     def __init__(self, name, human_readable_name, description,
                  search_strings=None, mesh_ids=None,
-                 assembly_config_template=None, test: bool = True):
+                 assembly_config_template=None):
         """A class to construct a literature-based prior for an EMMAA model.
 
         Parameters
@@ -56,8 +56,6 @@ class LiteraturePrior:
         assembly_config_template : Optional[str]
             The name of another model from which the initial assembly
             configuration should be adopted.
-        test :
-            Should tests be included in the configuration?
         """
         self.name = name
         self.human_readable_name = human_readable_name
@@ -69,7 +67,6 @@ class LiteraturePrior:
                 self.get_config_from(assembly_config_template)
         else:
             self.assembly_config = {}
-        self.test = test
         self.stmts = []
 
     def get_statements(self, mode='all', batch_size=100):
@@ -158,7 +155,8 @@ class LiteraturePrior:
             'dev_only': True,
             # These are the search terms constructed upon
             # initialization
-            'search_terms': [st.to_json() for st in self.search_terms],
+            'search_terms': [st.to_json()
+                             for st in self.search_terms],
             # We configure the large corpus tests by default
             'test': {
                 'statement_checking': {

--- a/emmaa/priors/literature_prior.py
+++ b/emmaa/priors/literature_prior.py
@@ -70,6 +70,7 @@ class LiteraturePrior:
         else:
             self.assembly_config = {}
         self.test = test
+        self.stmts = []
 
     def get_statements(self, mode='all', batch_size=100):
         """Return EMMAA Statements for this prior's literature set.
@@ -91,6 +92,8 @@ class LiteraturePrior:
             A list of EMMAA Statements corresponding to extractions from
             the subset of literature defined by this prior's search terms.
         """
+        if self.stmts:
+            return self.stmts
         terms_to_pmids = \
             EmmaaModel.search_pubmed(search_terms=self.search_terms,
                                      date_limit=None)
@@ -104,13 +107,12 @@ class LiteraturePrior:
             get_raw_statements_for_pmids(all_pmids, mode=mode,
                                          batch_size=batch_size)
         timestamp = datetime.datetime.now()
-        estmts = []
         for pmid, stmts in raw_statements_by_pmid.items():
             for stmt in stmts:
-                estmts.append(EmmaaStatement(stmt, timestamp,
-                                             pmids_to_terms[pmid],
-                                             {'internal': True}))
-        return estmts
+                self.stmts.append(EmmaaStatement(stmt, timestamp,
+                                                 pmids_to_terms[pmid],
+                                                 {'internal': True}))
+        return self.stmts
 
     def get_config_from(self, assembly_config_template):
         """Return assembly config given a template model's name.

--- a/emmaa/priors/literature_prior.py
+++ b/emmaa/priors/literature_prior.py
@@ -58,7 +58,7 @@ class LiteraturePrior:
         self.human_readable_name = human_readable_name
         self.description = description
         self.search_terms = \
-            make_search_terms(search_strings, mesh_ids)
+            make_search_terms(search_strings or [], mesh_ids or [])
         if assembly_config_template:
             self.assembly_config = \
                 self.get_config_from(assembly_config_template)

--- a/emmaa/priors/literature_prior.py
+++ b/emmaa/priors/literature_prior.py
@@ -181,24 +181,6 @@ class LiteraturePrior:
         if self.assembly_config:
             config["assembly"] = self.assembly_config
 
-        if self.test:
-            # We configure the large corpus tests by default
-            config["test"] = {
-                'statement_checking': {
-                    'max_path_length': 10,
-                    'max_paths': 1,
-                },
-                'mc_types': [
-                    'signed_graph', 'unsigned_graph',
-                ],
-                'make_links': True,
-                'test_corpus': ['large_corpus_tests'],
-                'default_test_corpus': 'large_corpus_tests',
-                'filters': {
-                    'large_corpus_tests': 'filter_chem_mesh_go',
-                },
-            }
-
         if upload_to_s3:
             from emmaa.model import save_config_to_s3
             save_config_to_s3(self.name, config)

--- a/emmaa/priors/literature_prior.py
+++ b/emmaa/priors/literature_prior.py
@@ -260,24 +260,29 @@ def get_raw_statements_for_pmids(pmids, mode='all', batch_size=100):
     return all_stmts
 
 
-def make_search_terms(search_strings, mesh_ids):
+def make_search_terms(
+    search_strings: List[str],
+    mesh_ids: List[str],
+) -> List[SearchTerm]:
     """Return EMMAA SearchTerms based on search strings and MeSH IDs.
 
     Parameters
     ----------
-    search_strings : list of str
+    search_strings :
         A list of search strings e.g., "diabetes" to find papers in the
         literature.
-    mesh_ids : list of str
+    mesh_ids :
         A list of MeSH IDs that are used to search the literature as headings
         associated with papers.
 
     Returns
     -------
-    list of emmmaa.prior.SearchTerm
+    :
         A list of EMMAA SearchTerm objects constructed from the search strings
         and the MeSH IDs.
     """
+    if not search_strings and not mesh_ids:
+        raise ValueError("Need at least one of search_strings or mesh_ids")
     search_terms = []
     for search_string in search_strings:
         search_term = SearchTerm(type='other', name=search_string,
@@ -285,10 +290,10 @@ def make_search_terms(search_strings, mesh_ids):
         search_terms.append(search_term)
     for mesh_id in mesh_ids:
         mesh_name = mesh_client.get_mesh_name(mesh_id)
+        # TODO explicitly handle mesh_id.startswith("C")?
         suffix = 'mh' if mesh_id.startswith('D') else 'nm'
         search_term = SearchTerm(type='mesh', name=mesh_name,
                                  db_refs={'MESH': mesh_id},
                                  search_term=f'{mesh_name} [{suffix}]')
         search_terms.append(search_term)
     return search_terms
-

--- a/emmaa/priors/literature_prior.py
+++ b/emmaa/priors/literature_prior.py
@@ -34,7 +34,7 @@ class LiteraturePrior:
     def __init__(self, name, human_readable_name, description,
                  search_strings=None, mesh_ids=None,
                  assembly_config_template=None):
-        """A class to construct a literture-based prior for an EMMAA model.
+        """A class to construct a literature-based prior for an EMMAA model.
 
         Parameters
         ----------
@@ -144,7 +144,7 @@ class LiteraturePrior:
             'description': self.description,
             # We don't make tests by default
             'make_tests': False,
-            # We run daily upates by default
+            # We run daily updates by default
             'run_daily_update': True,
             # We first show the model just on dev
             'dev_only': True,

--- a/emmaa/statements.py
+++ b/emmaa/statements.py
@@ -33,7 +33,6 @@ class EmmaaStatement(object):
             are meant to aid explanation construction but are not internal to
             the model.
     """
-
     def __init__(
         self,
         stmt: Statement,
@@ -84,7 +83,12 @@ def to_emmaa_stmts(
     logger.info(f'Making {len(stmt_list)} EMMAA statements with metadata: '
                 f'{metadata}')
     for indra_stmt in stmt_list:
-        es = EmmaaStatement(indra_stmt, date, search_terms, metadata)
+        es = EmmaaStatement(
+            indra_stmt,
+            date=date,
+            search_terms=search_terms,
+            metadata=metadata,
+        )
         emmaa_stmts.append(es)
     return emmaa_stmts
 

--- a/emmaa/statements.py
+++ b/emmaa/statements.py
@@ -33,6 +33,7 @@ class EmmaaStatement(object):
             are meant to aid explanation construction but are not internal to
             the model.
     """
+
     def __init__(
         self,
         stmt: Statement,


### PR DESCRIPTION
This PR does the following:

1. Reimplements `emmaa.priors.prior_stmts.get_stmts_for_gene()` to use new INDRA DB functionality
2. Adds a few extra fields to both the literature prior and the gene prior and make some fields optional via flags (but keep defaults the same as current functionality)
3. Make the `GeneListPrior.make_gene_statements()` method store the statements in the instance of the prior the same way that `LiteraturePrior.get_statements()` does
4. Makes the `LiteraturePrior.get_statements()` and  `GeneListPrior.make_gene_statements()` methods return the actual statement list after running
6. As I was grokking code, I added some type annotations and did light reformatting when that made it go over the line length limit

See results for the pompe configuration on https://github.com/indralab/indra-pompe, which will end up on https://dev.emmaa.indra.bio/dashboard/pompe

## Depends on

- [x] #264
- [x] #265
- [x] #266