### PR TITLE
Include nf in large model set

### DIFF
--- a/emmaa/aws_lambda_functions/model_manager_update.py
+++ b/emmaa/aws_lambda_functions/model_manager_update.py
@@ -17,7 +17,7 @@ PURPOSE = 'update-emmaa-model-manager'
 BRANCH = 'origin/master'
 # Specify the models that require more resources and need to be run in a
 # different queue with a different job definition.
-LARGE_MODELS = {'covid19', 'brca', 'rasmachine', 'painmachine'}
+LARGE_MODELS = {'covid19', 'brca', 'rasmachine', 'painmachine', 'nf'}
 
 
 def lambda_handler(event, context):


### PR DESCRIPTION
~Finding no trace of outside interference that explains the nf model update jobs being killed, the assumption is that the batch job lacks enough memory to handle the model update.~

_Edit: the batch job states it doesn't have enough memory_

This PR adds nf model to the batch queue with the job definition that has more memory available to it.

After merge, the lambda function needs to be updated.