### PR TITLE
Specify vue version

### DIFF
--- a/emmaa_service/templates/emmaa_page_template.html
+++ b/emmaa_service/templates/emmaa_page_template.html
@@ -34,7 +34,7 @@
   <script src="{{ url_for('static', filename='emmaaFunctions.js') }}"></script>
 
   <!-- Vue scripts -->
-  <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.min.js"></script>
   <script src="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-latest/IndralabVue.umd.min.js"></script>
   <link href="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-latest/IndralabVue.css" rel="stylesheet">
   <!-- <script src="https://bigmech.s3.amazonaws.com/indra-db/indralabvue-dev/IndralabVue.umd.min.js"></script> -->


### PR DESCRIPTION
This PR pins the Vue version to the latest release of Vue 2.x. Since Vue 3 [became the new default](https://blog.vuejs.org/posts/vue-3-as-the-new-default.html), the current way of loading Vue in Emmaa, i.e. by using https://cdn.jsdelivr.net/npm/vue/dist/vue.js creates the risk of suddenly loading Vue 3 instead of Vue 2. The [official recommendation](https://blog.vuejs.org/posts/vue-3-as-the-new-default.html#potential-required-actions) is to pin the version.

This PR also changes the loaded JavaScript from `*.js` to `*.min.js`.