### PR TITLE
Update undefined behavior on missing condition key

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,7 +47,8 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'sphinx_autodoc_typehints',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,6 @@
 sphinx
 sphinx_rtd_theme
+sphinx_autodoc_typehints
 mock
 boto3
 git+https://github.com/sorgerlab/indra.git

--- a/emmaa/priors/gene_list_prior.py
+++ b/emmaa/priors/gene_list_prior.py
@@ -57,7 +57,8 @@ class GeneListPrior(object):
         drug_names = [st.name for st in self.search_terms if
                       st.type == 'drug']
         indra_stmts = get_stmts_for_gene_list(self.gene_list, drug_names)
-        estmts = [EmmaaStatement(stmt, datetime.datetime.now(), [])
+        estmts = [EmmaaStatement(stmt, datetime.datetime.now(), [],
+                                 {'internal': True})
                   for stmt in indra_stmts]
         self.stmts = estmts
 

--- a/emmaa/priors/gene_list_prior.py
+++ b/emmaa/priors/gene_list_prior.py
@@ -54,11 +54,18 @@ class GeneListPrior(object):
 
     def make_gene_statements(self):
         """Generate Statements from the gene list."""
+
+        def is_internal(stmt):
+            # If all the agents are gene names, this is an internal statement.
+            # We classify any statements with drugs in them as external.
+            return all([a.name in self.gene_list
+                        for a in stmt.real_agent_list()])
+
         drug_names = [st.name for st in self.search_terms if
                       st.type == 'drug']
         indra_stmts = get_stmts_for_gene_list(self.gene_list, drug_names)
         estmts = [EmmaaStatement(stmt, datetime.datetime.now(), [],
-                                 {'internal': True})
+                                 {'internal': is_internal(stmt)})
                   for stmt in indra_stmts]
         self.stmts = estmts
 

--- a/emmaa/priors/literature_prior.py
+++ b/emmaa/priors/literature_prior.py
@@ -102,7 +102,8 @@ class LiteraturePrior:
         for pmid, stmts in raw_statements_by_pmid.items():
             for stmt in stmts:
                 estmts.append(EmmaaStatement(stmt, timestamp,
-                                             pmids_to_terms[pmid]))
+                                             pmids_to_terms[pmid],
+                                             {'internal': True}))
         return estmts
 
     def get_config_from(self, assembly_config_template):

--- a/emmaa/statements.py
+++ b/emmaa/statements.py
@@ -22,7 +22,16 @@ class EmmaaStatement(object):
     search_terms :
         The list of search terms that led to the creation of the Statement.
     metadata :
