### PR TITLE
Static page

### DIFF
--- a/emmaa/util.py
+++ b/emmaa/util.py
@@ -225,12 +225,10 @@ def does_exist(bucket, prefix, extension=None):
     extension exist in a bucket.
     """
     all_files = list_s3_files(bucket, prefix, extension)
-    if any(fname.startswith(prefix) for fname in all_files):
-        return True
-    return False
+    return any(fname.startswith(prefix) for fname in all_files)
 
 
-def get_s3_client(unsigned=True):
+def get_s3_client(unsigned=False):
     """Return a boto3 S3 client with optional unsigned config.
 
     Parameters

--- a/emmaa_service/generate_static_page.py
+++ b/emmaa_service/generate_static_page.py
@@ -9,6 +9,8 @@ from emmaa.util import find_latest_s3_file, load_json_from_s3, does_exist
 
 HERE = Path(__file__).parent.resolve()
 JSON_PATH = HERE / "models.json"
+TEMPLATES_DIRECTORY = HERE / "templates"
+HTML_PATH = TEMPLATES_DIRECTORY / "static_page.html"
 
 MODELS = [
     "aml",
@@ -32,6 +34,19 @@ MODELS = [
     "skcm",
     "vitiligo",
 ]
+
+
+def get_jinja_env():
+    """Get the Jinja2 environment."""
+    from jinja2 import Environment, FileSystemLoader
+
+    env = Environment(
+        autoescape=True,
+        loader=FileSystemLoader(TEMPLATES_DIRECTORY),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    return env
 
 
 def get_meta_data(model: str) -> Dict[str, str]:
@@ -94,11 +109,33 @@ def get_model_metadata() -> Dict[str, Dict[str, str]]:
 
 
 if __name__ == "__main__":
-    # Get the metadata for all models
-    model_metadata = get_model_metadata()
-
-    # Save the metadata to a JSON file
-    with open(JSON_PATH, "w") as f:
-        json.dump(model_metadata, f, indent=2)
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="Generate a static page for the models."
+    )
+    parser.add_argument(
+        "--regenerate-json",
+        action="store_true",
+        help="Regenerate the JSON file with model metadata.",
+    )
+    args = parser.parse_args()
+    if args.regenerate_json or not JSON_PATH.exists():
+        # Get the metadata for all models and save it to a JSON file
+        model_metadata = get_model_metadata()
+        with open(JSON_PATH, "w") as f:
+            json.dump(model_metadata, f, indent=2)
+    else:
+        # Load the metadata from the JSON file
+        model_metadata = json.loads(JSON_PATH.read_text())
 
     # Render page
+    environment = get_jinja_env()
+    template = environment.get_template("static_page_template.html")
+    html = template.render(
+        model_metadata=model_metadata,
+        models=MODELS,
+    )
+
+    # Save the rendered HTML to a file
+    print(f"Saving HTML to {HTML_PATH}")
+    HTML_PATH.write_text(html)

--- a/emmaa_service/generate_static_page.py
+++ b/emmaa_service/generate_static_page.py
@@ -1,8 +1,14 @@
+import json
+from pathlib import Path
 from typing import Dict
 
 from tqdm import tqdm
 
 from emmaa.util import find_latest_s3_file, load_json_from_s3, does_exist
+
+
+HERE = Path(__file__).parent.resolve()
+JSON_PATH = HERE / "models.json"
 
 MODELS = [
     "aml",
@@ -73,8 +79,8 @@ def get_meta_data(model: str) -> Dict[str, str]:
         "model_short_name": model_short_name,
         "name": human_readable_name,
         "description": config_json["description"],
-        "model_path": latest_model_pkl,
-        "test_path": latest_model_test,
+        "model_path": latest_model_pkl or "",
+        "test_path": latest_model_test or "",
         "ndex": config_json.get("ndex", {}).get("network", "")  # in config.json -> ndex -> network
     }
 
@@ -85,3 +91,14 @@ def get_model_metadata() -> Dict[str, Dict[str, str]]:
     for model in tqdm(MODELS, desc="Loading model metadata", unit="model"):
         model_metadata[model] = get_meta_data(model)
     return model_metadata
+
+
+if __name__ == "__main__":
+    # Get the metadata for all models
+    model_metadata = get_model_metadata()
+
+    # Save the metadata to a JSON file
+    with open(JSON_PATH, "w") as f:
+        json.dump(model_metadata, f, indent=2)
+
+    # Render page

--- a/emmaa_service/generate_static_page.py
+++ b/emmaa_service/generate_static_page.py
@@ -1,0 +1,87 @@
+from typing import Dict
+
+from tqdm import tqdm
+
+from emmaa.util import find_latest_s3_file, load_json_from_s3, does_exist
+
+MODELS = [
+    "aml",
+    "brca",
+    "covid19",
+    "covid19_dev",
+    "covid19_inflammasome",
+    "covid19_map",
+    "food_insecurity",
+    "luad",
+    "marm_model",
+    "monkeypox",
+    "ms",
+    "nf",
+    "paad",
+    "painmachine",
+    "pompe",
+    "prad",
+    "rasmachine",
+    "rasmodel",
+    "skcm",
+    "vitiligo",
+]
+
+
+def get_meta_data(model: str) -> Dict[str, str]:
+    """Get the metadata for a model."""
+    # Todo: handle models that have multiple test corpora
+    bucket = "emmaa"
+    prefix_meta_json = f"models/{model}/{model}_model_meta.json"
+    prefix_config = f"models/{model}/config.json"
+
+    if does_exist(bucket=bucket, prefix=prefix_meta_json):
+        meta_json = load_json_from_s3(bucket=bucket, key=prefix_meta_json)
+    else:
+        meta_json = {}
+
+    config_json = load_json_from_s3(bucket=bucket, key=prefix_config)
+
+    latest_model_pkl = find_latest_s3_file(
+        bucket=bucket,
+        prefix=f"models/{model}/model",
+        extension="pkl"
+    )
+    latest_model_test = find_latest_s3_file(
+        bucket=bucket,
+        prefix=f"stats/{model}/test",
+    )
+
+    def _get_val(key: str, default: str) -> str:
+        """Get the value from the metadata or return the default."""
+        if key in meta_json:
+            return meta_json[key]
+        if key in config_json:
+            return config_json[key]
+        return default
+
+    model_short_name = _get_val("name", "")
+    if not model_short_name:
+        model_short_name = model
+
+    human_readable_name = _get_val("human_readable_name", "")
+    if not human_readable_name:
+        human_readable_name = model_short_name
+
+    return {
+        "model": model,
+        "model_short_name": model_short_name,
+        "name": human_readable_name,
+        "description": config_json["description"],
+        "model_path": latest_model_pkl,
+        "test_path": latest_model_test,
+        "ndex": config_json.get("ndex", {}).get("network", "")  # in config.json -> ndex -> network
+    }
+
+
+def get_model_metadata() -> Dict[str, Dict[str, str]]:
+    """Get the metadata for all models."""
+    model_metadata = {}
+    for model in tqdm(MODELS, desc="Loading model metadata", unit="model"):
+        model_metadata[model] = get_meta_data(model)
+    return model_metadata

--- a/emmaa_service/models.json
+++ b/emmaa_service/models.json
@@ -1,0 +1,182 @@
+{
+  "aml": {
+    "model": "aml",
+    "model_short_name": "aml",
+    "name": "Acute myeloid leukemia",
+    "description": "A model of molecular mechanisms governing AML, focusing on frequently mutated genes, and the pathways in which they are involved.",
+    "model_path": "models/aml/model_2024-08-26-17-05-43.pkl",
+    "test_path": "stats/aml/test_stats_large_corpus_tests_2024-08-01-17-17-03.json",
+    "ndex": "ef58f76d-f6a2-11e8-aaa6-0ac135e8bacf"
+  },
+  "brca": {
+    "model": "brca",
+    "model_short_name": "brca",
+    "name": "Breast Cancer",
+    "description": "A model of molecular mechanisms governing brest cancer, focusing on frequently mutated genes, and the pathways in which they are involved.",
+    "model_path": "models/brca/model_2024-08-26-17-06-49.pkl",
+    "test_path": "stats/brca/test_stats_large_corpus_tests_2024-02-10-17-19-47.json",
+    "ndex": "a16b5ca0-f6a3-11e8-aaa6-0ac135e8bacf"
+  },
+  "covid19": {
+    "model": "covid19",
+    "model_short_name": "covid19",
+    "name": "Covid-19",
+    "description": "Covid-19 knowledge network automatically assembled from the CORD-19 document corpus.",
+    "model_path": "models/covid19/model_2024-08-26-17-08-33.pkl",
+    "test_path": "stats/covid19/test_stats_covid19_curated_tests_2024-08-01-17-49-59.json",
+    "ndex": "a8c0decc-6bbb-11ea-bfdc-0ac135e8bacf"
+  },
+  "covid19_dev": {
+    "model": "covid19_dev",
+    "model_short_name": "covid19_dev",
+    "name": "Covid-19 Dev",
+    "description": "Development version of Covid-19 knowledge network automatically assembled from the CORD-19 document corpus.",
+    "model_path": "models/covid19_dev/model_2021-01-19-06-44-59.pkl",
+    "test_path": "stats/covid19_dev/test_stats_covid19_curated_tests_2021-01-19-07-47-38.json",
+    "ndex": "959c94cc-7503-11ea-aaef-0ac135e8bacf"
+  },
+  "covid19_inflammasome": {
+    "model": "covid19_inflammasome",
+    "model_short_name": "covid19_inflammasome",
+    "name": "NLRP3 inflammasome in COVID-19",
+    "description": "NLRP3 inflammasome model assembled from the COVID-19 Disease Map and surrounding literature",
+    "model_path": "models/covid19_inflammasome/model_2021-08-19-13-39-52.pkl",
+    "test_path": "stats/covid19_inflammasome/test_stats_covid19_tests_2021-08-23-17-19-58.json",
+    "ndex": ""
+  },
+  "covid19_map": {
+    "model": "covid19_map",
+    "model_short_name": "covid19_map",
+    "name": "Covid-19 Disease Map",
+    "description": "Covid-19 knowledge network automatically assembled from the Covid-19 Disease Map",
+    "model_path": "models/covid19_map/model_2024-08-26-17-05-53.pkl",
+    "test_path": "stats/covid19_map/test_stats_covid19_curated_tests_c19dm_2024-07-31-17-09-56.json",
+    "ndex": ""
+  },
+  "food_insecurity": {
+    "model": "food_insecurity",
+    "model_short_name": "food_insecurity",
+    "name": "Food Insecurity Model",
+    "description": "A model of causal factors affecting food insecurity, built around a set of core concepts.",
+    "model_path": "models/food_insecurity/model_2024-08-26-17-06-40.pkl",
+    "test_path": "stats/food_insecurity/test_stats_world_modelers_tests_2024-08-01-17-20-04.json",
+    "ndex": "478a3ed6-b3b7-11e9-8bb4-0ac135e8bacf"
+  },
+  "luad": {
+    "model": "luad",
+    "model_short_name": "luad",
+    "name": "Lung adenocarcinoma",
+    "description": "A model of molecular mechanisms governing lung cancer, focusing on frequently mutated genes, and the pathways in which they are involved.",
+    "model_path": "models/luad/model_2024-08-26-17-06-36.pkl",
+    "test_path": "stats/luad/test_stats_large_corpus_tests_2024-08-01-17-19-03.json",
+    "ndex": "b56642b3-f6a3-11e8-aaa6-0ac135e8bacf"
+  },
+  "marm_model": {
+    "model": "marm_model",
+    "model_short_name": "marm_model",
+    "name": "MARM Model",
+    "description": "Natural-language-based implementation of the MARM model.",
+    "model_path": "",
+    "test_path": "stats/marm_model/test_stats_rasmachine_tests_2024-08-01-17-06-20.json",
+    "ndex": "b634dca6-87c7-11e9-848d-0ac135e8bacf"
+  },
+  "monkeypox": {
+    "model": "monkeypox",
+    "model_short_name": "monkeypox",
+    "name": "Monkeypox model",
+    "description": "A self-updating model of monkeypox literature.",
+    "model_path": "models/monkeypox/model_2024-08-26-17-05-44.pkl",
+    "test_path": "stats/monkeypox/test_stats_large_corpus_tests_2024-08-01-17-06-40.json",
+    "ndex": ""
+  },
+  "ms": {
+    "model": "ms",
+    "model_short_name": "ms",
+    "name": "Multiple sclerosis",
+    "description": "A self-updating model of multiple sclerosis",
+    "model_path": "models/ms/model_2024-08-26-17-05-55.pkl",
+    "test_path": "stats/ms/test_stats_large_corpus_tests_2024-08-01-17-07-24.json",
+    "ndex": "b02b8bcf-3425-11eb-9e72-0ac135e8bacf"
+  },
+  "nf": {
+    "model": "nf",
+    "model_short_name": "nf",
+    "name": "Neurofibromatosis",
+    "description": "Neurofibromatosis knowledge network automatically assembled from relevant publications in PubMed.",
+    "model_path": "models/nf/model_2024-08-26-17-05-53.pkl",
+    "test_path": "stats/nf/test_stats_large_corpus_tests_2024-08-01-17-11-46.json",
+    "ndex": "f2af7563-1874-11eb-9eee-0ac135e8bacf"
+  },
+  "paad": {
+    "model": "paad",
+    "model_short_name": "paad",
+    "name": "Pancreas adenocarcinoma",
+    "description": "A model of molecular mechanisms governing pancreatic cancer, focusing on frequently mutated genes, and the pathways in which they are involved.",
+    "model_path": "models/paad/model_2024-08-26-17-05-32.pkl",
+    "test_path": "stats/paad/test_stats_large_corpus_tests_2024-08-01-17-14-31.json",
+    "ndex": "8d1330ca-f6a2-11e8-aaa6-0ac135e8bacf"
+  },
+  "painmachine": {
+    "model": "painmachine",
+    "model_short_name": "painmachine",
+    "name": "Pain Machine",
+    "description": "A model of molecular mechanisms governing pain.",
+    "model_path": "models/painmachine/model_2024-08-26-17-07-15.pkl",
+    "test_path": "stats/painmachine/test_stats_chemical_pain_ctd_tests_2024-08-01-17-53-47.json",
+    "ndex": "e1e5963a-eb0e-11e9-bb65-0ac135e8bacf"
+  },
+  "pompe": {
+    "model": "pompe",
+    "model_short_name": "pompe",
+    "name": "Pompe Disease",
+    "description": "A self-updating model of Pompe Disease",
+    "model_path": "models/pompe/model_2024-08-26-17-06-00.pkl",
+    "test_path": "stats/pompe/test_stats_large_corpus_tests_2024-08-01-17-07-42.json",
+    "ndex": ""
+  },
+  "prad": {
+    "model": "prad",
+    "model_short_name": "prad",
+    "name": "Prostate adenocarcinoma",
+    "description": "A model of molecular mechanisms governing prostace cancer, focusing on frequently mutated genes, and the pathways in which they are involved.",
+    "model_path": "models/prad/model_2024-08-26-17-06-33.pkl",
+    "test_path": "stats/prad/test_stats_large_corpus_tests_2024-08-01-17-15-19.json",
+    "ndex": "caa8c3f6-f6a3-11e8-aaa6-0ac135e8bacf"
+  },
+  "rasmachine": {
+    "model": "rasmachine",
+    "model_short_name": "rasmachine",
+    "name": "Ras Machine 2.0",
+    "description": "A model of Ras signaling built using automated reading and assembly from the scientific literature.",
+    "model_path": "models/rasmachine/model_2024-08-26-17-07-46.pkl",
+    "test_path": "stats/rasmachine/test_stats_large_corpus_tests_2024-08-01-17-44-31.json",
+    "ndex": "cdba5bd5-5195-11e9-9f06-0ac135e8bacf"
+  },
+  "rasmodel": {
+    "model": "rasmodel",
+    "model_short_name": "luad",
+    "name": "Ras Model",
+    "description": "A human-curated model of Ras signaling defined in natural language.",
+    "model_path": "models/rasmodel/model_2020-11-20-19-18-50.pkl",
+    "test_path": "stats/rasmodel/test_stats_large_corpus_tests_2024-08-01-17-07-18.json",
+    "ndex": "cc9f904f-4ffd-11e9-9f06-0ac135e8bacf"
+  },
+  "skcm": {
+    "model": "skcm",
+    "model_short_name": "skcm",
+    "name": "Skin cutaneous melanoma",
+    "description": "A model of molecular mechanisms governing melanoma, focusing on frequently mutated genes, and the pathways in which they are involved.",
+    "model_path": "models/skcm/model_2024-08-26-17-06-51.pkl",
+    "test_path": "stats/skcm/test_stats_large_corpus_tests_2024-08-01-17-17-24.json",
+    "ndex": "da832549-f6a3-11e8-aaa6-0ac135e8bacf"
+  },
+  "vitiligo": {
+    "model": "vitiligo",
+    "model_short_name": "vitiligo",
+    "name": "Vitiligo",
+    "description": "A self-updating model of vitiligo",
+    "model_path": "models/vitiligo/model_2024-08-26-17-06-47.pkl",
+    "test_path": "stats/vitiligo/test_stats_large_corpus_tests_2024-08-01-17-08-04.json",
+    "ndex": "7e60e908-3420-11eb-9e72-0ac135e8bacf"
+  }
+}

--- a/emmaa_service/templates/static_page.html
+++ b/emmaa_service/templates/static_page.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>EMMAA dashboard</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+
+  <!-- Latest compiled and minified CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+
+  <!-- Optional theme -->
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
+
+  <!-- bootstrap 4.1.3 -->
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+
+  <!-- Add icon library -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+
+  <!-- Belief range style adapted from https://stackoverflow.com/questions/4753946/html5-slider-with-two-inputs-possible -->
+  <style>
+    html {
+      position: relative;
+      min-height: 100%;
+    }
+    body {
+      /* Margin bottom by footer height */
+      margin-bottom: 190px;
+    }
+    .footer {
+      position: absolute;
+      bottom: 0;
+      width: 100%;
+      /* Set the fixed height of the footer here */
+      height: 190px;
+      background-color: #f5f5f5;
+    }
+    a.model-link {
+      color: #000000;
+    }
+    .choices__list--multiple .choices__item {
+      background-color: #007bff;
+      border: #007bff;
+    }
+    a.stmt-dblink {
+      color: #000000;
+      text-decoration: none;
+    }
+    a.status-link {
+      color: #000000;
+      text-decoration: none;
+    }
+    a {
+      target-new: tab;
+    }
+    body > .container {
+      padding: 85px 15px 0;
+    }
+    a.btn {
+      background-color: rgb(255, 255, 255);
+    }
+    .btn-group .btn {
+      border-radius: 6px;
+    }
+    .btn-group>.btn-group:not(:last-child)>.btn , .btn-group>.btn:not(:last-child):not(.dropdown-toggle){
+      border-radius: 6px;
+    }
+    .btn-group>.btn-group:not(:first-child)>.btn, .btn-group>.btn:not(:first-child) {
+      border-radius: 6px;
+    }
+    .btn-query-submit {
+      background-color: rgb(221, 221, 221);
+    }
+    button.btn-primary { /* For login button */
+      background-color: #007bff;
+    }
+    .fa-check {color: #00ff00}
+    .fa-times {color: #ff0000}
+    .fa-ban {color: #a5a5a5}
+    .nav-tabs .nav-item.show .nav-link, .nav-tabs .nav-link.active {background-color: #f8f9fa}
+    .fa {
+      font-size:25px;
+      width: 30px;
+      text-align: center;
+      text-decoration: none;
+      padding: 0;
+    }
+    .fa-twitter {
+      background: white;
+      color:  #55ACEE;
+    }
+    section.range-slider {
+      position: relative;
+      width: 500px;
+      height: 15px;
+      text-align: center;
+  }
+  
+  section.range-slider input {
+      -webkit-appearance: none;
+      pointer-events: none;
+      position: absolute;
+      overflow: hidden;
+      left: 0;
+      top: 25px;
+      width: 500px;
+      outline: none;
+      height: 15px;
+      border-radius: 5px; 
+      margin: 0;
+      padding: 0;
+      background: #d3d3d3;
+  }
+  
+  section.range-slider input::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      pointer-events: all;
+      position: relative;
+      z-index: 1;
+      outline: 0;
+      height: 20px;
+      width: 15px;
+      cursor: pointer;
+      border-radius: 50%; 
+      background: #007bff;
+  }
+  
+  section.range-slider input::-moz-range-thumb {
+      pointer-events: all;
+      position: relative;
+      z-index: 10;
+      -moz-appearance: none;
+      width: 9px;
+      
+  }
+  
+  section.range-slider input:last-of-type::-moz-range-track {
+      -moz-appearance: none;
+      background: none transparent;
+      border: 0;
+  }
+    section.range-slider input[type=range]::-moz-focus-outer {
+    border: 0;
+  }
+  @-moz-document url-prefix() {
+    input[type='range']:nth-child(1){
+      -webkit-appearance: none;
+      position:absolute;
+      top:35px !important;
+      overflow:visible !important;
+      height:0;
+    }
+  
+    input[type='range']:nth-child(2){
+      -webkit-appearance: none;
+      position:absolute;
+      top:53px !important;
+      overflow:visible !important;
+      height:0;
+    }
+    input[type='range']::-moz-range-thumb {
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      position: relative;
+      height: 13px;
+      width: 15px;
+      margin-top: -7px;
+      background: #007bff;
+      border: 1px solid #007bff;
+      border-radius: 25px;
+      z-index: 1;
+    }
+  
+    input[type='range']:nth-child(1)::-moz-range-thumb {
+        -webkit-appearance: none;
+        transform: translateY(-20px);    
+    }
+    input[type='range']:nth-child(2)::-moz-range-thumb {
+        -webkit-appearance: none;
+        transform: translateY(-20px);    
+    }
+  }
+  </style>
+</head>
+
+<body>
+    <header class="bg-white border-bottom shadow-sm fixed-top no-horiz-pad">
+      <div class="d-flex flex-row align-items-center">
+        <nav class="d-inline-flex p-2">
+        <a class="p-2 text-dark"
+           href="https://emmaa.readthedocs.io/en/latest/index.html"
+           target="_blank">Documentation</a>
+      </nav>
+      </div>
+    </header>
+
+    <div class="container">
+      <h3>Where did the page go?</h3>
+      <p>
+        The EMMAA project has been put on hold and we are no longer serving the EMMAA
+        dashboard homepage. All the models and data are still available for download. A
+        future project may be launched to serve the EMMAA dashboard again.<br>
+        The documentation is still available at <a href="https://emmaa.readthedocs.io/en/latest/index.html" target="_blank">emmaa.readthedocs.io</a>.<br>
+      </p>
+      <h3>Download the latest data</h3>
+      <p>
+        The latest data is available for download:
+      </p>
+      <div>
+        <table class="table">
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">Description</th>
+              <th scope="col">Download Link</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Acute Myeloid Leukemia (AML)</td>
+              <td>A model of the signaling pathways involved in AML.</td>
+              <td><a href="https://emmaa.s3.us-east-1.amazonaws.com/models/aml/model_2024-08-26-17-05-43.pkl" target="_blank">Download pickle</a></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+  <footer class="footer text-muted" id="about" style="background: #F5F5F5;">
+    <div class="container">
+      <h5 class="my-0 mr-md-auto font-weight-normal">About</h5>
+      <small>
+        <p class="float-right">
+          <a href="#">Back to top</a>
+        </p>
+        <p><a href="https://indralab.github.io" target="_blank">INDRALAB</a></p>
+        <p><a href="http://hits.harvard.edu" target="_blank">Harvard Program in Therapeutic Science (HiTS)</a></p>
+        <p><b>Automating Scientific Knowledge Extraction (ASKE)</b><br>EMMAA (Ecosystem of Machine-maintained Models with Automated Assembly) is a part of the DARPA ASKE program, which is part of DARPA's broader Artificial Intelligence Exploration program with the goal of developing technologies for the "Third Wave" of AI.<br><i>The EMMAA project is funded by the Defense Advanced Research Projects Agency under award HR00111990009.</i></p>
+      </small>
+    </div>
+  </footer>
+</body>

--- a/emmaa_service/templates/static_page.html
+++ b/emmaa_service/templates/static_page.html
@@ -222,8 +222,8 @@
               <td>Acute myeloid leukemia</td>
               <td>A model of molecular mechanisms governing AML, focusing on frequently mutated genes, and the pathways in which they are involved.</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/aml/model_2024-08-26-17-05-43.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/aml/test_stats_large_corpus_tests_2024-08-01-17-17-03.json" target="_blank">Tests JSON</a>
+                  <a href="/models/aml/model_2024-08-26-17-05-43.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/aml/test_stats_large_corpus_tests_2024-08-01-17-17-03.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -235,8 +235,8 @@
               <td>Breast Cancer</td>
               <td>A model of molecular mechanisms governing brest cancer, focusing on frequently mutated genes, and the pathways in which they are involved.</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/brca/model_2024-08-26-17-06-49.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/brca/test_stats_large_corpus_tests_2024-02-10-17-19-47.json" target="_blank">Tests JSON</a>
+                  <a href="/models/brca/model_2024-08-26-17-06-49.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/brca/test_stats_large_corpus_tests_2024-02-10-17-19-47.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -248,8 +248,8 @@
               <td>Covid-19</td>
               <td>Covid-19 knowledge network automatically assembled from the CORD-19 document corpus.</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/covid19/model_2024-08-26-17-08-33.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/covid19/test_stats_covid19_curated_tests_2024-08-01-17-49-59.json" target="_blank">Tests JSON</a>
+                  <a href="/models/covid19/model_2024-08-26-17-08-33.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/covid19/test_stats_covid19_curated_tests_2024-08-01-17-49-59.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -261,8 +261,8 @@
               <td>Covid-19 Dev</td>
               <td>Development version of Covid-19 knowledge network automatically assembled from the CORD-19 document corpus.</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/covid19_dev/model_2021-01-19-06-44-59.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/covid19_dev/test_stats_covid19_curated_tests_2021-01-19-07-47-38.json" target="_blank">Tests JSON</a>
+                  <a href="/models/covid19_dev/model_2021-01-19-06-44-59.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/covid19_dev/test_stats_covid19_curated_tests_2021-01-19-07-47-38.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -274,8 +274,8 @@
               <td>NLRP3 inflammasome in COVID-19</td>
               <td>NLRP3 inflammasome model assembled from the COVID-19 Disease Map and surrounding literature</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/covid19_inflammasome/model_2021-08-19-13-39-52.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/covid19_inflammasome/test_stats_covid19_tests_2021-08-23-17-19-58.json" target="_blank">Tests JSON</a>
+                  <a href="/models/covid19_inflammasome/model_2021-08-19-13-39-52.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/covid19_inflammasome/test_stats_covid19_tests_2021-08-23-17-19-58.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <i class="text-muted">No network available</i>
@@ -284,8 +284,8 @@
               <td>Covid-19 Disease Map</td>
               <td>Covid-19 knowledge network automatically assembled from the Covid-19 Disease Map</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/covid19_map/model_2024-08-26-17-05-53.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/covid19_map/test_stats_covid19_curated_tests_c19dm_2024-07-31-17-09-56.json" target="_blank">Tests JSON</a>
+                  <a href="/models/covid19_map/model_2024-08-26-17-05-53.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/covid19_map/test_stats_covid19_curated_tests_c19dm_2024-07-31-17-09-56.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <i class="text-muted">No network available</i>
@@ -294,8 +294,8 @@
               <td>Food Insecurity Model</td>
               <td>A model of causal factors affecting food insecurity, built around a set of core concepts.</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/food_insecurity/model_2024-08-26-17-06-40.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/food_insecurity/test_stats_world_modelers_tests_2024-08-01-17-20-04.json" target="_blank">Tests JSON</a>
+                  <a href="/models/food_insecurity/model_2024-08-26-17-06-40.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/food_insecurity/test_stats_world_modelers_tests_2024-08-01-17-20-04.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -307,8 +307,8 @@
               <td>Lung adenocarcinoma</td>
               <td>A model of molecular mechanisms governing lung cancer, focusing on frequently mutated genes, and the pathways in which they are involved.</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/luad/model_2024-08-26-17-06-36.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/luad/test_stats_large_corpus_tests_2024-08-01-17-19-03.json" target="_blank">Tests JSON</a>
+                  <a href="/models/luad/model_2024-08-26-17-06-36.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/luad/test_stats_large_corpus_tests_2024-08-01-17-19-03.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -320,7 +320,7 @@
               <td>MARM Model</td>
               <td>Natural-language-based implementation of the MARM model.</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/marm_model/test_stats_rasmachine_tests_2024-08-01-17-06-20.json" target="_blank">Tests JSON</a>
+                  <a href="/stats/marm_model/test_stats_rasmachine_tests_2024-08-01-17-06-20.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -332,8 +332,8 @@
               <td>Monkeypox model</td>
               <td>A self-updating model of monkeypox literature.</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/monkeypox/model_2024-08-26-17-05-44.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/monkeypox/test_stats_large_corpus_tests_2024-08-01-17-06-40.json" target="_blank">Tests JSON</a>
+                  <a href="/models/monkeypox/model_2024-08-26-17-05-44.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/monkeypox/test_stats_large_corpus_tests_2024-08-01-17-06-40.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <i class="text-muted">No network available</i>
@@ -342,8 +342,8 @@
               <td>Multiple sclerosis</td>
               <td>A self-updating model of multiple sclerosis</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/ms/model_2024-08-26-17-05-55.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/ms/test_stats_large_corpus_tests_2024-08-01-17-07-24.json" target="_blank">Tests JSON</a>
+                  <a href="/models/ms/model_2024-08-26-17-05-55.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/ms/test_stats_large_corpus_tests_2024-08-01-17-07-24.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -355,8 +355,8 @@
               <td>Neurofibromatosis</td>
               <td>Neurofibromatosis knowledge network automatically assembled from relevant publications in PubMed.</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/nf/model_2024-08-26-17-05-53.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/nf/test_stats_large_corpus_tests_2024-08-01-17-11-46.json" target="_blank">Tests JSON</a>
+                  <a href="/models/nf/model_2024-08-26-17-05-53.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/nf/test_stats_large_corpus_tests_2024-08-01-17-11-46.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -368,8 +368,8 @@
               <td>Pancreas adenocarcinoma</td>
               <td>A model of molecular mechanisms governing pancreatic cancer, focusing on frequently mutated genes, and the pathways in which they are involved.</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/paad/model_2024-08-26-17-05-32.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/paad/test_stats_large_corpus_tests_2024-08-01-17-14-31.json" target="_blank">Tests JSON</a>
+                  <a href="/models/paad/model_2024-08-26-17-05-32.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/paad/test_stats_large_corpus_tests_2024-08-01-17-14-31.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -381,8 +381,8 @@
               <td>Pain Machine</td>
               <td>A model of molecular mechanisms governing pain.</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/painmachine/model_2024-08-26-17-07-15.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/painmachine/test_stats_chemical_pain_ctd_tests_2024-08-01-17-53-47.json" target="_blank">Tests JSON</a>
+                  <a href="/models/painmachine/model_2024-08-26-17-07-15.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/painmachine/test_stats_chemical_pain_ctd_tests_2024-08-01-17-53-47.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -394,8 +394,8 @@
               <td>Pompe Disease</td>
               <td>A self-updating model of Pompe Disease</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/pompe/model_2024-08-26-17-06-00.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/pompe/test_stats_large_corpus_tests_2024-08-01-17-07-42.json" target="_blank">Tests JSON</a>
+                  <a href="/models/pompe/model_2024-08-26-17-06-00.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/pompe/test_stats_large_corpus_tests_2024-08-01-17-07-42.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <i class="text-muted">No network available</i>
@@ -404,8 +404,8 @@
               <td>Prostate adenocarcinoma</td>
               <td>A model of molecular mechanisms governing prostace cancer, focusing on frequently mutated genes, and the pathways in which they are involved.</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/prad/model_2024-08-26-17-06-33.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/prad/test_stats_large_corpus_tests_2024-08-01-17-15-19.json" target="_blank">Tests JSON</a>
+                  <a href="/models/prad/model_2024-08-26-17-06-33.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/prad/test_stats_large_corpus_tests_2024-08-01-17-15-19.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -417,8 +417,8 @@
               <td>Ras Machine 2.0</td>
               <td>A model of Ras signaling built using automated reading and assembly from the scientific literature.</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/rasmachine/model_2024-08-26-17-07-46.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/rasmachine/test_stats_large_corpus_tests_2024-08-01-17-44-31.json" target="_blank">Tests JSON</a>
+                  <a href="/models/rasmachine/model_2024-08-26-17-07-46.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/rasmachine/test_stats_large_corpus_tests_2024-08-01-17-44-31.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -430,8 +430,8 @@
               <td>Ras Model</td>
               <td>A human-curated model of Ras signaling defined in natural language.</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/rasmodel/model_2020-11-20-19-18-50.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/rasmodel/test_stats_large_corpus_tests_2024-08-01-17-07-18.json" target="_blank">Tests JSON</a>
+                  <a href="/models/rasmodel/model_2020-11-20-19-18-50.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/rasmodel/test_stats_large_corpus_tests_2024-08-01-17-07-18.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -443,8 +443,8 @@
               <td>Skin cutaneous melanoma</td>
               <td>A model of molecular mechanisms governing melanoma, focusing on frequently mutated genes, and the pathways in which they are involved.</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/skcm/model_2024-08-26-17-06-51.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/skcm/test_stats_large_corpus_tests_2024-08-01-17-17-24.json" target="_blank">Tests JSON</a>
+                  <a href="/models/skcm/model_2024-08-26-17-06-51.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/skcm/test_stats_large_corpus_tests_2024-08-01-17-17-24.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -456,8 +456,8 @@
               <td>Vitiligo</td>
               <td>A self-updating model of vitiligo</td>
               <td>
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/vitiligo/model_2024-08-26-17-06-47.pkl" target="_blank">Model pickle</a>,
-                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/vitiligo/test_stats_large_corpus_tests_2024-08-01-17-08-04.json" target="_blank">Tests JSON</a>
+                  <a href="/models/vitiligo/model_2024-08-26-17-06-47.pkl" target="_blank">Model pickle</a>,
+                  <a href="/stats/vitiligo/test_stats_large_corpus_tests_2024-08-01-17-08-04.json" target="_blank">Tests JSON</a>
               </td>
               <td>
                   <a
@@ -479,7 +479,7 @@
         </p>
         <p><a href="https://indralab.github.io" target="_blank">INDRALAB</a></p>
         <p><a href="http://hits.harvard.edu" target="_blank">Harvard Program in Therapeutic Science (HiTS)</a></p>
-        <p><b>Automating Scientific Knowledge Extraction (ASKE)</b><br>EMMAA (Ecosystem of Machine-maintained Models with Automated Assembly) is a part of the DARPA ASKE program, which is part of DARPA's broader Artificial Intelligence Exploration program with the goal of developing technologies for the "Third Wave" of AI.<br><i>The EMMAA project is funded by the Defense Advanced Research Projects Agency under award HR00111990009.</i></p>
+        <p><b>Automating Scientific Knowledge Extraction (ASKE)</b><br>EMMAA (Ecosystem of Machine-maintained Models with Automated Assembly) was a part of the DARPA ASKE program, which was part of DARPA's broader Artificial Intelligence Exploration program with the goal of developing technologies for the "Third Wave" of AI.<br><i>The EMMAA project was funded by the Defense Advanced Research Projects Agency under award HR00111990009.</i></p>
       </small>
     </div>
   </footer>

--- a/emmaa_service/templates/static_page.html
+++ b/emmaa_service/templates/static_page.html
@@ -213,17 +213,257 @@
             <tr>
               <th scope="col">Name</th>
               <th scope="col">Description</th>
-              <th scope="col">Download Link</th>
+              <th scope="col">Download Links</th>
+              <th scope="col">Network on NDex</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td>Acute Myeloid Leukemia (AML)</td>
-              <td>A model of the signaling pathways involved in AML.</td>
+              <td>Acute myeloid leukemia</td>
+              <td>A model of molecular mechanisms governing AML, focusing on frequently mutated genes, and the pathways in which they are involved.</td>
               <td>
-                <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/aml/model_2024-08-26-17-05-43.pkl" target="_blank">Model pickle</a>,
-                <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/aml/test_stats_large_corpus_tests_2024-08-01-17-17-03.json" target="_blank">Tests JSON</a>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/aml/model_2024-08-26-17-05-43.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/aml/test_stats_large_corpus_tests_2024-08-01-17-17-03.json" target="_blank">Tests JSON</a>
               </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/ef58f76d-f6a2-11e8-aaa6-0ac135e8bacf"
+                      target="_blank">ef58f76d-f6a2-11e8-aaa6-0ac135e8bacf
+                  </a>
+            </tr>
+            <tr>
+              <td>Breast Cancer</td>
+              <td>A model of molecular mechanisms governing brest cancer, focusing on frequently mutated genes, and the pathways in which they are involved.</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/brca/model_2024-08-26-17-06-49.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/brca/test_stats_large_corpus_tests_2024-02-10-17-19-47.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/a16b5ca0-f6a3-11e8-aaa6-0ac135e8bacf"
+                      target="_blank">a16b5ca0-f6a3-11e8-aaa6-0ac135e8bacf
+                  </a>
+            </tr>
+            <tr>
+              <td>Covid-19</td>
+              <td>Covid-19 knowledge network automatically assembled from the CORD-19 document corpus.</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/covid19/model_2024-08-26-17-08-33.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/covid19/test_stats_covid19_curated_tests_2024-08-01-17-49-59.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/a8c0decc-6bbb-11ea-bfdc-0ac135e8bacf"
+                      target="_blank">a8c0decc-6bbb-11ea-bfdc-0ac135e8bacf
+                  </a>
+            </tr>
+            <tr>
+              <td>Covid-19 Dev</td>
+              <td>Development version of Covid-19 knowledge network automatically assembled from the CORD-19 document corpus.</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/covid19_dev/model_2021-01-19-06-44-59.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/covid19_dev/test_stats_covid19_curated_tests_2021-01-19-07-47-38.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/959c94cc-7503-11ea-aaef-0ac135e8bacf"
+                      target="_blank">959c94cc-7503-11ea-aaef-0ac135e8bacf
+                  </a>
+            </tr>
+            <tr>
+              <td>NLRP3 inflammasome in COVID-19</td>
+              <td>NLRP3 inflammasome model assembled from the COVID-19 Disease Map and surrounding literature</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/covid19_inflammasome/model_2021-08-19-13-39-52.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/covid19_inflammasome/test_stats_covid19_tests_2021-08-23-17-19-58.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <i class="text-muted">No network available</i>
+            </tr>
+            <tr>
+              <td>Covid-19 Disease Map</td>
+              <td>Covid-19 knowledge network automatically assembled from the Covid-19 Disease Map</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/covid19_map/model_2024-08-26-17-05-53.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/covid19_map/test_stats_covid19_curated_tests_c19dm_2024-07-31-17-09-56.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <i class="text-muted">No network available</i>
+            </tr>
+            <tr>
+              <td>Food Insecurity Model</td>
+              <td>A model of causal factors affecting food insecurity, built around a set of core concepts.</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/food_insecurity/model_2024-08-26-17-06-40.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/food_insecurity/test_stats_world_modelers_tests_2024-08-01-17-20-04.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/478a3ed6-b3b7-11e9-8bb4-0ac135e8bacf"
+                      target="_blank">478a3ed6-b3b7-11e9-8bb4-0ac135e8bacf
+                  </a>
+            </tr>
+            <tr>
+              <td>Lung adenocarcinoma</td>
+              <td>A model of molecular mechanisms governing lung cancer, focusing on frequently mutated genes, and the pathways in which they are involved.</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/luad/model_2024-08-26-17-06-36.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/luad/test_stats_large_corpus_tests_2024-08-01-17-19-03.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/b56642b3-f6a3-11e8-aaa6-0ac135e8bacf"
+                      target="_blank">b56642b3-f6a3-11e8-aaa6-0ac135e8bacf
+                  </a>
+            </tr>
+            <tr>
+              <td>MARM Model</td>
+              <td>Natural-language-based implementation of the MARM model.</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/marm_model/test_stats_rasmachine_tests_2024-08-01-17-06-20.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/b634dca6-87c7-11e9-848d-0ac135e8bacf"
+                      target="_blank">b634dca6-87c7-11e9-848d-0ac135e8bacf
+                  </a>
+            </tr>
+            <tr>
+              <td>Monkeypox model</td>
+              <td>A self-updating model of monkeypox literature.</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/monkeypox/model_2024-08-26-17-05-44.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/monkeypox/test_stats_large_corpus_tests_2024-08-01-17-06-40.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <i class="text-muted">No network available</i>
+            </tr>
+            <tr>
+              <td>Multiple sclerosis</td>
+              <td>A self-updating model of multiple sclerosis</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/ms/model_2024-08-26-17-05-55.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/ms/test_stats_large_corpus_tests_2024-08-01-17-07-24.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/b02b8bcf-3425-11eb-9e72-0ac135e8bacf"
+                      target="_blank">b02b8bcf-3425-11eb-9e72-0ac135e8bacf
+                  </a>
+            </tr>
+            <tr>
+              <td>Neurofibromatosis</td>
+              <td>Neurofibromatosis knowledge network automatically assembled from relevant publications in PubMed.</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/nf/model_2024-08-26-17-05-53.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/nf/test_stats_large_corpus_tests_2024-08-01-17-11-46.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/f2af7563-1874-11eb-9eee-0ac135e8bacf"
+                      target="_blank">f2af7563-1874-11eb-9eee-0ac135e8bacf
+                  </a>
+            </tr>
+            <tr>
+              <td>Pancreas adenocarcinoma</td>
+              <td>A model of molecular mechanisms governing pancreatic cancer, focusing on frequently mutated genes, and the pathways in which they are involved.</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/paad/model_2024-08-26-17-05-32.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/paad/test_stats_large_corpus_tests_2024-08-01-17-14-31.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/8d1330ca-f6a2-11e8-aaa6-0ac135e8bacf"
+                      target="_blank">8d1330ca-f6a2-11e8-aaa6-0ac135e8bacf
+                  </a>
+            </tr>
+            <tr>
+              <td>Pain Machine</td>
+              <td>A model of molecular mechanisms governing pain.</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/painmachine/model_2024-08-26-17-07-15.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/painmachine/test_stats_chemical_pain_ctd_tests_2024-08-01-17-53-47.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/e1e5963a-eb0e-11e9-bb65-0ac135e8bacf"
+                      target="_blank">e1e5963a-eb0e-11e9-bb65-0ac135e8bacf
+                  </a>
+            </tr>
+            <tr>
+              <td>Pompe Disease</td>
+              <td>A self-updating model of Pompe Disease</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/pompe/model_2024-08-26-17-06-00.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/pompe/test_stats_large_corpus_tests_2024-08-01-17-07-42.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <i class="text-muted">No network available</i>
+            </tr>
+            <tr>
+              <td>Prostate adenocarcinoma</td>
+              <td>A model of molecular mechanisms governing prostace cancer, focusing on frequently mutated genes, and the pathways in which they are involved.</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/prad/model_2024-08-26-17-06-33.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/prad/test_stats_large_corpus_tests_2024-08-01-17-15-19.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/caa8c3f6-f6a3-11e8-aaa6-0ac135e8bacf"
+                      target="_blank">caa8c3f6-f6a3-11e8-aaa6-0ac135e8bacf
+                  </a>
+            </tr>
+            <tr>
+              <td>Ras Machine 2.0</td>
+              <td>A model of Ras signaling built using automated reading and assembly from the scientific literature.</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/rasmachine/model_2024-08-26-17-07-46.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/rasmachine/test_stats_large_corpus_tests_2024-08-01-17-44-31.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/cdba5bd5-5195-11e9-9f06-0ac135e8bacf"
+                      target="_blank">cdba5bd5-5195-11e9-9f06-0ac135e8bacf
+                  </a>
+            </tr>
+            <tr>
+              <td>Ras Model</td>
+              <td>A human-curated model of Ras signaling defined in natural language.</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/rasmodel/model_2020-11-20-19-18-50.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/rasmodel/test_stats_large_corpus_tests_2024-08-01-17-07-18.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/cc9f904f-4ffd-11e9-9f06-0ac135e8bacf"
+                      target="_blank">cc9f904f-4ffd-11e9-9f06-0ac135e8bacf
+                  </a>
+            </tr>
+            <tr>
+              <td>Skin cutaneous melanoma</td>
+              <td>A model of molecular mechanisms governing melanoma, focusing on frequently mutated genes, and the pathways in which they are involved.</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/skcm/model_2024-08-26-17-06-51.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/skcm/test_stats_large_corpus_tests_2024-08-01-17-17-24.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/da832549-f6a3-11e8-aaa6-0ac135e8bacf"
+                      target="_blank">da832549-f6a3-11e8-aaa6-0ac135e8bacf
+                  </a>
+            </tr>
+            <tr>
+              <td>Vitiligo</td>
+              <td>A self-updating model of vitiligo</td>
+              <td>
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/vitiligo/model_2024-08-26-17-06-47.pkl" target="_blank">Model pickle</a>,
+                  <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/vitiligo/test_stats_large_corpus_tests_2024-08-01-17-08-04.json" target="_blank">Tests JSON</a>
+              </td>
+              <td>
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/7e60e908-3420-11eb-9e72-0ac135e8bacf"
+                      target="_blank">7e60e908-3420-11eb-9e72-0ac135e8bacf
+                  </a>
             </tr>
           </tbody>
         </table>

--- a/emmaa_service/templates/static_page.html
+++ b/emmaa_service/templates/static_page.html
@@ -220,7 +220,10 @@
             <tr>
               <td>Acute Myeloid Leukemia (AML)</td>
               <td>A model of the signaling pathways involved in AML.</td>
-              <td><a href="https://emmaa.s3.us-east-1.amazonaws.com/models/aml/model_2024-08-26-17-05-43.pkl" target="_blank">Download pickle</a></td>
+              <td>
+                <a href="https://emmaa.s3.us-east-1.amazonaws.com/models/aml/model_2024-08-26-17-05-43.pkl" target="_blank">Model pickle</a>,
+                <a href="https://emmaa.s3.us-east-1.amazonaws.com/stats/aml/test_stats_large_corpus_tests_2024-08-01-17-17-03.json" target="_blank">Tests JSON</a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/emmaa_service/templates/static_page_template.html
+++ b/emmaa_service/templates/static_page_template.html
@@ -260,7 +260,7 @@
         </p>
         <p><a href="https://indralab.github.io" target="_blank">INDRALAB</a></p>
         <p><a href="http://hits.harvard.edu" target="_blank">Harvard Program in Therapeutic Science (HiTS)</a></p>
-        <p><b>Automating Scientific Knowledge Extraction (ASKE)</b><br>EMMAA (Ecosystem of Machine-maintained Models with Automated Assembly) is a part of the DARPA ASKE program, which is part of DARPA's broader Artificial Intelligence Exploration program with the goal of developing technologies for the "Third Wave" of AI.<br><i>The EMMAA project is funded by the Defense Advanced Research Projects Agency under award HR00111990009.</i></p>
+        <p><b>Automating Scientific Knowledge Extraction (ASKE)</b><br>EMMAA (Ecosystem of Machine-maintained Models with Automated Assembly) was a part of the DARPA ASKE program, which was part of DARPA's broader Artificial Intelligence Exploration program with the goal of developing technologies for the "Third Wave" of AI.<br><i>The EMMAA project was funded by the Defense Advanced Research Projects Agency under award HR00111990009.</i></p>
       </small>
     </div>
   </footer>

--- a/emmaa_service/templates/static_page_template.html
+++ b/emmaa_service/templates/static_page_template.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>EMMAA dashboard</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+
+  <!-- Latest compiled and minified CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+
+  <!-- Optional theme -->
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
+
+  <!-- bootstrap 4.1.3 -->
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+
+  <!-- Add icon library -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+
+  <!-- Belief range style adapted from https://stackoverflow.com/questions/4753946/html5-slider-with-two-inputs-possible -->
+  <style>
+    html {
+      position: relative;
+      min-height: 100%;
+    }
+    body {
+      /* Margin bottom by footer height */
+      margin-bottom: 190px;
+    }
+    .footer {
+      position: absolute;
+      bottom: 0;
+      width: 100%;
+      /* Set the fixed height of the footer here */
+      height: 190px;
+      background-color: #f5f5f5;
+    }
+    a.model-link {
+      color: #000000;
+    }
+    .choices__list--multiple .choices__item {
+      background-color: #007bff;
+      border: #007bff;
+    }
+    a.stmt-dblink {
+      color: #000000;
+      text-decoration: none;
+    }
+    a.status-link {
+      color: #000000;
+      text-decoration: none;
+    }
+    a {
+      target-new: tab;
+    }
+    body > .container {
+      padding: 85px 15px 0;
+    }
+    a.btn {
+      background-color: rgb(255, 255, 255);
+    }
+    .btn-group .btn {
+      border-radius: 6px;
+    }
+    .btn-group>.btn-group:not(:last-child)>.btn , .btn-group>.btn:not(:last-child):not(.dropdown-toggle){
+      border-radius: 6px;
+    }
+    .btn-group>.btn-group:not(:first-child)>.btn, .btn-group>.btn:not(:first-child) {
+      border-radius: 6px;
+    }
+    .btn-query-submit {
+      background-color: rgb(221, 221, 221);
+    }
+    button.btn-primary { /* For login button */
+      background-color: #007bff;
+    }
+    .fa-check {color: #00ff00}
+    .fa-times {color: #ff0000}
+    .fa-ban {color: #a5a5a5}
+    .nav-tabs .nav-item.show .nav-link, .nav-tabs .nav-link.active {background-color: #f8f9fa}
+    .fa {
+      font-size:25px;
+      width: 30px;
+      text-align: center;
+      text-decoration: none;
+      padding: 0;
+    }
+    .fa-twitter {
+      background: white;
+      color:  #55ACEE;
+    }
+    section.range-slider {
+      position: relative;
+      width: 500px;
+      height: 15px;
+      text-align: center;
+  }
+  
+  section.range-slider input {
+      -webkit-appearance: none;
+      pointer-events: none;
+      position: absolute;
+      overflow: hidden;
+      left: 0;
+      top: 25px;
+      width: 500px;
+      outline: none;
+      height: 15px;
+      border-radius: 5px; 
+      margin: 0;
+      padding: 0;
+      background: #d3d3d3;
+  }
+  
+  section.range-slider input::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      pointer-events: all;
+      position: relative;
+      z-index: 1;
+      outline: 0;
+      height: 20px;
+      width: 15px;
+      cursor: pointer;
+      border-radius: 50%; 
+      background: #007bff;
+  }
+  
+  section.range-slider input::-moz-range-thumb {
+      pointer-events: all;
+      position: relative;
+      z-index: 10;
+      -moz-appearance: none;
+      width: 9px;
+      
+  }
+  
+  section.range-slider input:last-of-type::-moz-range-track {
+      -moz-appearance: none;
+      background: none transparent;
+      border: 0;
+  }
+    section.range-slider input[type=range]::-moz-focus-outer {
+    border: 0;
+  }
+  @-moz-document url-prefix() {
+    input[type='range']:nth-child(1){
+      -webkit-appearance: none;
+      position:absolute;
+      top:35px !important;
+      overflow:visible !important;
+      height:0;
+    }
+  
+    input[type='range']:nth-child(2){
+      -webkit-appearance: none;
+      position:absolute;
+      top:53px !important;
+      overflow:visible !important;
+      height:0;
+    }
+    input[type='range']::-moz-range-thumb {
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      position: relative;
+      height: 13px;
+      width: 15px;
+      margin-top: -7px;
+      background: #007bff;
+      border: 1px solid #007bff;
+      border-radius: 25px;
+      z-index: 1;
+    }
+  
+    input[type='range']:nth-child(1)::-moz-range-thumb {
+        -webkit-appearance: none;
+        transform: translateY(-20px);    
+    }
+    input[type='range']:nth-child(2)::-moz-range-thumb {
+        -webkit-appearance: none;
+        transform: translateY(-20px);    
+    }
+  }
+  </style>
+</head>
+
+<body>
+    <header class="bg-white border-bottom shadow-sm fixed-top no-horiz-pad">
+      <div class="d-flex flex-row align-items-center">
+        <nav class="d-inline-flex p-2">
+        <a class="p-2 text-dark"
+           href="https://emmaa.readthedocs.io/en/latest/index.html"
+           target="_blank">Documentation</a>
+      </nav>
+      </div>
+    </header>
+
+    <div class="container">
+      <h3>Where did the page go?</h3>
+      <p>
+        The EMMAA project has been put on hold and we are no longer serving the EMMAA
+        dashboard homepage. All the models and data are still available for download. A
+        future project may be launched to serve the EMMAA dashboard again.<br>
+        The documentation is still available at <a href="https://emmaa.readthedocs.io/en/latest/index.html" target="_blank">emmaa.readthedocs.io</a>.<br>
+      </p>
+      <h3>Download the latest data</h3>
+      <p>
+        The latest data is available for download:
+      </p>
+      <div>
+        <table class="table">
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">Description</th>
+              <th scope="col">Download Links</th>
+              <th scope="col">Network on NDex</th>
+            </tr>
+          </thead>
+          <tbody>
+          {% for model in models %}
+          {% set meta_data = model_metadata[model] %}
+            <tr>
+              <td>{{ meta_data.name }}</td>
+              <td>{{ model.description }}</td>
+              <td>
+                {% if model.model_path or model.test_path %}
+                  {% if model.model_path %}
+                  <a href="{{ model.model_path }}" target="_blank">Model pickle</a>,
+                  {% endif %}
+                  {% if model.test_path %}
+                  <a href="{{ model.test_path }}" target="_blank">Tests JSON</a>
+                  {% endif %}
+                {% else %}
+                  <i class="text-muted">No download available</i>
+                {% endif %}
+              </td>
+              <td>
+                {% if model.ndex %}
+                  <a
+                      href="https://www.ndexbio.org/viewer/networks/{{ model.ndex }}"
+                      target="_blank">{{ model.ndex }}
+                  </a>
+                {% else %}
+                  <i class="text-muted">No network available</i>
+                {% endif %}
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+  <footer class="footer text-muted" id="about" style="background: #F5F5F5;">
+    <div class="container">
+      <h5 class="my-0 mr-md-auto font-weight-normal">About</h5>
+      <small>
+        <p class="float-right">
+          <a href="#">Back to top</a>
+        </p>
+        <p><a href="https://indralab.github.io" target="_blank">INDRALAB</a></p>
+        <p><a href="http://hits.harvard.edu" target="_blank">Harvard Program in Therapeutic Science (HiTS)</a></p>
+        <p><b>Automating Scientific Knowledge Extraction (ASKE)</b><br>EMMAA (Ecosystem of Machine-maintained Models with Automated Assembly) is a part of the DARPA ASKE program, which is part of DARPA's broader Artificial Intelligence Exploration program with the goal of developing technologies for the "Third Wave" of AI.<br><i>The EMMAA project is funded by the Defense Advanced Research Projects Agency under award HR00111990009.</i></p>
+      </small>
+    </div>
+  </footer>
+</body>

--- a/emmaa_service/templates/static_page_template.html
+++ b/emmaa_service/templates/static_page_template.html
@@ -222,24 +222,24 @@
           {% set meta_data = model_metadata[model] %}
             <tr>
               <td>{{ meta_data.name }}</td>
-              <td>{{ model.description }}</td>
+              <td>{{ meta_data.description }}</td>
               <td>
-                {% if model.model_path or model.test_path %}
-                  {% if model.model_path %}
-                  <a href="{{ model.model_path }}" target="_blank">Model pickle</a>,
+                {% if meta_data.model_path or meta_data.test_path %}
+                  {% if meta_data.model_path %}
+                  <a href="/{{ meta_data.model_path }}" target="_blank">Model pickle</a>,
                   {% endif %}
-                  {% if model.test_path %}
-                  <a href="{{ model.test_path }}" target="_blank">Tests JSON</a>
+                  {% if meta_data.test_path %}
+                  <a href="/{{ meta_data.test_path }}" target="_blank">Tests JSON</a>
                   {% endif %}
                 {% else %}
                   <i class="text-muted">No download available</i>
                 {% endif %}
               </td>
               <td>
-                {% if model.ndex %}
+                {% if meta_data.ndex %}
                   <a
-                      href="https://www.ndexbio.org/viewer/networks/{{ model.ndex }}"
-                      target="_blank">{{ model.ndex }}
+                      href="https://www.ndexbio.org/viewer/networks/{{ meta_data.ndex }}"
+                      target="_blank">{{ meta_data.ndex }}
                   </a>
                 {% else %}
                   <i class="text-muted">No network available</i>


### PR DESCRIPTION
This PR adds a script that renders a static page intended for showing when the emmaa service is shut down.

Other changes:
- simplified logic in a helper function 
- Use a signed s3 client by default instead of an unsigend one