### PR TITLE
Add painmachine to large models for after_update lambda

### DIFF
--- a/emmaa/aws_lambda_functions/after_update.py
+++ b/emmaa/aws_lambda_functions/after_update.py
@@ -18,7 +18,7 @@ PROJECT = 'aske'
 BRANCH = 'origin/master'
 # Specify the models that require more resources and need to be run in a
 # different queue with a different job definition.
-LARGE_MODELS = {'covid19'}
+LARGE_MODELS = {'covid19', 'painmachine'}
 
 
 def submit_batch_job(script_command, purpose, job_name, wait_for=None,


### PR DESCRIPTION
This PR adds the painmachine to the set of large models in the `after_update` lambda function defintion. This will allow the painmachine model stats, tests and test stats to be run with the job defintion in batch that has more memory, which should resolve batch jobs for the painmachine model that errored due to low memory.

After merge, run the lambda upload script:

```bash
python update_lambda.py after_update.py emmaa-after-update
```
from `emmaa/aws_lambda_functions`