### PR TITLE
EMMAA statement improvements

### DIFF
--- a/emmaa/statements.py
+++ b/emmaa/statements.py
@@ -61,7 +61,7 @@ class EmmaaStatement(object):
 
 def to_emmaa_stmts(
     stmt_list: List[Statement],
-    date: Optional[datetime.datetime],
+    date: Optional[datetime.datetime] = None,
     search_terms: Optional[List[SearchTerm]] = None,
     metadata: Optional[Mapping[str, Any]] = None,
 ):
@@ -75,6 +75,7 @@ def to_emmaa_stmts(
     logger.info(f'Making {len(stmt_list)} EMMAA statements with metadata: '
                 f'{metadata}')
     for indra_stmt in stmt_list:
+        es = EmmaaStatement(indra_stmt, date, search_terms, metadata)
         emmaa_stmts.append(es)
     return emmaa_stmts
 

--- a/emmaa/tests/test_statements.py
+++ b/emmaa/tests/test_statements.py
@@ -37,16 +37,17 @@ def test_to_emmaa_stmts():
 
 
 def test_filter_emmaa_stmts():
-    estmt1 = EmmaaStatement(stmt, date, search_terms, {'internal': True})
-    estmt2 = EmmaaStatement(stmt, date, search_terms, {'internal': False})
-    estmt3 = EmmaaStatement(stmt, date, search_terms)
-    del estmt3.metadata  # Imitate older style statement withou metadata
-    # Only estmt2 with internal False should be filtered out
-    filtered_estmts = filter_emmaa_stmts_by_metadata(
-        [estmt1, estmt2, estmt3], {'internal': True})
-    assert len(filtered_estmts) == 2
-    assert estmt1 in filtered_estmts
-    assert estmt3 in filtered_estmts
+    for st in [None, search_terms]:
+        estmt1 = EmmaaStatement(stmt, date, st, {'internal': True})
+        estmt2 = EmmaaStatement(stmt, date, st, {'internal': False})
+        estmt3 = EmmaaStatement(stmt, date, st)
+        del estmt3.metadata  # Imitate older style statement without metadata
+        # Only estmt2 with internal False should be filtered out
+        filtered_estmts = filter_emmaa_stmts_by_metadata(
+            [estmt1, estmt2, estmt3], {'internal': True})
+        assert len(filtered_estmts) == 2
+        assert estmt1 in filtered_estmts
+        assert estmt3 in filtered_estmts
 
 
 def test_filter_indra_stmts():


### PR DESCRIPTION
This PR makes the date and search terms optional in the `EmmaaStatement` class. It better handles `None` in the related code to automatically turn them into an empty list. It also updates the tests to demonstrate this works (these tests would fail without the update)

This was necessary to get the GeneListPrior to work without modification, and ultimately makes creation of EmmaStatements safer. 

If I wanted to make a much bigger mess of the diff, I'd also consider making all of the arguments besides `stmt` to `EmmaaStatement` be keyword-only to make sure that they don't get mismatched, since a lot of places duplicate functionality by passing an empty list to `search_terms` or `datetime.datetime.now()` to `date`.