-        Additional metadata for the statement.
+        Additional metadata for the statement. The metadata dict is expected
+        to contain the following keys:
+          - 'internal': a Boolean indicating whether the statement is internal
+            to the model or not. A statement is internal if it was picked up
+            using the model's scope definition (through e.g., literature searches
+            and subsequent text mining), and is typically not internal, if it
+            was added to the model to provide additional knowledge, such
+            as statements representing drug targets or phenotypic readouts that
+            are meant to aid explanation construction but are not internal to
+            the model.
     """
 
     def __init__(

--- a/emmaa/statements.py
+++ b/emmaa/statements.py
@@ -199,7 +199,7 @@ def check_stmt(stmt, conditions, evid_policy='any'):
             metadata = emmaa_anns.get('metadata')
             checks = []
             for key, value in conditions.items():
-                checks.append(metadata[key] == value)
+                checks.append(key in metadata and metadata[key] == value)
             evid_checks.append(all(checks))
             if all(checks) and evid_policy == 'any':
                 break

--- a/emmaa/tests/test_statements.py
+++ b/emmaa/tests/test_statements.py
@@ -76,7 +76,7 @@ def test_filter_indra_stmts():
     stmt6 = make_stmt_with_evid_anns([False])  # Only false anns
     stmt7 = make_stmt_with_evid_anns([None, False])  # Filter false or unknown
     stmt8 = make_stmt_with_evid_anns([False, False])  # Only false anns
-
+    # Case in which the "internal" key is missing
     stmt9 = make_stmt_with_evid_anns([False])
     del stmt9.evidence[0].annotations["emmaa"]["metadata"]["internal"]
 
@@ -97,5 +97,6 @@ def test_filter_indra_stmts():
     assert stmt6 not in filtered_all
     assert stmt7 not in filtered_all
     assert stmt8 not in filtered_all
+    assert stmt9 not in filtered_all
     # Mixed is filtered too here
     assert stmt5 not in filtered_all

--- a/emmaa/tests/test_statements.py
+++ b/emmaa/tests/test_statements.py
@@ -77,14 +77,18 @@ def test_filter_indra_stmts():
     stmt7 = make_stmt_with_evid_anns([None, False])  # Filter false or unknown
     stmt8 = make_stmt_with_evid_anns([False, False])  # Only false anns
 
+    stmt9 = make_stmt_with_evid_anns([False])
+    del stmt9.evidence[0].annotations["emmaa"]["metadata"]["internal"]
+
     conditions = {'internal': True}
-    stmts = [stmt1, stmt2, stmt3, stmt4, stmt5, stmt6, stmt7, stmt8]
+    stmts = [stmt1, stmt2, stmt3, stmt4, stmt5, stmt6, stmt7, stmt8, stmt9]
 
     filtered_any = filter_indra_stmts_by_metadata(stmts, conditions, 'any')
     assert len(filtered_any) == 5
     assert stmt6 not in filtered_any
     assert stmt7 not in filtered_any
     assert stmt8 not in filtered_any
+    assert stmt9 not in filtered_any
     # Mixed is not filtered
     assert stmt5 in filtered_any
 

--- a/scripts/generate_simple_model_test.py
+++ b/scripts/generate_simple_model_test.py
@@ -15,8 +15,9 @@ def generate_model(model_name):
     tp = trips.process_text('BRAF activates MAP2K1. '
                             'Active MAP2K1 activates MAPK1.')
     indra_stmts = tp.statements
-    emmaa_stmts = [EmmaaStatement(stmt, datetime.datetime.now(), 'MAPK1')
-                    for stmt in indra_stmts]
+    emmaa_stmts = [EmmaaStatement(stmt, datetime.datetime.now(), 'MAPK1',
+                                  {'internal': True})
+                   for stmt in indra_stmts]
     # Create a CXAssembled model, upload to NDEx and retrieve key
     #cxa = CxAssembler(indra_stmts)
     #cxa.make_model()

--- a/scripts/priors_from_muts.py
+++ b/scripts/priors_from_muts.py
@@ -42,13 +42,11 @@ def save_prior(ctype, stmts):
         pickle.dump(stmts, fh)
 
 
-def upload_prior(ctype, config):
+def upload_prior(ctype, config, gene_names):
     fname = f'../models/{ctype}/prior_stmts.pkl'
     with open(fname, 'rb') as fh:
         stmts = pickle.load(fh)
-    estmts = [EmmaaStatement(stmt, datetime.datetime.now(), [],
-                             {'internal': True})
-              for stmt in stmts]
+    estmts = get_emmaa_statements(stmts, gene_names)
     model = EmmaaModel(ctype, config)
     model.add_statements(estmts)
     model.update_to_ndex()

--- a/scripts/priors_from_muts.py
+++ b/scripts/priors_from_muts.py
@@ -46,11 +46,24 @@ def upload_prior(ctype, config):
     fname = f'../models/{ctype}/prior_stmts.pkl'
     with open(fname, 'rb') as fh:
         stmts = pickle.load(fh)
-    estmts = [EmmaaStatement(stmt, datetime.datetime.now(), [])
+    estmts = [EmmaaStatement(stmt, datetime.datetime.now(), [],
+                             {'internal': True})
               for stmt in stmts]
     model = EmmaaModel(ctype, config)
     model.add_statements(estmts)
     model.update_to_ndex()
+
+
+def get_emmaa_statements(stmts, gene_names):
+    def is_internal(stmt):
+        # If all the agents are gene names, this is an internal statement.
+        # We classify any statements with drugs in them as external.
+        return all([a.name in gene_names for a in stmt.real_agent_list()])
+
+    estmts = [EmmaaStatement(stmt, datetime.datetime.now(), [],
+                             {'internal': is_internal(stmt)})
+              for stmt in stmts]
+    return estmts
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The current error I'm getting in the Pompe build on AWS Batch is because the `"internal"` key is not available in the annotations one of the EMMAA statements, which is causing the `is_internal` function to fail. This also adds a corresponding case that handles when there's a "metadata" but it's missing one of the keys needed for the conditions check -> it evaluates as false for passing the condition.

I haven't figured out where in the pipeline this annotation is supposed to be added based on the current assembly configuration yet.
