### PR TITLE
JavaScript vs Python data representation fix

### DIFF
--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -21,7 +21,7 @@ from pusher import pusher
 from sqlalchemy.sql.sqltypes import String
 
 from indra_db.exceptions import BadHashError
-from indra_db import get_db
+from indra_db import get_db as get_indra_db
 from indra_db.util import _get_trids
 from indra.statements import get_all_descendants, IncreaseAmount, \
     DecreaseAmount, Activation, Inhibition, AddModification, Agent, \
@@ -1481,7 +1481,7 @@ def annotate_paper_statements(model):
     if paper_id_type == 'TRID':
         trid = paper_id
     else:
-        db = get_db('primary')
+        db = get_indra_db('primary')
         trids = _get_trids(db, paper_id, paper_id_type.lower())
         if trids:
             trid = str(trids[0])
@@ -1547,7 +1547,7 @@ def get_paper_statements(model):
     if paper_id_type.upper() == 'TRID':
         trid = paper_id
     else:
-        db = get_db('primary')
+        db = get_indra_db('primary')
         trids = _get_trids(db, paper_id, paper_id_type.lower())
         if trids:
             trid = str(trids[0])

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -896,8 +896,11 @@ def _get_stmt_row(stmt, source, model, cur_counts, date, test_corpus=None,
     evid_count = len(stmt.evidence)
     evid = []
     if with_evid and cur_dict is not None:
-        evid = json.loads(json.dumps(_format_evidence_text(
-            stmt, cur_dict, ['correct', 'act_vs_amt', 'hypothesis'])))[:10]
+        evid = json.dumps(
+            _format_evidence_text(
+                stmt, cur_dict, ['correct', 'act_vs_amt', 'hypothesis']
+            )[:10]
+        )
     params = {'stmt_hash': stmt_hash, 'source': source, 'model': model,
               'format': 'json', 'date': date}
     if test_corpus:
@@ -916,7 +919,9 @@ def _get_stmt_row(stmt, source, model, cur_counts, date, test_corpus=None,
                           round(stmt.belief, 2),
                           cur_counts.get(stmt_hash), neg)
     stmt_row = [
-        (stmt.get_hash(refresh=True), english, evid, evid_count, badges)]
+        (stmt.get_hash(refresh=True), english,
+         evid, evid_count, json.dumps(badges))
+    ]
     return stmt_row
 
 

--- a/emmaa_service/api.py
+++ b/emmaa_service/api.py
@@ -913,7 +913,7 @@ def _get_stmt_row(stmt, source, model, cur_counts, date, test_corpus=None,
     json_link = f'/evidence?{url_param}'
     path_count = 0
     if path_counts:
-        path_count = path_counts.get(stmt_hash)
+        path_count = path_counts.get(stmt_hash, 0)
     neg = len([ev for ev in stmt.evidence if ev.epistemics.get('negated')])
     badges = _make_badges(evid_count, json_link, path_count,
                           round(stmt.belief, 2),


### PR DESCRIPTION
This PR resolves an issue where the JavaScript in Vue receiving data to render the Vue `<statement>` component received Python `None` and `True/False` instead of JavaScript `null` and `true/false`, respectively. The solution was to make sure the data is properly json dumped as suggested here: https://stackoverflow.com/a/15322060/10478812

The code has been run locally with the same versions of Flask, Jinja2, markupsafe and werkzeug as what's running on the emmaa server and all endpoints that use the function that have been updated has been tested.

Other fixes:
- There was a namespace clash where `get_db` was imported from both `indra_db` and `emmaa`, a commit is added that fixes the clash
- A path count would sometimes be missing and a `dict.get` method would return `None` instead of a count of zero which is the assumed default value when path counts are missing 