### PR TITLE
Intelligent tiering for new S3 uploads

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
         export AWS_DEFAULT_REGION='us-east-1'
         export NOSEATTR="!notravis"
         export NOSEATTR=$(if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then echo $NOSEATTR,!nonpublic; else echo $NOSEATTR; fi)
-        export PYTHONPATH=$PYTHONPATH:`pwd`/covid-19:`pwd`/kappy:`pwd`/indra_world:`pwd`/automates/scripts/gromet
+        export PYTHONPATH=$PYTHONPATH:`pwd`/covid-19:`pwd`/kappy:`pwd`/indra_world:`pwd`/automates/scripts/gromet/gromet_v1
         export BNGPATH=`pwd`/BioNetGen-2.4.0
         export INDRA_WM_CACHE="."
         nosetests -v -a $NOSEATTR emmaa/tests/test_s3.py

--- a/emmaa/tests/test_reactome_prior.py
+++ b/emmaa/tests/test_reactome_prior.py
@@ -12,7 +12,7 @@ from indra.statements import Inhibition, Agent
 def test_rx_id_from_up_id():
     """Check that Uniprot ids are being successfully mapped to reactome ids
     """
-    test_cases = [('P01116', 'R-HSA-9653079'),   # KRAS
+    test_cases = [('P01116', 'R-HSA-9647815'),   # KRAS
                   ('P04637', 'R-HSA-8869337'),   # TP53
                   ('Q13485', 'R-HSA-177103')]  # SMAD4
     for up_id, rx_id in test_cases:

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -283,12 +283,12 @@ def load_pickle_from_s3(bucket, key):
         logger.info(e)
 
 
-def save_pickle_to_s3(obj, bucket, key):
-    client = get_s3_client(unsigned=False)
+def save_pickle_to_s3(obj, bucket, key, intelligent_tiering=True):
     logger.info('Pickling object')
     obj_str = pickle.dumps(obj, protocol=4)
     logger.info(f'Saving object to {key}')
-    client.put_object(Body=obj_str, Bucket=bucket, Key=key)
+    s3_put(bucket=bucket, key=key, body=obj_str, unsigned_client=False,
+           intelligent_tiering=intelligent_tiering)
 
 
 def load_json_from_s3(bucket, key):
@@ -299,12 +299,12 @@ def load_json_from_s3(bucket, key):
     return content
 
 
-def save_json_to_s3(obj, bucket, key, save_format='json'):
-    client = get_s3_client(unsigned=False)
+def save_json_to_s3(obj, bucket, key, save_format='json',
+                    intelligent_tiering=True):
     json_str = _get_json_str(obj, save_format=save_format)
     logger.info(f'Uploading the {save_format} object to S3')
-    client.put_object(Body=json_str.encode('utf8'),
-                      Bucket=bucket, Key=key)
+    s3_put(bucket=bucket, key=key, body=json_str.encode('utf8'),
+           unsigned_client=False, intelligent_tiering=intelligent_tiering)
 
 
 def load_gzip_json_from_s3(bucket, key):
@@ -325,11 +325,12 @@ def load_gzip_json_from_s3(bucket, key):
     return content
 
 
-def save_gzip_json_to_s3(obj, bucket, key, save_format='json'):
-    client = get_s3_client(unsigned=False)
+def save_gzip_json_to_s3(obj, bucket, key, save_format='json',
+                         intelligent_tiering=True):
     json_str = _get_json_str(obj, save_format=save_format)
     gz_str = gzip_string(json_str, f'assembled_stmts.{save_format}')
-    client.put_object(Body=gz_str, Bucket=bucket, Key=key)
+    s3_put(bucket=bucket, key=key, body=gz_str, unsigned_client=False,
+           intelligent_tiering=intelligent_tiering)
 
 
 def _get_json_str(json_obj, save_format='json'):

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -477,7 +477,7 @@ def s3_head_object(bucket: str, key: str, unsigned_client: bool = False) -> \
             raise err
 
 
-def get_s3_object_archive_status(bucket, key, unsigned_client=False) -> Dict[str, bool]:
+def get_s3_archive_status(bucket, key, unsigned_client=False) -> Dict[str, bool]:
     # See more details about the HeadObject status response here:
     # https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html
     head_resp = s3_head_object(bucket=bucket, key=key,

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -426,7 +426,7 @@ def _make_delta_msg(model_name, msg_type, delta, date, mc_type=None,
 def s3_put(
     bucket: str,
     key: str,
-    obj: bytes,
+    body: bytes,
     unsigned_client: bool,
     intelligent_tiering: bool = False,
     **s3_options
@@ -439,8 +439,9 @@ def s3_put(
         The S3 bucket to put the object in.
     key :
         The key to put the object in.
-    obj :
-        The object to put as a bytestring.
+    body :
+        The bytestring representation of an object to put in a body as a
+        bytestring.
     unsigned_client :
         Whether to use an unsigned client.
     intelligent_tiering :
@@ -451,7 +452,7 @@ def s3_put(
         override the values set in the s3_options.
     """
     client = get_s3_client(unsigned=unsigned_client)
-    options = {**s3_options, **{'Body': obj, 'Bucket': bucket, 'Key': key}}
+    options = {**s3_options, **{'Body': body, 'Bucket': bucket, 'Key': key}}
     if intelligent_tiering:
         options['StorageClass'] = 'INTELLIGENT_TIERING'
     client.put_object(**options)

--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -421,3 +421,37 @@ def _make_delta_msg(model_name, msg_type, delta, date, mc_type=None,
     msg = f'{start}{delta_part}{middle}. See {url} for more details.'
     return {'url': url, 'start': start, 'delta_part': delta_part,
             'middle': middle, 'message': msg}
+
+
+def s3_put(
+    bucket: str,
+    key: str,
+    obj: bytes,
+    unsigned_client: bool,
+    intelligent_tiering: bool = False,
+    **s3_options
+):
+    """A wrapper around boto3's put_object method.
+
+    Parameters
+    ----------
+    bucket :
+        The S3 bucket to put the object in.
+    key :
+        The key to put the object in.
+    obj :
+        The object to put as a bytestring.
+    unsigned_client :
+        Whether to use an unsigned client.
+    intelligent_tiering :
+        Whether to use intelligent tiering. Default is False.
+    s3_options :
+        Additional options to pass to the put_object method. If there are
+        any duplicate keys, the explicit values set in the parameters will
+        override the values set in the s3_options.
+    """
+    client = get_s3_client(unsigned=unsigned_client)
+    options = {**s3_options, **{'Body': obj, 'Bucket': bucket, 'Key': key}}
+    if intelligent_tiering:
+        options['StorageClass'] = 'INTELLIGENT_TIERING'
+    client.put_object(**options)


### PR DESCRIPTION
This PR introduces the option to upload objects to s3, via a wrapper to `s3.put_object()`, into the intelligent tiering storage class. After merge, new uploads using any of `save_gzip_json_to_s3`, `save_json_to_s3`, or `save_pickle_to_s3` in `emmaa.util` will be put in the intelligent tiering storage class _by default_. To opt out of this storage class the caller has to specify `intelligent_tiering=False` when calling the new function `s3_put` in `emmaa.util`.

Two other functions are introduced:
- `s3_head_object`: a wrapper to `s3.head_object`
- `get_s3_archive_status`: a function returning if an object on S3 is in the intelligent tier class and if it is, if it's archived or not.